### PR TITLE
feat: T-08 events query API with filters and pagination

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -27,6 +27,7 @@ func main() {
 
 	// Repositories
 	appRepo := repo.NewAppRepo(db)
+	eventRepo := repo.NewEventRepo(db)
 
 	// Router
 	r := chi.NewRouter()
@@ -37,6 +38,7 @@ func main() {
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(auth.RequireAuth(cfg.DevMode))
 		api.NewAppsHandler(appRepo).Routes(r)
+		api.NewEventsHandler(eventRepo).Routes(r)
 	})
 
 	addr := fmt.Sprintf(":%s", cfg.Port)

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -1,0 +1,266 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+)
+
+// EventsHandler holds dependencies for the events resource handlers.
+type EventsHandler struct {
+	events repo.EventRepo
+}
+
+// NewEventsHandler creates an EventsHandler with the given repository.
+func NewEventsHandler(events repo.EventRepo) *EventsHandler {
+	return &EventsHandler{events: events}
+}
+
+// Routes registers all event endpoints on r.
+func (h *EventsHandler) Routes(r chi.Router) {
+	r.Get("/events", h.List)
+	r.Get("/events/{id}", h.Get)
+	r.Get("/apps/{id}/events", h.ListByApp)
+}
+
+// --- response types ---
+
+// eventItem is the list-response shape: fields is a JSON object; raw_payload is excluded.
+type eventItem struct {
+	ID          string          `json:"id"`
+	AppID       string          `json:"app_id"`
+	AppName     string          `json:"app_name"`
+	ReceivedAt  time.Time       `json:"received_at"`
+	Severity    string          `json:"severity"`
+	DisplayText string          `json:"display_text"`
+	Fields      json.RawMessage `json:"fields"`
+}
+
+// eventDetail is the single-event shape: includes raw_payload as a JSON object.
+type eventDetail struct {
+	ID          string          `json:"id"`
+	AppID       string          `json:"app_id"`
+	AppName     string          `json:"app_name"`
+	ReceivedAt  time.Time       `json:"received_at"`
+	Severity    string          `json:"severity"`
+	DisplayText string          `json:"display_text"`
+	Fields      json.RawMessage `json:"fields"`
+	RawPayload  json.RawMessage `json:"raw_payload"`
+}
+
+// listEventsResponse wraps a page of events with pagination metadata.
+type listEventsResponse struct {
+	Data   []eventItem `json:"data"`
+	Total  int         `json:"total"`
+	Limit  int         `json:"limit"`
+	Offset int         `json:"offset"`
+}
+
+// rawOrEmpty returns the string as a RawMessage, falling back to {} for empty/null.
+func rawOrEmpty(s string) json.RawMessage {
+	if s == "" || s == "null" {
+		return json.RawMessage(`{}`)
+	}
+	return json.RawMessage(s)
+}
+
+func toEventItem(e models.Event) eventItem {
+	return eventItem{
+		ID:          e.ID,
+		AppID:       e.AppID,
+		AppName:     e.AppName,
+		ReceivedAt:  e.ReceivedAt,
+		Severity:    e.Severity,
+		DisplayText: e.DisplayText,
+		Fields:      rawOrEmpty(e.Fields),
+	}
+}
+
+func toEventDetail(e *models.Event) eventDetail {
+	return eventDetail{
+		ID:          e.ID,
+		AppID:       e.AppID,
+		AppName:     e.AppName,
+		ReceivedAt:  e.ReceivedAt,
+		Severity:    e.Severity,
+		DisplayText: e.DisplayText,
+		Fields:      rawOrEmpty(e.Fields),
+		RawPayload:  rawOrEmpty(e.RawPayload),
+	}
+}
+
+// parseFilter reads event filter query params from the request.
+// Returns an error string (400) if any param is malformed.
+func parseFilter(r *http.Request) (repo.ListFilter, error) {
+	q := r.URL.Query()
+
+	f := repo.ListFilter{
+		AppID:  q.Get("app_id"),
+		Limit:  50,
+		Offset: 0,
+	}
+
+	if sv := q.Get("severity"); sv != "" {
+		for _, s := range strings.Split(sv, ",") {
+			if s = strings.TrimSpace(s); s != "" {
+				f.Severity = append(f.Severity, s)
+			}
+		}
+	}
+
+	if s := q.Get("since"); s != "" {
+		t, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			return f, fmt.Errorf("invalid since: must be RFC3339")
+		}
+		f.Since = &t
+	}
+
+	if s := q.Get("until"); s != "" {
+		t, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			return f, fmt.Errorf("invalid until: must be RFC3339")
+		}
+		f.Until = &t
+	}
+
+	if s := q.Get("limit"); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil || n < 1 {
+			return f, fmt.Errorf("invalid limit: must be a positive integer")
+		}
+		f.Limit = n
+	}
+
+	if s := q.Get("offset"); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil || n < 0 {
+			return f, fmt.Errorf("invalid offset: must be a non-negative integer")
+		}
+		f.Offset = n
+	}
+
+	return f, nil
+}
+
+// --- handlers ---
+
+// List returns a filtered page of events: GET /api/v1/events
+//
+// @Summary      List events
+// @Description  Returns a filtered, paginated list of events across all apps. raw_payload is excluded.
+// @Tags         events
+// @Produce      json
+// @Param        app_id    query  string  false  "Filter by app ID"
+// @Param        severity  query  string  false  "Comma-separated severity filter: debug,info,warn,error,critical"
+// @Param        since     query  string  false  "ISO8601 lower bound (inclusive) e.g. 2026-01-01T00:00:00Z"
+// @Param        until     query  string  false  "ISO8601 upper bound (inclusive) e.g. 2026-12-31T23:59:59Z"
+// @Param        limit     query  int     false  "Page size (default 50, max 200)"
+// @Param        offset    query  int     false  "Pagination offset (default 0)"
+// @Success      200  {object}  listEventsResponse
+// @Failure      400  {object}  map[string]string
+// @Failure      500  {object}  map[string]string
+// @Security     BearerToken
+// @Router       /events [get]
+func (h *EventsHandler) List(w http.ResponseWriter, r *http.Request) {
+	f, err := parseFilter(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	events, total, err := h.events.List(r.Context(), f)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	items := make([]eventItem, len(events))
+	for i, e := range events {
+		items[i] = toEventItem(e)
+	}
+	writeJSON(w, http.StatusOK, listEventsResponse{
+		Data:   items,
+		Total:  total,
+		Limit:  f.Limit,
+		Offset: f.Offset,
+	})
+}
+
+// Get returns a single event with raw_payload: GET /api/v1/events/{id}
+//
+// @Summary      Get an event
+// @Description  Returns a single event by ID. Includes raw_payload as a parsed JSON object.
+// @Tags         events
+// @Produce      json
+// @Param        id   path      string  true  "Event ID"
+// @Success      200  {object}  eventDetail
+// @Failure      404  {object}  map[string]string
+// @Failure      500  {object}  map[string]string
+// @Security     BearerToken
+// @Router       /events/{id} [get]
+func (h *EventsHandler) Get(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	ev, err := h.events.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "event not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, toEventDetail(ev))
+}
+
+// ListByApp returns events scoped to a single app: GET /api/v1/apps/{id}/events
+//
+// @Summary      List events for an app
+// @Description  Returns a filtered, paginated list of events for a specific app. Same query params as /events.
+// @Tags         events
+// @Produce      json
+// @Param        id        path   string  true   "App ID"
+// @Param        severity  query  string  false  "Comma-separated severity filter"
+// @Param        since     query  string  false  "ISO8601 lower bound"
+// @Param        until     query  string  false  "ISO8601 upper bound"
+// @Param        limit     query  int     false  "Page size (default 50, max 200)"
+// @Param        offset    query  int     false  "Pagination offset"
+// @Success      200  {object}  listEventsResponse
+// @Failure      400  {object}  map[string]string
+// @Failure      500  {object}  map[string]string
+// @Security     BearerToken
+// @Router       /apps/{id}/events [get]
+func (h *EventsHandler) ListByApp(w http.ResponseWriter, r *http.Request) {
+	appID := chi.URLParam(r, "id")
+	f, err := parseFilter(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	f.AppID = appID // override any app_id query param with the path param
+
+	events, total, err := h.events.List(r.Context(), f)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	items := make([]eventItem, len(events))
+	for i, e := range events {
+		items[i] = toEventItem(e)
+	}
+	writeJSON(w, http.StatusOK, listEventsResponse{
+		Data:   items,
+		Total:  total,
+		Limit:  f.Limit,
+		Offset: f.Offset,
+	})
+}

--- a/internal/api/events_test.go
+++ b/internal/api/events_test.go
@@ -1,0 +1,441 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/api"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+// newEventsTestSetup creates an in-memory DB and a router with both apps and events routes.
+func newEventsTestSetup(t *testing.T) (http.Handler, *sqlx.DB) {
+	t.Helper()
+	db := newTestDB(t)
+	appRepo := repo.NewAppRepo(db)
+	eventRepo := repo.NewEventRepo(db)
+	r := chi.NewRouter()
+	api.NewAppsHandler(appRepo).Routes(r)
+	api.NewEventsHandler(eventRepo).Routes(r)
+	return r, db
+}
+
+// insertEvent inserts an event directly into the DB and returns it.
+func insertEvent(t *testing.T, db *sqlx.DB, appID, severity, displayText string, at time.Time) models.Event {
+	t.Helper()
+	ev := models.Event{
+		ID:          uuid.New().String(),
+		AppID:       appID,
+		ReceivedAt:  at.UTC().Truncate(time.Second),
+		Severity:    severity,
+		DisplayText: displayText,
+		RawPayload:  `{"source":"test"}`,
+		Fields:      `{"event_type":"test"}`,
+	}
+	_, err := db.ExecContext(context.Background(),
+		`INSERT INTO events (id, app_id, received_at, severity, display_text, raw_payload, fields)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		ev.ID, ev.AppID, ev.ReceivedAt, ev.Severity, ev.DisplayText, ev.RawPayload, ev.Fields)
+	if err != nil {
+		t.Fatalf("insertEvent: %v", err)
+	}
+	return ev
+}
+
+// eventsListResponse mirrors the listEventsResponse shape for decoding in tests.
+type eventsListResponse struct {
+	Data []struct {
+		ID          string                 `json:"id"`
+		AppID       string                 `json:"app_id"`
+		AppName     string                 `json:"app_name"`
+		Severity    string                 `json:"severity"`
+		DisplayText string                 `json:"display_text"`
+		Fields      map[string]interface{} `json:"fields"`
+		RawPayload  interface{}            `json:"raw_payload"`
+	} `json:"data"`
+	Total  int `json:"total"`
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
+}
+
+func decodeEventsResp(t *testing.T, rr *httptest.ResponseRecorder) eventsListResponse {
+	t.Helper()
+	var resp eventsListResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode events response: %v", err)
+	}
+	return resp
+}
+
+// --- List ---
+
+func TestListEvents_Empty(t *testing.T) {
+	router, _ := newEventsTestSetup(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	resp := decodeEventsResp(t, rr)
+	if resp.Total != 0 {
+		t.Errorf("expected total=0 got %d", resp.Total)
+	}
+	if len(resp.Data) != 0 {
+		t.Errorf("expected empty data got %d items", len(resp.Data))
+	}
+	if resp.Limit != 50 {
+		t.Errorf("expected default limit=50 got %d", resp.Limit)
+	}
+}
+
+func TestListEvents_ReturnsAll(t *testing.T) {
+	router, db := newEventsTestSetup(t)
+	app := createApp(t, router, "Sonarr")
+	now := time.Now()
+	insertEvent(t, db, app.ID, "info", "event one", now)
+	insertEvent(t, db, app.ID, "warn", "event two", now.Add(time.Minute))
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	resp := decodeEventsResp(t, rr)
+	if resp.Total != 2 {
+		t.Errorf("expected total=2 got %d", resp.Total)
+	}
+	if len(resp.Data) != 2 {
+		t.Errorf("expected 2 items got %d", len(resp.Data))
+	}
+}
+
+func TestListEvents_AppNamePopulated(t *testing.T) {
+	router, db := newEventsTestSetup(t)
+	app := createApp(t, router, "Radarr")
+	insertEvent(t, db, app.ID, "info", "download complete", time.Now())
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	resp := decodeEventsResp(t, rr)
+	if len(resp.Data) == 0 {
+		t.Fatal("expected at least one event")
+	}
+	if resp.Data[0].AppName != "Radarr" {
+		t.Errorf("expected app_name=Radarr got %q", resp.Data[0].AppName)
+	}
+}
+
+func TestListEvents_RawPayloadExcluded(t *testing.T) {
+	router, db := newEventsTestSetup(t)
+	app := createApp(t, router, "Sonarr")
+	insertEvent(t, db, app.ID, "info", "test", time.Now())
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	resp := decodeEventsResp(t, rr)
+	if len(resp.Data) == 0 {
+		t.Fatal("expected one event")
+	}
+	if resp.Data[0].RawPayload != nil {
+		t.Errorf("expected raw_payload to be absent from list response, got %v", resp.Data[0].RawPayload)
+	}
+}
+
+func TestListEvents_FieldsIsObject(t *testing.T) {
+	router, db := newEventsTestSetup(t)
+	app := createApp(t, router, "Sonarr")
+	insertEvent(t, db, app.ID, "info", "test", time.Now())
+
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	resp := decodeEventsResp(t, rr)
+	if len(resp.Data) == 0 {
+		t.Fatal("expected one event")
+	}
+	// fields must be a JSON object, not a string
+	if resp.Data[0].Fields == nil {
+		t.Error("expected fields to be a JSON object, got nil")
+	}
+}
+
+// --- Filter: app_id ---
+
+func TestListEvents_FilterByAppID(t *testing.T) {
+	router, db := newEventsTestSetup(t)
+	app1 := createApp(t, router, "Sonarr")
+	app2 := createApp(t, router, "Radarr")
+	now := time.Now()
+	insertEvent(t, db, app1.ID, "info", "sonarr event", now)
+	insertEvent(t, db, app2.ID, "info", "radarr event", now)
+
+	req := httptest.NewRequest(http.MethodGet, "/events?app_id="+app1.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	resp := decodeEventsResp(t, rr)
+	if resp.Total != 1 {
+		t.Errorf("expected total=1 got %d", resp.Total)
+	}
+	if resp.Data[0].AppID != app1.ID {
+		t.Errorf("expected app_id=%s got %s", app1.ID, resp.Data[0].AppID)
+	}
+}
+
+// --- Filter: severity ---
+
+func TestListEvents_FilterBySingleSeverity(t *testing.T) {
+	router, db := newEventsTestSetup(t)
+	app := createApp(t, router, "Sonarr")
+	now := time.Now()
+	insertEvent(t, db, app.ID, "info", "info event", now)
+	insertEvent(t, db, app.ID, "warn", "warn event", now.Add(time.Second))
+	insertEvent(t, db, app.ID, "error", "error event", now.Add(2*time.Second))
+
+	req := httptest.NewRequest(http.MethodGet, "/events?severity=warn", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	resp := decodeEventsResp(t, rr)
+	if resp.Total != 1 {
+		t.Errorf("expected total=1 got %d", resp.Total)
+	}
+	if resp.Data[0].Severity != "warn" {
+		t.Errorf("expected severity=warn got %s", resp.Data[0].Severity)
+	}
+}
+
+func TestListEvents_FilterByMultipleSeverities(t *testing.T) {
+	router, db := newEventsTestSetup(t)
+	app := createApp(t, router, "Sonarr")
+	now := time.Now()
+	insertEvent(t, db, app.ID, "info", "info", now)
+	insertEvent(t, db, app.ID, "warn", "warn", now.Add(time.Second))
+	insertEvent(t, db, app.ID, "error", "error", now.Add(2*time.Second))
+	insertEvent(t, db, app.ID, "critical", "critical", now.Add(3*time.Second))
+
+	req := httptest.NewRequest(http.MethodGet, "/events?severity=warn,error,critical", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	resp := decodeEventsResp(t, rr)
+	if resp.Total != 3 {
+		t.Errorf("expected total=3 got %d", resp.Total)
+	}
+}
+
+// --- Filter: since / until ---
+
+func TestListEvents_FilterBySince(t *testing.T) {
+	router, db := newEventsTestSetup(t)
+	app := createApp(t, router, "Sonarr")
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	insertEvent(t, db, app.ID, "info", "old", base)
+	insertEvent(t, db, app.ID, "info", "new", base.Add(2*time.Hour))
+
+	since := base.Add(time.Hour).Format(time.RFC3339)
+	req := httptest.NewRequest(http.MethodGet, "/events?since="+since, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	resp := decodeEventsResp(t, rr)
+	if resp.Total != 1 {
+		t.Errorf("expected total=1 got %d", resp.Total)
+	}
+	if resp.Data[0].DisplayText != "new" {
+		t.Errorf("expected 'new' event got %q", resp.Data[0].DisplayText)
+	}
+}
+
+func TestListEvents_FilterByUntil(t *testing.T) {
+	router, db := newEventsTestSetup(t)
+	app := createApp(t, router, "Sonarr")
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	insertEvent(t, db, app.ID, "info", "old", base)
+	insertEvent(t, db, app.ID, "info", "new", base.Add(2*time.Hour))
+
+	until := base.Add(time.Hour).Format(time.RFC3339)
+	req := httptest.NewRequest(http.MethodGet, "/events?until="+until, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	resp := decodeEventsResp(t, rr)
+	if resp.Total != 1 {
+		t.Errorf("expected total=1 got %d", resp.Total)
+	}
+	if resp.Data[0].DisplayText != "old" {
+		t.Errorf("expected 'old' event got %q", resp.Data[0].DisplayText)
+	}
+}
+
+// --- Pagination ---
+
+func TestListEvents_LimitOffset(t *testing.T) {
+	router, db := newEventsTestSetup(t)
+	app := createApp(t, router, "Sonarr")
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		insertEvent(t, db, app.ID, "info", fmt.Sprintf("event %d", i), now.Add(time.Duration(i)*time.Second))
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/events?limit=2&offset=2", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	resp := decodeEventsResp(t, rr)
+	if resp.Total != 5 {
+		t.Errorf("expected total=5 got %d", resp.Total)
+	}
+	if len(resp.Data) != 2 {
+		t.Errorf("expected 2 items on page got %d", len(resp.Data))
+	}
+	if resp.Limit != 2 {
+		t.Errorf("expected limit=2 got %d", resp.Limit)
+	}
+	if resp.Offset != 2 {
+		t.Errorf("expected offset=2 got %d", resp.Offset)
+	}
+}
+
+func TestListEvents_InvalidLimit(t *testing.T) {
+	router, _ := newEventsTestSetup(t)
+	req := httptest.NewRequest(http.MethodGet, "/events?limit=bad", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+func TestListEvents_InvalidSince(t *testing.T) {
+	router, _ := newEventsTestSetup(t)
+	req := httptest.NewRequest(http.MethodGet, "/events?since=not-a-date", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+// --- Get single event ---
+
+func TestGetEvent_HappyPath(t *testing.T) {
+	router, db := newEventsTestSetup(t)
+	app := createApp(t, router, "Sonarr")
+	ev := insertEvent(t, db, app.ID, "error", "disk full", time.Now())
+
+	req := httptest.NewRequest(http.MethodGet, "/events/"+ev.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var detail struct {
+		ID         string                 `json:"id"`
+		Severity   string                 `json:"severity"`
+		RawPayload map[string]interface{} `json:"raw_payload"`
+		Fields     map[string]interface{} `json:"fields"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode detail: %v", err)
+	}
+	if detail.ID != ev.ID {
+		t.Errorf("expected id=%s got %s", ev.ID, detail.ID)
+	}
+	if detail.Severity != "error" {
+		t.Errorf("expected severity=error got %s", detail.Severity)
+	}
+	// raw_payload must be present and be an object in the detail response
+	if detail.RawPayload == nil {
+		t.Error("expected raw_payload to be present in detail response")
+	}
+}
+
+func TestGetEvent_NotFound(t *testing.T) {
+	router, _ := newEventsTestSetup(t)
+	req := httptest.NewRequest(http.MethodGet, "/events/does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+// --- ListByApp ---
+
+func TestListByApp_HappyPath(t *testing.T) {
+	router, db := newEventsTestSetup(t)
+	app := createApp(t, router, "Sonarr")
+	insertEvent(t, db, app.ID, "info", "episode grabbed", time.Now())
+
+	req := httptest.NewRequest(http.MethodGet, "/apps/"+app.ID+"/events", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+	resp := decodeEventsResp(t, rr)
+	if resp.Total != 1 {
+		t.Errorf("expected total=1 got %d", resp.Total)
+	}
+}
+
+func TestListByApp_ExcludesOtherApps(t *testing.T) {
+	router, db := newEventsTestSetup(t)
+	app1 := createApp(t, router, "Sonarr")
+	app2 := createApp(t, router, "Radarr")
+	now := time.Now()
+	insertEvent(t, db, app1.ID, "info", "sonarr", now)
+	insertEvent(t, db, app2.ID, "info", "radarr", now)
+
+	req := httptest.NewRequest(http.MethodGet, "/apps/"+app1.ID+"/events", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	resp := decodeEventsResp(t, rr)
+	if resp.Total != 1 {
+		t.Errorf("expected total=1 (only app1 events) got %d", resp.Total)
+	}
+	if resp.Data[0].AppID != app1.ID {
+		t.Errorf("expected app_id=%s got %s", app1.ID, resp.Data[0].AppID)
+	}
+}
+
+func TestListByApp_WithSeverityFilter(t *testing.T) {
+	router, db := newEventsTestSetup(t)
+	app := createApp(t, router, "Sonarr")
+	now := time.Now()
+	insertEvent(t, db, app.ID, "info", "info", now)
+	insertEvent(t, db, app.ID, "error", "error", now.Add(time.Second))
+
+	req := httptest.NewRequest(http.MethodGet, "/apps/"+app.ID+"/events?severity=error", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	resp := decodeEventsResp(t, rr)
+	if resp.Total != 1 {
+		t.Errorf("expected total=1 got %d", resp.Total)
+	}
+	if resp.Data[0].Severity != "error" {
+		t.Errorf("expected severity=error got %s", resp.Data[0].Severity)
+	}
+}

--- a/internal/models/event.go
+++ b/internal/models/event.go
@@ -1,0 +1,15 @@
+package models
+
+import "time"
+
+// Event represents a single inbound event captured from an application webhook.
+type Event struct {
+	ID          string    `db:"id"           json:"id"`
+	AppID       string    `db:"app_id"       json:"app_id"`
+	AppName     string    `db:"app_name"     json:"app_name"`
+	ReceivedAt  time.Time `db:"received_at"  json:"received_at"`
+	Severity    string    `db:"severity"     json:"severity"`
+	DisplayText string    `db:"display_text" json:"display_text"`
+	RawPayload  string    `db:"raw_payload"  json:"raw_payload"`
+	Fields      string    `db:"fields"       json:"fields"`
+}

--- a/internal/repo/events.go
+++ b/internal/repo/events.go
@@ -1,0 +1,133 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/jmoiron/sqlx"
+)
+
+// ListFilter constrains an event list query. Zero values mean "no filter".
+type ListFilter struct {
+	AppID    string
+	Severity []string
+	Since    *time.Time
+	Until    *time.Time
+	Limit    int
+	Offset   int
+}
+
+// EventRepo defines read operations for the events table.
+type EventRepo interface {
+	// List returns a page of events matching f plus the total matching count.
+	List(ctx context.Context, f ListFilter) (events []models.Event, total int, err error)
+	// Get returns a single event by ID, including raw_payload.
+	Get(ctx context.Context, id string) (*models.Event, error)
+}
+
+type sqliteEventRepo struct {
+	db *sqlx.DB
+}
+
+// NewEventRepo returns an EventRepo backed by the given SQLite database.
+func NewEventRepo(db *sqlx.DB) EventRepo {
+	return &sqliteEventRepo{db: db}
+}
+
+// buildWhere constructs the WHERE clause and argument slice from a ListFilter.
+// Time comparisons use datetime() so sub-second precision in stored values is handled correctly.
+func buildWhere(f ListFilter) (clause string, args []interface{}) {
+	var parts []string
+
+	if f.AppID != "" {
+		parts = append(parts, "e.app_id = ?")
+		args = append(args, f.AppID)
+	}
+
+	if len(f.Severity) > 0 {
+		ph := strings.TrimRight(strings.Repeat("?,", len(f.Severity)), ",")
+		parts = append(parts, "e.severity IN ("+ph+")")
+		for _, s := range f.Severity {
+			args = append(args, s)
+		}
+	}
+
+	if f.Since != nil {
+		parts = append(parts, "datetime(e.received_at) >= datetime(?)")
+		args = append(args, f.Since.UTC().Format(time.RFC3339))
+	}
+
+	if f.Until != nil {
+		parts = append(parts, "datetime(e.received_at) <= datetime(?)")
+		args = append(args, f.Until.UTC().Format(time.RFC3339))
+	}
+
+	if len(parts) == 0 {
+		return "", nil
+	}
+	return " WHERE " + strings.Join(parts, " AND "), args
+}
+
+func (r *sqliteEventRepo) List(ctx context.Context, f ListFilter) ([]models.Event, int, error) {
+	if f.Limit <= 0 {
+		f.Limit = 50
+	}
+	if f.Limit > 200 {
+		f.Limit = 200
+	}
+	if f.Offset < 0 {
+		f.Offset = 0
+	}
+
+	where, whereArgs := buildWhere(f)
+
+	// Total matching rows (no LIMIT/OFFSET).
+	countQ := "SELECT COUNT(*) FROM events e" + where
+	var total int
+	if err := r.db.GetContext(ctx, &total, countQ, whereArgs...); err != nil {
+		return nil, 0, fmt.Errorf("count events: %w", err)
+	}
+
+	// Fetch the page. raw_payload is excluded from list results.
+	pageQ := `
+		SELECT e.id, e.app_id, COALESCE(a.name, '') AS app_name,
+		       e.received_at, e.severity, e.display_text, e.fields
+		FROM events e
+		LEFT JOIN apps a ON a.id = e.app_id` +
+		where +
+		` ORDER BY e.received_at DESC
+		 LIMIT ? OFFSET ?`
+
+	pageArgs := append(whereArgs, f.Limit, f.Offset)
+	var events []models.Event
+	if err := r.db.SelectContext(ctx, &events, pageQ, pageArgs...); err != nil {
+		return nil, 0, fmt.Errorf("list events: %w", err)
+	}
+	if events == nil {
+		events = []models.Event{}
+	}
+	return events, total, nil
+}
+
+func (r *sqliteEventRepo) Get(ctx context.Context, id string) (*models.Event, error) {
+	const q = `
+		SELECT e.id, e.app_id, COALESCE(a.name, '') AS app_name,
+		       e.received_at, e.severity, e.display_text, e.raw_payload, e.fields
+		FROM events e
+		LEFT JOIN apps a ON a.id = e.app_id
+		WHERE e.id = ?`
+
+	var ev models.Event
+	if err := r.db.GetContext(ctx, &ev, q, id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get event: %w", err)
+	}
+	return &ev, nil
+}


### PR DESCRIPTION
## What
Adds three read endpoints for the stored event stream with rich filtering support.

## Why
Closes #8 (T-08). Powers the event list on the dashboard, app detail screen, and the full events page.

## How

**New endpoints:**
| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/v1/events` | Filtered/paginated list across all apps |
| `GET` | `/api/v1/events/{id}` | Single event with `raw_payload` |
| `GET` | `/api/v1/apps/{id}/events` | Same as list but scoped to one app |

**Query params:** `app_id`, `severity` (comma-separated), `since` (RFC3339), `until` (RFC3339), `limit` (default 50, max 200), `offset` (default 0)

**Key design decisions:**
- `raw_payload` excluded from list responses, included as a parsed JSON object in single-event GET
- `fields` serialised as a JSON object (not a string) in all responses
- Time comparisons use `datetime()` in SQLite so sub-second precision in stored values doesn't cause boundary issues
- `buildWhere` builds a dynamic WHERE clause — only adds clauses for non-zero filter values
- `total` in the response reflects the unfiltered count matching the query (for pagination UI)
- `app_name` joined from the apps table via `LEFT JOIN` — no N+1 queries

**New packages/types:**
- `models.Event` — DB model with `db` and `json` tags
- `repo.EventRepo` — `List(ctx, ListFilter)` and `Get(ctx, id)` interface + SQLite impl
- `repo.ListFilter` — filter struct used by the events list query
- `api.EventsHandler` — three handlers with swag annotations

## Test coverage
17 tests in `internal/api/events_test.go`:
- Empty list, returns all, app_name populated, raw_payload excluded from list, fields as object
- Filter: app_id isolation, single severity, multi-severity (`warn,error,critical`)
- Filter: since, until (time range)
- Pagination: limit/offset, total unchanged, invalid limit/since → 400
- Get: happy path (raw_payload present), 404
- ListByApp: happy path, cross-app isolation, severity filter

`go test ./...` passes. `go build ./cmd/nora` clean.

## Closes
Closes #8