### PR TITLE
chore: change default port from 8080 to 6000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   nora:
     build: .
     ports:
-      - "8080:8080"
+      - "6000:6000"
     volumes:
       - ./data:/data
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -11,4 +11,4 @@ services:
       - NORA_DEV_MODE=true
       - NORA_SECRET=dev-secret-change-me
       - NORA_DB_PATH=/data/nora.db
-      - NORA_PORT=8080
+      - NORA_PORT=6000

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ func Load() *Config {
 		DevMode:        getEnvBool("NORA_DEV_MODE", false),
 		Secret:         os.Getenv("NORA_SECRET"),
 		DBPath:         getEnvStr("NORA_DB_PATH", "/data/nora.db"),
-		Port:           getEnvStr("NORA_PORT", "8080"),
+		Port:           getEnvStr("NORA_PORT", "6000"),
 		SMTPHost:       os.Getenv("NORA_SMTP_HOST"),
 		SMTPPort:       getEnvInt("NORA_SMTP_PORT", 587),
 		SMTPUser:       os.Getenv("NORA_SMTP_USER"),


### PR DESCRIPTION
## What
Changes the NORA listen port from 8080 to 6000.

## How
- `docker-compose.yml`: updated port mapping and `NORA_PORT` env var
- `internal/config/config.go`: updated default port fallback