### PR TITLE
feat: T-06 Apps CRUD API

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"net/http"
 
+	"github.com/digitalcheffe/nora/internal/api"
+	"github.com/digitalcheffe/nora/internal/auth"
 	"github.com/digitalcheffe/nora/internal/config"
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/digitalcheffe/nora/migrations"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 )
 
 func main() {
@@ -19,5 +25,23 @@ func main() {
 
 	log.Printf("NORA database ready at %s", cfg.DBPath)
 
-	// TODO: initialize router and background jobs (T-02 / T-04+)
+	// Repositories
+	appRepo := repo.NewAppRepo(db)
+
+	// Router
+	r := chi.NewRouter()
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+
+	// API v1 — protected by auth middleware
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(auth.RequireAuth(cfg.DevMode))
+		api.NewAppsHandler(appRepo).Routes(r)
+	})
+
+	addr := fmt.Sprintf(":%s", cfg.Port)
+	log.Printf("NORA listening on %s (dev_mode=%v)", addr, cfg.DevMode)
+	if err := http.ListenAndServe(addr, r); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,8 @@ require (
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/mattn/go-sqlite3 v1.14.37
 )
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
 github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -1,0 +1,229 @@
+package api
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// AppsHandler holds dependencies for the apps resource handlers.
+type AppsHandler struct {
+	apps repo.AppRepo
+}
+
+// NewAppsHandler creates an AppsHandler with the given repository.
+func NewAppsHandler(apps repo.AppRepo) *AppsHandler {
+	return &AppsHandler{apps: apps}
+}
+
+// Routes registers all app endpoints on r.
+func (h *AppsHandler) Routes(r chi.Router) {
+	r.Get("/apps", h.List)
+	r.Post("/apps", h.Create)
+	r.Get("/apps/{id}", h.Get)
+	r.Put("/apps/{id}", h.Update)
+	r.Delete("/apps/{id}", h.Delete)
+	r.Post("/apps/{id}/token/regenerate", h.RegenerateToken)
+}
+
+// --- request / response types ---
+
+type createAppRequest struct {
+	Name      string          `json:"name"`
+	ProfileID string          `json:"profile_id"`
+	Config    json.RawMessage `json:"config"`
+	RateLimit int             `json:"rate_limit"`
+}
+
+type listAppsResponse struct {
+	Data  []models.App `json:"data"`
+	Total int          `json:"total"`
+}
+
+type regenerateTokenResponse struct {
+	Token string `json:"token"`
+}
+
+// --- handlers ---
+
+// List returns all apps: GET /api/v1/apps
+func (h *AppsHandler) List(w http.ResponseWriter, r *http.Request) {
+	apps, err := h.apps.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if apps == nil {
+		apps = []models.App{}
+	}
+	writeJSON(w, http.StatusOK, listAppsResponse{Data: apps, Total: len(apps)})
+}
+
+// Create creates a new app: POST /api/v1/apps
+func (h *AppsHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var req createAppRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+
+	token, err := generateToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate token")
+		return
+	}
+
+	cfg := "{}"
+	if len(req.Config) > 0 {
+		cfg = string(req.Config)
+	}
+	rateLimit := req.RateLimit
+	if rateLimit <= 0 {
+		rateLimit = 100
+	}
+
+	app := &models.App{
+		ID:        uuid.New().String(),
+		Name:      req.Name,
+		Token:     token,
+		ProfileID: req.ProfileID,
+		Config:    cfg,
+		RateLimit: rateLimit,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	if err := h.apps.Create(r.Context(), app); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, app)
+}
+
+// Get returns a single app: GET /api/v1/apps/{id}
+func (h *AppsHandler) Get(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	app, err := h.apps.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "app not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, app)
+}
+
+// Update replaces an app's mutable fields: PUT /api/v1/apps/{id}
+func (h *AppsHandler) Update(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	// Verify the app exists first so we can return 404 before decoding.
+	existing, err := h.apps.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "app not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var req createAppRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Name != "" {
+		existing.Name = req.Name
+	}
+	if req.ProfileID != "" {
+		existing.ProfileID = req.ProfileID
+	}
+	if len(req.Config) > 0 {
+		existing.Config = string(req.Config)
+	}
+	if req.RateLimit > 0 {
+		existing.RateLimit = req.RateLimit
+	}
+
+	if err := h.apps.Update(r.Context(), existing); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, existing)
+}
+
+// Delete removes an app: DELETE /api/v1/apps/{id}
+func (h *AppsHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	err := h.apps.Delete(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "app not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// RegenerateToken rotates the app's ingest token: POST /api/v1/apps/{id}/token/regenerate
+func (h *AppsHandler) RegenerateToken(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	// Confirm the app exists.
+	if _, err := h.apps.Get(r.Context(), id); errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "app not found")
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	token, err := generateToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate token")
+		return
+	}
+	if err := h.apps.UpdateToken(r.Context(), id, token); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, regenerateTokenResponse{Token: token})
+}
+
+// --- helpers ---
+
+// generateToken returns a cryptographically random 32-byte base64url token (no padding).
+func generateToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}

--- a/internal/api/apps_test.go
+++ b/internal/api/apps_test.go
@@ -1,0 +1,258 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/digitalcheffe/nora/internal/api"
+	"github.com/digitalcheffe/nora/internal/config"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/migrations"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+// newTestDB opens an in-memory SQLite database with all migrations applied.
+func newTestDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	cfg := &config.Config{DBPath: ":memory:", DevMode: true}
+	db, err := repo.Open(cfg, migrations.Files)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// newTestRouter wires an AppsHandler onto a chi router.
+func newTestRouter(t *testing.T) http.Handler {
+	t.Helper()
+	db := newTestDB(t)
+	appRepo := repo.NewAppRepo(db)
+	h := api.NewAppsHandler(appRepo)
+	r := chi.NewRouter()
+	h.Routes(r)
+	return r
+}
+
+// createApp is a helper that POSTs a create-app request and returns the decoded App.
+func createApp(t *testing.T, router http.Handler, name string) models.App {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{"name": name, "profile_id": "sonarr", "rate_limit": 100})
+	req := httptest.NewRequest(http.MethodPost, "/apps", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("createApp: expected 201 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var app models.App
+	if err := json.NewDecoder(rr.Body).Decode(&app); err != nil {
+		t.Fatalf("createApp decode: %v", err)
+	}
+	return app
+}
+
+// --- List ---
+
+func TestListApps_Empty(t *testing.T) {
+	router := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/apps", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	var resp struct {
+		Data  []models.App `json:"data"`
+		Total int          `json:"total"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 0 {
+		t.Errorf("expected total=0 got %d", resp.Total)
+	}
+}
+
+func TestListApps_ReturnsAll(t *testing.T) {
+	router := newTestRouter(t)
+	createApp(t, router, "Sonarr")
+	createApp(t, router, "Radarr")
+
+	req := httptest.NewRequest(http.MethodGet, "/apps", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	var resp struct {
+		Data  []models.App `json:"data"`
+		Total int          `json:"total"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.Total != 2 {
+		t.Errorf("expected total=2 got %d", resp.Total)
+	}
+}
+
+// --- Create ---
+
+func TestCreateApp_HappyPath(t *testing.T) {
+	router := newTestRouter(t)
+	app := createApp(t, router, "Sonarr")
+
+	if app.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if app.Token == "" {
+		t.Error("expected non-empty token")
+	}
+	if app.Name != "Sonarr" {
+		t.Errorf("expected name=Sonarr got %q", app.Name)
+	}
+	// Token should be base64url, 43 chars for 32 bytes with no padding.
+	if len(app.Token) != 43 {
+		t.Errorf("expected token length 43 got %d", len(app.Token))
+	}
+}
+
+func TestCreateApp_MissingName(t *testing.T) {
+	router := newTestRouter(t)
+	body := bytes.NewBufferString(`{}`)
+	req := httptest.NewRequest(http.MethodPost, "/apps", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+// --- Get ---
+
+func TestGetApp_HappyPath(t *testing.T) {
+	router := newTestRouter(t)
+	created := createApp(t, router, "Sonarr")
+
+	req := httptest.NewRequest(http.MethodGet, "/apps/"+created.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	var app models.App
+	json.NewDecoder(rr.Body).Decode(&app)
+	if app.ID != created.ID {
+		t.Errorf("expected id=%s got %s", created.ID, app.ID)
+	}
+}
+
+func TestGetApp_NotFound(t *testing.T) {
+	router := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/apps/does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+// --- Update ---
+
+func TestUpdateApp_HappyPath(t *testing.T) {
+	router := newTestRouter(t)
+	created := createApp(t, router, "Sonarr")
+
+	body, _ := json.Marshal(map[string]any{"name": "Sonarr Updated"})
+	req := httptest.NewRequest(http.MethodPut, "/apps/"+created.ID, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var app models.App
+	json.NewDecoder(rr.Body).Decode(&app)
+	if app.Name != "Sonarr Updated" {
+		t.Errorf("expected updated name got %q", app.Name)
+	}
+}
+
+func TestUpdateApp_NotFound(t *testing.T) {
+	router := newTestRouter(t)
+	body, _ := json.Marshal(map[string]any{"name": "X"})
+	req := httptest.NewRequest(http.MethodPut, "/apps/does-not-exist", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+// --- Delete ---
+
+func TestDeleteApp_HappyPath(t *testing.T) {
+	router := newTestRouter(t)
+	created := createApp(t, router, "Sonarr")
+
+	req := httptest.NewRequest(http.MethodDelete, "/apps/"+created.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 got %d", rr.Code)
+	}
+}
+
+func TestDeleteApp_NotFound(t *testing.T) {
+	router := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodDelete, "/apps/does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+// --- RegenerateToken ---
+
+func TestRegenerateToken_HappyPath(t *testing.T) {
+	router := newTestRouter(t)
+	created := createApp(t, router, "Sonarr")
+	originalToken := created.Token
+
+	req := httptest.NewRequest(http.MethodPost, "/apps/"+created.ID+"/token/regenerate", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Token string `json:"token"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.Token == "" {
+		t.Error("expected non-empty new token")
+	}
+	if resp.Token == originalToken {
+		t.Error("expected token to change after regeneration")
+	}
+}
+
+func TestRegenerateToken_NotFound(t *testing.T) {
+	router := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodPost, "/apps/does-not-exist/token/regenerate", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,36 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+)
+
+type contextKey string
+
+const userIDKey contextKey = "userID"
+
+// RequireAuth is an HTTP middleware that enforces authentication.
+// When NORA_DEV_MODE=true a hardcoded admin session is injected — no login required.
+// TODO(T-30): remove the dev-mode bypass before production release.
+func RequireAuth(devMode bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if devMode {
+				// Dev bypass: inject a hardcoded admin identity so every request
+				// is treated as authenticated. Never ship this in a production image.
+				ctx := context.WithValue(r.Context(), userIDKey, "dev-admin")
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+
+			// TODO(T-10): validate JWT/session cookie and populate context.
+			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		})
+	}
+}
+
+// UserID returns the authenticated user ID stored in the request context.
+func UserID(ctx context.Context) string {
+	v, _ := ctx.Value(userIDKey).(string)
+	return v
+}

--- a/internal/models/app.go
+++ b/internal/models/app.go
@@ -1,0 +1,15 @@
+package models
+
+import "time"
+
+// App represents a monitored application registered in NORA.
+type App struct {
+	ID             string    `db:"id"               json:"id"`
+	Name           string    `db:"name"             json:"name"`
+	Token          string    `db:"token"            json:"token"`
+	ProfileID      string    `db:"profile_id"       json:"profile_id"`
+	DockerEngineID string    `db:"docker_engine_id" json:"docker_engine_id,omitempty"`
+	Config         string    `db:"config"           json:"config"`
+	RateLimit      int       `db:"rate_limit"       json:"rate_limit"`
+	CreatedAt      time.Time `db:"created_at"       json:"created_at"`
+}

--- a/internal/repo/apps.go
+++ b/internal/repo/apps.go
@@ -1,0 +1,110 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/jmoiron/sqlx"
+)
+
+// ErrNotFound is returned when a requested record does not exist.
+var ErrNotFound = errors.New("not found")
+
+// AppRepo defines CRUD operations for apps.
+type AppRepo interface {
+	List(ctx context.Context) ([]models.App, error)
+	Create(ctx context.Context, app *models.App) error
+	Get(ctx context.Context, id string) (*models.App, error)
+	Update(ctx context.Context, app *models.App) error
+	Delete(ctx context.Context, id string) error
+	UpdateToken(ctx context.Context, id, token string) error
+}
+
+type sqliteAppRepo struct {
+	db *sqlx.DB
+}
+
+// NewAppRepo returns an AppRepo backed by the given SQLite database.
+func NewAppRepo(db *sqlx.DB) AppRepo {
+	return &sqliteAppRepo{db: db}
+}
+
+func (r *sqliteAppRepo) List(ctx context.Context) ([]models.App, error) {
+	var apps []models.App
+	err := r.db.SelectContext(ctx, &apps, `
+		SELECT id, name, token, profile_id, COALESCE(docker_engine_id,'') AS docker_engine_id,
+		       config, rate_limit, created_at
+		FROM apps ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("list apps: %w", err)
+	}
+	return apps, nil
+}
+
+func (r *sqliteAppRepo) Create(ctx context.Context, app *models.App) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO apps (id, name, token, profile_id, docker_engine_id, config, rate_limit)
+		VALUES (?, ?, ?, ?, NULLIF(?, ''), ?, ?)`,
+		app.ID, app.Name, app.Token, app.ProfileID, app.DockerEngineID, app.Config, app.RateLimit)
+	if err != nil {
+		return fmt.Errorf("create app: %w", err)
+	}
+	return nil
+}
+
+func (r *sqliteAppRepo) Get(ctx context.Context, id string) (*models.App, error) {
+	var app models.App
+	err := r.db.GetContext(ctx, &app, `
+		SELECT id, name, token, profile_id, COALESCE(docker_engine_id,'') AS docker_engine_id,
+		       config, rate_limit, created_at
+		FROM apps WHERE id = ?`, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get app: %w", err)
+	}
+	return &app, nil
+}
+
+func (r *sqliteAppRepo) Update(ctx context.Context, app *models.App) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE apps SET name=?, profile_id=?, docker_engine_id=NULLIF(?,?), config=?, rate_limit=?
+		WHERE id=?`,
+		app.Name, app.ProfileID, app.DockerEngineID, app.DockerEngineID, app.Config, app.RateLimit, app.ID)
+	if err != nil {
+		return fmt.Errorf("update app: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sqliteAppRepo) Delete(ctx context.Context, id string) error {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM apps WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete app: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sqliteAppRepo) UpdateToken(ctx context.Context, id, token string) error {
+	res, err := r.db.ExecContext(ctx, `UPDATE apps SET token=? WHERE id=?`, token, id)
+	if err != nil {
+		return fmt.Errorf("update token: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}


### PR DESCRIPTION
## What
Full CRUD API for the Apps resource, plus the auth middleware skeleton and App model/repo layer.

## Why
Closes T-06 (#6). Apps are the core entity in NORA — every event, monitor check, and ingest token is scoped to an app. This PR lays the foundation before the ingest pipeline and frontend wiring.

## How
- **`internal/models/app.go`** — `App` struct with `db` and `json` tags matching the migration schema.
- **`internal/repo/apps.go`** — `AppRepo` interface + SQLite implementation (`List`, `Create`, `Get`, `Update`, `Delete`, `UpdateToken`). `ErrNotFound` sentinel returned on 0-row results.
- **`internal/auth/middleware.go`** — `RequireAuth(devMode bool)` middleware. Dev-mode bypass injects a hardcoded admin context key; non-dev path returns 401 (JWT implementation deferred to T-10). TODO comment marks the bypass for removal in T-30.
- **`internal/api/apps.go`** — Six handlers wired via `AppsHandler.Routes(r chi.Router)`. Token generation uses `crypto/rand` → 32 bytes → `base64.RawURLEncoding` (43-char output, no padding). IDs are UUIDs via `github.com/google/uuid`.
- **`cmd/nora/main.go`** — Initialises the chi router, mounts `/api/v1` with auth middleware, registers the apps handler.
- Added `github.com/go-chi/chi/v5` and `github.com/google/uuid` to `go.mod`.

## Test coverage
`go test ./internal/api/...` — 12 tests covering happy path and 404 path for all 6 endpoints:
- List (empty + populated)
- Create (happy path + missing name → 400)
- Get (happy path + 404)
- Update (happy path + 404)
- Delete (happy path + 404)
- RegenerateToken (happy path with token-change assertion + 404)

Tests use an in-memory SQLite DB with real migrations applied via `httptest`.

## Closes
Closes #6