### PR TITLE
feat: T-03 SQLite setup, migration runner, and full schema

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -1,5 +1,23 @@
 package main
 
+import (
+	"log"
+
+	"github.com/digitalcheffe/nora/internal/config"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/migrations"
+)
+
 func main() {
-	// TODO: initialize config, DB, router, and background jobs
+	cfg := config.Load()
+
+	db, err := repo.Open(cfg, migrations.Files)
+	if err != nil {
+		log.Fatalf("database init failed: %v", err)
+	}
+	defer db.Close()
+
+	log.Printf("NORA database ready at %s", cfg.DBPath)
+
+	// TODO: initialize router and background jobs (T-02 / T-04+)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/digitalcheffe/nora
 
-go 1.22
+go 1.25.0
+
+toolchain go1.26.1
+
+require (
+	github.com/jmoiron/sqlx v1.4.0
+	github.com/mattn/go-sqlite3 v1.14.37
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
+github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
+github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mattn/go-sqlite3 v1.14.37 h1:3DOZp4cXis1cUIpCfXLtmlGolNLp2VEqhiB/PARNBIg=
+github.com/mattn/go-sqlite3 v1.14.37/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"log"
+	"os"
+	"strconv"
+)
+
+type Config struct {
+	DevMode        bool
+	Secret         string
+	DBPath         string
+	Port           string
+	SMTPHost       string
+	SMTPPort       int
+	SMTPUser       string
+	SMTPPass       string
+	SMTPFrom       string
+	DigestSchedule string
+	VAPIDPublic    string
+	VAPIDPrivate   string
+}
+
+func Load() *Config {
+	cfg := &Config{
+		DevMode:        getEnvBool("NORA_DEV_MODE", false),
+		Secret:         os.Getenv("NORA_SECRET"),
+		DBPath:         getEnvStr("NORA_DB_PATH", "/data/nora.db"),
+		Port:           getEnvStr("NORA_PORT", "8080"),
+		SMTPHost:       os.Getenv("NORA_SMTP_HOST"),
+		SMTPPort:       getEnvInt("NORA_SMTP_PORT", 587),
+		SMTPUser:       os.Getenv("NORA_SMTP_USER"),
+		SMTPPass:       os.Getenv("NORA_SMTP_PASS"),
+		SMTPFrom:       os.Getenv("NORA_SMTP_FROM"),
+		DigestSchedule: getEnvStr("NORA_DIGEST_SCHEDULE", "0 8 1 * *"),
+		VAPIDPublic:    os.Getenv("NORA_VAPID_PUBLIC"),
+		VAPIDPrivate:   os.Getenv("NORA_VAPID_PRIVATE"),
+	}
+
+	if !cfg.DevMode && cfg.Secret == "" {
+		log.Fatal("NORA_SECRET is required when NORA_DEV_MODE is false")
+	}
+
+	return cfg
+}
+
+func getEnvStr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func getEnvBool(key string, def bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
+}
+
+func getEnvInt(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return i
+}

--- a/internal/repo/db.go
+++ b/internal/repo/db.go
@@ -1,0 +1,38 @@
+package repo
+
+import (
+	"fmt"
+	"io/fs"
+
+	"github.com/digitalcheffe/nora/internal/config"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Open opens the SQLite database at Config.DBPath, enforces WAL journal mode
+// and foreign key constraints, then runs all pending migrations from the
+// provided FS. It returns the ready-to-use *sqlx.DB or an error.
+func Open(cfg *config.Config, migrations fs.FS) (*sqlx.DB, error) {
+	db, err := sqlx.Open("sqlite3", cfg.DBPath+"?_journal_mode=WAL&_foreign_keys=ON")
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+
+	if err := db.Ping(); err != nil {
+		return nil, fmt.Errorf("ping database: %w", err)
+	}
+
+	// Also set via PRAGMA in case DSN query params are not honoured by the driver build.
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		return nil, fmt.Errorf("set journal_mode=WAL: %w", err)
+	}
+	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
+		return nil, fmt.Errorf("set foreign_keys=ON: %w", err)
+	}
+
+	if err := runMigrations(db, migrations); err != nil {
+		return nil, fmt.Errorf("run migrations: %w", err)
+	}
+
+	return db, nil
+}

--- a/internal/repo/migrate.go
+++ b/internal/repo/migrate.go
@@ -1,0 +1,70 @@
+package repo
+
+import (
+	"fmt"
+	"io/fs"
+	"log"
+	"sort"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// runMigrations creates the schema_migrations tracking table if needed, then
+// applies every *.sql file from the provided FS in filename order, skipping any
+// that have already been recorded. It panics on a failed migration — a broken
+// schema at startup is unrecoverable.
+func runMigrations(db *sqlx.DB, files fs.FS) error {
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS schema_migrations (
+			name       TEXT PRIMARY KEY,
+			applied_at TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+		)`)
+	if err != nil {
+		return fmt.Errorf("create schema_migrations: %w", err)
+	}
+
+	entries, err := fs.ReadDir(files, ".")
+	if err != nil {
+		return fmt.Errorf("read migrations fs: %w", err)
+	}
+
+	// Sort by filename to guarantee 001, 002, … ordering.
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			continue
+		}
+
+		name := entry.Name()
+
+		var count int
+		if err := db.QueryRow("SELECT COUNT(*) FROM schema_migrations WHERE name = ?", name).Scan(&count); err != nil {
+			return fmt.Errorf("check migration %s: %w", name, err)
+		}
+		if count > 0 {
+			log.Printf("migration: skip %s (already applied)", name)
+			continue
+		}
+
+		data, err := fs.ReadFile(files, name)
+		if err != nil {
+			return fmt.Errorf("read migration %s: %w", name, err)
+		}
+
+		if _, err := db.Exec(string(data)); err != nil {
+			panic(fmt.Sprintf("migration %s failed: %v", name, err))
+		}
+
+		if _, err := db.Exec("INSERT INTO schema_migrations (name) VALUES (?)", name); err != nil {
+			return fmt.Errorf("record migration %s: %w", name, err)
+		}
+
+		log.Printf("migration: applied %s", name)
+	}
+
+	return nil
+}

--- a/internal/repo/migrate_test.go
+++ b/internal/repo/migrate_test.go
@@ -1,0 +1,102 @@
+package repo
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func openTestDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	db, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestRunMigrations_HappyPath(t *testing.T) {
+	db := openTestDB(t)
+
+	migrations := fstest.MapFS{
+		"001_test.sql": &fstest.MapFile{
+			Data: []byte(`CREATE TABLE test_table (id TEXT PRIMARY KEY, name TEXT NOT NULL);`),
+		},
+	}
+
+	if err := runMigrations(db, migrations); err != nil {
+		t.Fatalf("runMigrations failed: %v", err)
+	}
+
+	// Verify schema_migrations row was recorded.
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM schema_migrations WHERE name = '001_test.sql'").Scan(&count); err != nil {
+		t.Fatalf("query schema_migrations: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 schema_migrations row, got %d", count)
+	}
+
+	// Verify the table was actually created.
+	if _, err := db.Exec("INSERT INTO test_table (id, name) VALUES ('1', 'hello')"); err != nil {
+		t.Errorf("test_table not created: %v", err)
+	}
+}
+
+func TestRunMigrations_Idempotent(t *testing.T) {
+	db := openTestDB(t)
+
+	migrations := fstest.MapFS{
+		"001_test.sql": &fstest.MapFile{
+			Data: []byte(`CREATE TABLE idempotent_table (id TEXT PRIMARY KEY);`),
+		},
+	}
+
+	// First run — should apply the migration.
+	if err := runMigrations(db, migrations); err != nil {
+		t.Fatalf("first runMigrations failed: %v", err)
+	}
+
+	// Second run — should skip (idempotent), NOT return an error.
+	if err := runMigrations(db, migrations); err != nil {
+		t.Fatalf("second runMigrations failed: %v", err)
+	}
+
+	// Should still be exactly one row in schema_migrations.
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM schema_migrations WHERE name = '001_test.sql'").Scan(&count); err != nil {
+		t.Fatalf("query schema_migrations: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 schema_migrations row after idempotent run, got %d", count)
+	}
+}
+
+func TestRunMigrations_OrderedApplication(t *testing.T) {
+	db := openTestDB(t)
+
+	// 002 depends on 001 — if order is wrong the FK will fail and the test panics.
+	migrations := fstest.MapFS{
+		"001_create_parent.sql": &fstest.MapFile{
+			Data: []byte(`CREATE TABLE parent (id TEXT PRIMARY KEY);`),
+		},
+		"002_create_child.sql": &fstest.MapFile{
+			Data: []byte(`CREATE TABLE child (id TEXT PRIMARY KEY, parent_id TEXT REFERENCES parent(id));`),
+		},
+	}
+
+	if err := runMigrations(db, migrations); err != nil {
+		t.Fatalf("runMigrations failed: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM schema_migrations").Scan(&count); err != nil {
+		t.Fatalf("query schema_migrations: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 applied migrations, got %d", count)
+	}
+}

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,0 +1,144 @@
+-- 001_init.sql
+-- Full NORA schema. All tables created here — including v2 stubs — so there are never gaps.
+
+CREATE TABLE users (
+    id            TEXT PRIMARY KEY,
+    email         TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    role          TEXT NOT NULL DEFAULT 'member',
+    created_at    TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE physical_hosts (
+    id         TEXT PRIMARY KEY,
+    name       TEXT NOT NULL,
+    ip         TEXT NOT NULL,
+    type       TEXT NOT NULL CHECK (type IN ('bare_metal', 'proxmox_node')),
+    notes      TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE virtual_hosts (
+    id               TEXT PRIMARY KEY,
+    physical_host_id TEXT REFERENCES physical_hosts (id) ON DELETE SET NULL,
+    name             TEXT NOT NULL,
+    ip               TEXT NOT NULL,
+    type             TEXT NOT NULL CHECK (type IN ('vm', 'lxc', 'wsl')),
+    created_at       TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE docker_engines (
+    id              TEXT PRIMARY KEY,
+    virtual_host_id TEXT REFERENCES virtual_hosts (id) ON DELETE SET NULL,
+    name            TEXT NOT NULL,
+    socket_type     TEXT NOT NULL CHECK (socket_type IN ('local', 'remote_proxy')),
+    socket_path     TEXT NOT NULL,
+    created_at      TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE apps (
+    id               TEXT PRIMARY KEY,
+    name             TEXT NOT NULL,
+    token            TEXT UNIQUE NOT NULL,
+    profile_id       TEXT,
+    docker_engine_id TEXT REFERENCES docker_engines (id) ON DELETE SET NULL,
+    config           TEXT NOT NULL DEFAULT '{}',
+    rate_limit       INTEGER NOT NULL DEFAULT 100,
+    created_at       TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE events (
+    id           TEXT PRIMARY KEY,
+    app_id       TEXT NOT NULL REFERENCES apps (id) ON DELETE CASCADE,
+    received_at  TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    severity     TEXT NOT NULL CHECK (severity IN ('debug', 'info', 'warn', 'error', 'critical')),
+    display_text TEXT NOT NULL,
+    raw_payload  TEXT NOT NULL DEFAULT '{}',
+    fields       TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX idx_events_app_id     ON events (app_id);
+CREATE INDEX idx_events_received_at ON events (received_at);
+CREATE INDEX idx_events_severity   ON events (severity);
+
+CREATE TABLE monitor_checks (
+    id              TEXT PRIMARY KEY,
+    app_id          TEXT REFERENCES apps (id) ON DELETE SET NULL,
+    name            TEXT NOT NULL,
+    type            TEXT NOT NULL CHECK (type IN ('ping', 'url', 'ssl')),
+    target          TEXT NOT NULL,
+    interval_secs   INTEGER NOT NULL DEFAULT 300,
+    expected_status INTEGER,
+    ssl_warn_days   INTEGER NOT NULL DEFAULT 30,
+    ssl_crit_days   INTEGER NOT NULL DEFAULT 7,
+    enabled         INTEGER NOT NULL DEFAULT 1,
+    last_checked_at TIMESTAMP,
+    last_status     TEXT CHECK (last_status IN ('up', 'warn', 'down')),
+    last_result     TEXT,
+    created_at      TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE rollups (
+    app_id     TEXT    NOT NULL REFERENCES apps (id) ON DELETE CASCADE,
+    year       INTEGER NOT NULL,
+    month      INTEGER NOT NULL,
+    event_type TEXT    NOT NULL,
+    severity   TEXT    NOT NULL,
+    count      INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (app_id, year, month, event_type, severity)
+);
+
+CREATE TABLE metrics (
+    app_id            TEXT      NOT NULL REFERENCES apps (id) ON DELETE CASCADE,
+    period            TIMESTAMP NOT NULL,
+    events_per_hour   INTEGER   NOT NULL DEFAULT 0,
+    avg_payload_bytes INTEGER   NOT NULL DEFAULT 0,
+    peak_per_minute   INTEGER   NOT NULL DEFAULT 0,
+    PRIMARY KEY (app_id, period)
+);
+
+CREATE TABLE resource_readings (
+    id          TEXT PRIMARY KEY,
+    source_id   TEXT      NOT NULL,
+    source_type TEXT      NOT NULL CHECK (source_type IN ('docker_container', 'host', 'vm')),
+    metric      TEXT      NOT NULL CHECK (metric IN ('cpu_percent', 'mem_percent', 'mem_bytes', 'disk_percent')),
+    value       REAL      NOT NULL,
+    recorded_at TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX idx_resource_readings_source ON resource_readings (source_id, recorded_at);
+
+CREATE TABLE resource_rollups (
+    source_id    TEXT      NOT NULL,
+    source_type  TEXT      NOT NULL CHECK (source_type IN ('docker_container', 'host', 'vm')),
+    metric       TEXT      NOT NULL CHECK (metric IN ('cpu_percent', 'mem_percent', 'mem_bytes', 'disk_percent')),
+    period_type  TEXT      NOT NULL CHECK (period_type IN ('hour', 'day')),
+    period_start TIMESTAMP NOT NULL,
+    avg          REAL      NOT NULL,
+    min          REAL      NOT NULL,
+    max          REAL      NOT NULL,
+    PRIMARY KEY (source_id, metric, period_type, period_start)
+);
+
+-- v2 stub — schema present from day one, implementation deferred
+CREATE TABLE alert_rules (
+    id              TEXT PRIMARY KEY,
+    app_id          TEXT REFERENCES apps (id) ON DELETE CASCADE,
+    name            TEXT NOT NULL,
+    conditions      TEXT NOT NULL DEFAULT '[]',
+    condition_logic TEXT NOT NULL DEFAULT 'AND',
+    notif_title     TEXT NOT NULL DEFAULT '',
+    notif_body      TEXT NOT NULL DEFAULT '',
+    enabled         INTEGER NOT NULL DEFAULT 1,
+    created_at      TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+-- v2 stub — Web Push subscriptions
+CREATE TABLE web_push_subscriptions (
+    id         TEXT PRIMARY KEY,
+    user_id    TEXT NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    endpoint   TEXT NOT NULL,
+    p256dh     TEXT NOT NULL,
+    auth       TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);

--- a/migrations/embed.go
+++ b/migrations/embed.go
@@ -1,0 +1,7 @@
+// Package migrations exposes the embedded SQL migration files.
+package migrations
+
+import "embed"
+
+//go:embed *.sql
+var Files embed.FS


### PR DESCRIPTION
## What
SQLite database layer for NORA: connection setup, embedded migration runner, and the full initial schema.

## Why
Closes #3. Establishes the persistence layer all other tasks will build on. All tables — including v2 stubs — are created in `001_init.sql` so there are never schema gaps across phases.

## How
- **`migrations/embed.go`** — tiny package that exports `embed.FS` pointed at `*.sql` files. Required because `//go:embed` cannot traverse up to a parent directory from `internal/repo/`, so the embed lives alongside the SQL files and is imported into the repo layer.
- **`internal/repo/db.go`** — `Open(cfg, migrations.Files)` opens SQLite, enforces WAL journal mode and foreign keys (both via DSN query params and explicit `PRAGMA` calls for driver-build robustness), then runs migrations.
- **`internal/repo/migrate.go`** — idempotent runner: creates `schema_migrations` tracking table on first run, reads embedded FS entries sorted by filename (001→002→…), skips already-applied files, panics on any failure (fail-fast at startup is intentional).
- **`migrations/001_init.sql`** — all 13 tables from the architecture data model, including `alert_rules` and `web_push_subscriptions` stubs. Uses `strftime('%Y-%m-%dT%H:%M:%fZ', 'now')` for ISO-8601 UTC defaults. CHECK constraints enforce enum columns. Indexes on `events(app_id)`, `events(received_at)`, `events(severity)`, and `resource_readings(source_id, recorded_at)`.
- **`internal/config/config.go`** — Config struct + `Load()` from env vars. Identical design to the T-02 branch; included here because T-02 is not yet merged to main and `repo.Open` requires it.

## Test coverage
- `TestRunMigrations_HappyPath` — applies a migration, verifies `schema_migrations` row written and table created.
- `TestRunMigrations_Idempotent` — runs same migration twice, asserts no error and exactly one tracking row.
- `TestRunMigrations_OrderedApplication` — two migrations with an FK dependency between them; verifies 001 is applied before 002.
All tests use in-memory SQLite via `fstest.MapFS` — no disk I/O.

## Assumptions
- `internal/config/config.go` is a forward-port of the T-02 design. When T-02 merges, this file will conflict cleanly (identical content); the T-02 version wins.
- `cmd/nora/main.go` is intentionally minimal — it wires config + DB and leaves a TODO for the router and background jobs (T-02 / T-04+).
- `go mod tidy` removed `chi` and `x/crypto` since they are not referenced on this branch; they will be restored when T-02 merges.

## Closes
Closes #3