### PR TITLE
feat: T-09 dashboard summary API

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -2,9 +2,36 @@
 # Claude Code Instructions — NORA
 
 ## Before Starting Any Task
-- Checkout main: `git checkout main`
-- Pull latest: `git pull origin main`
-- Create a fresh branch: `git checkout -b <type>/<short-description>`
+
+**Every new session starts here. No exceptions. Do not skip any step.**
+
+### Step 1 — Establish ground truth from the remote
+```
+git fetch --all --prune
+git checkout main
+git pull origin main
+git log --oneline -10
+git branch -a
+```
+Read the output. Do not assume anything about what is merged or what branch you are on.
+`git log` tells you what is actually on main right now.
+`git branch -a` tells you what branches still exist locally and remotely.
+
+### Step 2 — Confirm previous work is merged
+Before starting anything new, verify the last known branch is no longer open.
+If a branch still exists remotely, check its PR status with `gh pr list --state all`.
+Do not declare something merged unless `git log` on main shows the commits.
+
+### Step 3 — Clean up any stale local branches
+```
+git branch -d <any-branch-that-has-been-merged>
+```
+If `git branch -d` fails because the branch is not fully merged, stop and ask — do not force delete.
+
+### Step 4 — Create a fresh branch for this session's work
+```
+git checkout -b <type>/<short-description>
+```
 - Branch naming: feat/, fix/, chore/, docs/
 - Never commit directly to main or master
 - Never start work on a stale branch
@@ -31,6 +58,8 @@
 - Do not ask for confirmation on routine git operations
 - Do not pause for approval on branch creation, commits, pushes, or PRs
 - Only stop and ask if something is ambiguous or destructive
+- **Never assume git state — always verify with git fetch + git log before acting**
+- **Never say a branch is merged or a feature is complete without confirming it in git log on main**
 
 ---
 
@@ -140,12 +169,66 @@ NORA_VAPID_PRIVATE     VAPID private key (auto-generated on first run if absent)
 
 ---
 
-## Testing Expectations
-- Backend: `go test ./...` must pass before opening a PR
-- Each handler should have at minimum a happy-path and an error-path test
+## Testing & Build Verification
+
+Run all of the following before opening any PR. No exceptions.
+
+### Backend
+- `go test ./...` must pass
+- Each handler must have at minimum a happy-path and an error-path test
 - Use `net/http/httptest` for handler tests — no external test servers
-- Frontend: `npm run build` must succeed with zero TypeScript errors
-- Lint: `golangci-lint run` for Go, `npm run lint` for frontend — fix all warnings
+- `golangci-lint run` — fix all warnings
+
+### Frontend
+- `cd frontend && npm run build` must succeed with zero TypeScript errors
+- `npm run lint` — fix all warnings
+
+### Docker Build
+All development and testing runs in Docker Desktop. One Dockerfile. One `docker-compose.yml`. No exceptions.
+
+```
+docker compose up --build       — must complete with zero errors
+curl http://localhost:8080/     — must return a response
+docker images                   — nora image must be under 50MB
+```
+
+**Dockerfile is a 3-stage build — do not change this structure:**
+- Stage 1 `frontend-build`: `node:20-alpine` → `npm ci` → `npm run build`
+- Stage 2 `backend-build`: `golang:1.22-alpine` → `go mod download` → `go build`
+- Stage 3 `final`: `alpine:3.19` → binary only
+
+Final image contains ONLY the binary + ca-certificates + tzdata. No node_modules. No Go toolchain. No source code.
+
+**Layer cache rule — always copy dependency manifests before source code:**
+```
+COPY package.json package-lock.json ./   ← before npm ci
+COPY go.mod go.sum ./                    ← before go mod download
+COPY . .                                 ← source always last
+```
+Violating this means every build downloads all dependencies from scratch.
+
+**What Claude Code must NOT do:**
+- Do NOT create a second compose file or any dev override
+- Do NOT use concurrently, air, nodemon, or any process watcher
+- Do NOT run backend and frontend as separate containers
+- Do NOT write shell scripts that start multiple processes
+- Do NOT use `--watch` flags on any docker command
+- Do NOT copy node_modules into the final image
+- Do NOT use the golang or node image as the runtime base — `alpine:3.19` only
+
+**If the build fails, diagnose in this order:**
+1. `cd frontend && npm run build`
+2. `go build ./cmd/nora/`
+3. `docker compose up --build`
+
+Fix the earliest failing stage first. Use `docker build --progress=plain .` to see full output.
+
+### PR Checklist
+- [ ] `go test ./...` passes
+- [ ] `npm run build` passes with zero TypeScript errors
+- [ ] `docker compose up --build` completes with zero errors
+- [ ] `curl http://localhost:8080/` returns a response
+- [ ] `docker images` shows nora image under 50MB
 
 ---
 

--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/digitalcheffe/nora/internal/profile"
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/digitalcheffe/nora/migrations"
+	noraprofiles "github.com/digitalcheffe/nora/profiles"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 )
@@ -32,10 +33,17 @@ func main() {
 	// Repositories
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	store := repo.NewStore(appRepo, eventRepo)
+	checkRepo := repo.NewCheckRepo(db)
+	rollupRepo := repo.NewRollupRepo(db)
+	store := repo.NewStore(appRepo, eventRepo, checkRepo, rollupRepo)
 
-	// Ingest dependencies
-	profiler := &profile.NoopLoader{}
+	// Profile registry — load all bundled YAML profiles
+	registry, err := profile.NewRegistry(noraprofiles.Files)
+	if err != nil {
+		log.Fatalf("profile registry init failed: %v", err)
+	}
+	log.Printf("loaded %d profiles", len(registry.List()))
+
 	limiter := ingest.NewRateLimiter()
 
 	// Router
@@ -45,13 +53,14 @@ func main() {
 
 	// Public routes — no session auth
 	api.RegisterDocsRoutes(r)
-	r.Post("/api/v1/ingest/{token}", api.HandleIngest(store, profiler, limiter))
+	r.Post("/api/v1/ingest/{token}", api.HandleIngest(store, registry, limiter))
 
 	// API v1 — protected by auth middleware
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(auth.RequireAuth(cfg.DevMode))
 		api.NewAppsHandler(appRepo).Routes(r)
 		api.NewEventsHandler(eventRepo).Routes(r)
+		api.NewDashboardHandler(appRepo, eventRepo, checkRepo, rollupRepo, registry).Routes(r)
 	})
 
 	// Frontend — serve embedded React app, SPA fallback to index.html

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 require (
 	github.com/go-chi/chi/v5 v5.2.5 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -13,3 +13,6 @@ github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mattn/go-sqlite3 v1.14.37 h1:3DOZp4cXis1cUIpCfXLtmlGolNLp2VEqhiB/PARNBIg=
 github.com/mattn/go-sqlite3 v1.14.37/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -1,0 +1,565 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/profile"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+)
+
+// DashboardHandler holds dependencies for the dashboard endpoints.
+type DashboardHandler struct {
+	apps     repo.AppRepo
+	events   repo.EventRepo
+	checks   repo.CheckRepo
+	rollups  repo.RollupRepo
+	profiler profile.Loader
+}
+
+// NewDashboardHandler creates a DashboardHandler with the given dependencies.
+func NewDashboardHandler(apps repo.AppRepo, events repo.EventRepo, checks repo.CheckRepo, rollups repo.RollupRepo, profiler profile.Loader) *DashboardHandler {
+	return &DashboardHandler{
+		apps:     apps,
+		events:   events,
+		checks:   checks,
+		rollups:  rollups,
+		profiler: profiler,
+	}
+}
+
+// Routes registers dashboard endpoints on r.
+func (h *DashboardHandler) Routes(r chi.Router) {
+	r.Get("/dashboard/summary", h.Summary)
+	r.Get("/dashboard/digest/{period}", h.Digest)
+}
+
+// --- period helpers ---
+
+type periodConfig struct {
+	since     time.Time
+	until     time.Time
+	bucketDur time.Duration
+}
+
+func parsePeriod(param string, now time.Time) periodConfig {
+	switch param {
+	case "day":
+		// 7 × 4h buckets = 28h window
+		bd := 4 * time.Hour
+		return periodConfig{since: now.Add(-7 * bd), until: now, bucketDur: bd}
+	case "month":
+		// 7 × 4-day buckets = 28d window
+		bd := 4 * 24 * time.Hour
+		return periodConfig{since: now.Add(-7 * bd), until: now, bucketDur: bd}
+	default: // "week"
+		// 7 × 1-day buckets = 7d window
+		bd := 24 * time.Hour
+		return periodConfig{since: now.Add(-7 * bd), until: now, bucketDur: bd}
+	}
+}
+
+// --- response types ---
+
+type summaryBarItem struct {
+	Label     string `json:"label"`
+	Count     int    `json:"count"`
+	Sub       string `json:"sub"`
+	Sparkline [7]int `json:"sparkline"`
+}
+
+type appStat struct {
+	Label string `json:"label"`
+	Value string `json:"value"`
+	Color string `json:"color,omitempty"`
+}
+
+type appSummary struct {
+	ID            string    `json:"id"`
+	Name          string    `json:"name"`
+	ProfileID     string    `json:"profile_id"`
+	Status        string    `json:"status"`
+	LastEventAt   *string   `json:"last_event_at"`
+	LastEventText *string   `json:"last_event_text"`
+	Stats         []appStat `json:"stats"`
+	Sparkline     [7]int    `json:"sparkline"`
+}
+
+type checkSummary struct {
+	ID            string  `json:"id"`
+	Name          string  `json:"name"`
+	Type          string  `json:"type"`
+	Target        string  `json:"target"`
+	Status        string  `json:"status"`
+	UptimePct     float64 `json:"uptime_pct"`
+	LastCheckedAt *string `json:"last_checked_at,omitempty"`
+}
+
+type sslCert struct {
+	Domain        string `json:"domain"`
+	DaysRemaining int    `json:"days_remaining"`
+	ExpiresAt     string `json:"expires_at"`
+	Status        string `json:"status"`
+}
+
+type summaryResponse struct {
+	Status     string           `json:"status"`
+	Period     string           `json:"period"`
+	SummaryBar []summaryBarItem `json:"summary_bar"`
+	Apps       []appSummary     `json:"apps"`
+	Checks     []checkSummary   `json:"checks"`
+	SSLCerts   []sslCert        `json:"ssl_certs"`
+}
+
+// Summary handles GET /api/v1/dashboard/summary?period=week
+func (h *DashboardHandler) Summary(w http.ResponseWriter, r *http.Request) {
+	periodParam := r.URL.Query().Get("period")
+	if periodParam == "" {
+		periodParam = "week"
+	}
+	now := time.Now().UTC()
+	pc := parsePeriod(periodParam, now)
+
+	ctx := r.Context()
+
+	// --- 1. Load all apps ---
+	apps, err := h.apps.List(ctx)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load apps")
+		return
+	}
+
+	// --- 2. Load all checks ---
+	checks, err := h.checks.List(ctx)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load checks")
+		return
+	}
+
+	// --- 3. Build summary_bar via profile digest aggregation ---
+
+	// categoryEntry accumulates cross-app data for one label.
+	type categoryEntry struct {
+		cats    []profile.DigestCategory // all matching category definitions
+		perApp  map[string]int           // appID → count
+		total   int
+		sparkline [7]int
+	}
+
+	// keyed by label
+	catMap := map[string]*categoryEntry{}
+	// preserve insertion order
+	catOrder := []string{}
+
+	appIDs := make([]string, 0, len(apps))
+	for _, a := range apps {
+		appIDs = append(appIDs, a.ID)
+	}
+
+	// Gather per-app latest events for status/last_event fields
+	latestEvents, err := h.events.LatestPerApp(ctx, appIDs)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load latest events")
+		return
+	}
+
+	for _, a := range apps {
+		if a.ProfileID == "" {
+			continue
+		}
+		p, err := h.profiler.Get(a.ProfileID)
+		if err != nil || p == nil {
+			continue
+		}
+
+		for _, cat := range p.Digest.Categories {
+			if _, exists := catMap[cat.Label]; !exists {
+				catMap[cat.Label] = &categoryEntry{
+					perApp: make(map[string]int),
+				}
+				catOrder = append(catOrder, cat.Label)
+			}
+			entry := catMap[cat.Label]
+			entry.cats = append(entry.cats, cat)
+
+			// Count events for this app+category in the period
+			f := repo.CategoryFilter{
+				AppIDs:        []string{a.ID},
+				MatchField:    cat.MatchField,
+				MatchValue:    cat.MatchValue,
+				MatchSeverity: cat.MatchSeverity,
+				Since:         pc.since,
+				Until:         pc.until,
+			}
+			n, err := h.events.CountForCategory(ctx, f)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to count events")
+				return
+			}
+			entry.perApp[a.ID] += n
+			entry.total += n
+		}
+	}
+
+	// Build sparklines and sub-strings, only for categories with count > 0
+	summaryBar := make([]summaryBarItem, 0, len(catOrder))
+	for _, label := range catOrder {
+		entry := catMap[label]
+		if entry.total == 0 {
+			continue
+		}
+
+		// Use the first category definition's match criteria for sparkline (they share a label)
+		cat := entry.cats[0]
+		sf := repo.CategoryFilter{
+			MatchField:    cat.MatchField,
+			MatchValue:    cat.MatchValue,
+			MatchSeverity: cat.MatchSeverity,
+		}
+		// Collect all app IDs that contribute to this label
+		for appID := range entry.perApp {
+			sf.AppIDs = append(sf.AppIDs, appID)
+		}
+		sparkline, err := h.events.SparklineBuckets(ctx, sf, pc.since, pc.bucketDur)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to build sparkline")
+			return
+		}
+
+		// Build sub string: "AppName N · AppName N" for apps with count > 0
+		type appCount struct {
+			name  string
+			count int
+		}
+		var breakdown []appCount
+		for _, a := range apps {
+			if n := entry.perApp[a.ID]; n > 0 {
+				breakdown = append(breakdown, appCount{name: a.Name, count: n})
+			}
+		}
+		sort.Slice(breakdown, func(i, j int) bool { return breakdown[i].count > breakdown[j].count })
+		subParts := make([]string, 0, len(breakdown))
+		for _, ac := range breakdown {
+			subParts = append(subParts, fmt.Sprintf("%s %d", ac.name, ac.count))
+		}
+
+		summaryBar = append(summaryBar, summaryBarItem{
+			Label:     label,
+			Count:     entry.total,
+			Sub:       strings.Join(subParts, " · "),
+			Sparkline: sparkline,
+		})
+	}
+
+	// --- 4. Build per-app summaries ---
+	// Build a map from appID → check status using monitor_checks
+	appCheckStatus := map[string]string{}
+	for _, c := range checks {
+		if c.AppID == "" {
+			continue
+		}
+		if c.LastStatus == "down" {
+			appCheckStatus[c.AppID] = "down"
+		} else if c.LastStatus == "warn" && appCheckStatus[c.AppID] != "down" {
+			appCheckStatus[c.AppID] = "warn"
+		} else if appCheckStatus[c.AppID] == "" {
+			appCheckStatus[c.AppID] = c.LastStatus
+		}
+	}
+
+	appSummaries := make([]appSummary, 0, len(apps))
+	for _, a := range apps {
+		status := "online"
+		if s := appCheckStatus[a.ID]; s == "down" {
+			status = "down"
+		} else if s == "warn" {
+			status = "warn"
+		}
+
+		// Per-app sparkline: all events for this app in the period
+		appSparkline, err := h.events.SparklineBuckets(ctx, repo.CategoryFilter{
+			AppIDs: []string{a.ID},
+			Since:  pc.since,
+			Until:  pc.until,
+		}, pc.since, pc.bucketDur)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to build app sparkline")
+			return
+		}
+
+		// Per-app stats from profile digest categories
+		var stats []appStat
+		if a.ProfileID != "" {
+			p, err := h.profiler.Get(a.ProfileID)
+			if err == nil && p != nil {
+				for _, cat := range p.Digest.Categories {
+					f := repo.CategoryFilter{
+						AppIDs:        []string{a.ID},
+						MatchField:    cat.MatchField,
+						MatchValue:    cat.MatchValue,
+						MatchSeverity: cat.MatchSeverity,
+						Since:         pc.since,
+						Until:         pc.until,
+					}
+					n, err := h.events.CountForCategory(ctx, f)
+					if err != nil {
+						writeError(w, http.StatusInternalServerError, "failed to count app category events")
+						return
+					}
+					if n > 0 {
+						stats = append(stats, appStat{
+							Label: cat.Label,
+							Value: strconv.Itoa(n),
+						})
+					}
+				}
+			}
+		}
+
+		var lastEventAt *string
+		var lastEventText *string
+		if ev, ok := latestEvents[a.ID]; ok {
+			s := ev.ReceivedAt.UTC().Format(time.RFC3339)
+			lastEventAt = &s
+			lastEventText = &ev.DisplayText
+		}
+
+		appSummaries = append(appSummaries, appSummary{
+			ID:            a.ID,
+			Name:          a.Name,
+			ProfileID:     a.ProfileID,
+			Status:        status,
+			LastEventAt:   lastEventAt,
+			LastEventText: lastEventText,
+			Stats:         stats,
+			Sparkline:     appSparkline,
+		})
+	}
+
+	// --- 5. Build check summaries ---
+	checkSummaries := make([]checkSummary, 0)
+	sslCerts := make([]sslCert, 0)
+
+	for _, c := range checks {
+		if !c.Enabled {
+			continue
+		}
+
+		status := "unknown"
+		if c.LastStatus != "" {
+			status = c.LastStatus
+		}
+
+		var lastCheckedAt *string
+		if c.LastCheckedAt != nil {
+			s := c.LastCheckedAt.UTC().Format(time.RFC3339)
+			lastCheckedAt = &s
+		}
+
+		if c.Type == "ssl" {
+			// Parse expiry from last_result if available
+			cert := sslCert{
+				Domain: c.Target,
+				Status: "unknown",
+			}
+			if c.LastResult != "" {
+				var result map[string]interface{}
+				if err := json.Unmarshal([]byte(c.LastResult), &result); err == nil {
+					if exp, ok := result["expires_at"].(string); ok {
+						cert.ExpiresAt = exp
+						if t, err := time.Parse("2006-01-02", exp); err == nil {
+							days := int(time.Until(t).Hours() / 24)
+							cert.DaysRemaining = days
+							switch {
+							case days <= c.SSLCritDays:
+								cert.Status = "critical"
+							case days <= c.SSLWarnDays:
+								cert.Status = "warn"
+							default:
+								cert.Status = "ok"
+							}
+						}
+					}
+					if days, ok := result["days_remaining"].(float64); ok {
+						cert.DaysRemaining = int(days)
+					}
+				}
+			}
+			sslCerts = append(sslCerts, cert)
+		}
+
+		checkSummaries = append(checkSummaries, checkSummary{
+			ID:            c.ID,
+			Name:          c.Name,
+			Type:          c.Type,
+			Target:        c.Target,
+			Status:        status,
+			UptimePct:     100.0,
+			LastCheckedAt: lastCheckedAt,
+		})
+	}
+
+	// Sort SSL certs by days remaining ascending (soonest expiry first)
+	sort.Slice(sslCerts, func(i, j int) bool {
+		return sslCerts[i].DaysRemaining < sslCerts[j].DaysRemaining
+	})
+
+	// --- 6. Compute global status ---
+	globalStatus := "normal"
+	for _, c := range checks {
+		if !c.Enabled {
+			continue
+		}
+		if c.LastStatus == "down" {
+			globalStatus = "down"
+			break
+		}
+		if c.LastStatus == "warn" && globalStatus != "down" {
+			globalStatus = "warn"
+		}
+	}
+	if globalStatus != "down" {
+		for _, a := range appSummaries {
+			if a.Status == "down" {
+				globalStatus = "down"
+				break
+			}
+			if a.Status == "warn" && globalStatus != "down" {
+				globalStatus = "warn"
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, summaryResponse{
+		Status:     globalStatus,
+		Period:     periodParam,
+		SummaryBar: summaryBar,
+		Apps:       appSummaries,
+		Checks:     checkSummaries,
+		SSLCerts:   sslCerts,
+	})
+}
+
+// --- digest types ---
+
+type digestCategory struct {
+	Label     string `json:"label"`
+	Count     int    `json:"count"`
+	Breakdown string `json:"breakdown,omitempty"`
+	OK        *bool  `json:"ok,omitempty"`
+}
+
+type digestResponse struct {
+	Period      string           `json:"period"`
+	Categories  []digestCategory `json:"categories"`
+	UptimePct   float64          `json:"uptime_pct"`
+	ErrorCount  int              `json:"error_count"`
+}
+
+// Digest handles GET /api/v1/dashboard/digest/{period}
+// period format: YYYY-MM
+func (h *DashboardHandler) Digest(w http.ResponseWriter, r *http.Request) {
+	periodStr := chi.URLParam(r, "period")
+	parts := strings.SplitN(periodStr, "-", 2)
+	if len(parts) != 2 {
+		writeError(w, http.StatusBadRequest, "period must be YYYY-MM")
+		return
+	}
+	year, err := strconv.Atoi(parts[0])
+	if err != nil || year < 2000 {
+		writeError(w, http.StatusBadRequest, "invalid year in period")
+		return
+	}
+	month, err := strconv.Atoi(parts[1])
+	if err != nil || month < 1 || month > 12 {
+		writeError(w, http.StatusBadRequest, "invalid month in period")
+		return
+	}
+
+	ctx := r.Context()
+
+	rollups, err := h.rollups.ListByPeriod(ctx, year, month)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load rollups")
+		return
+	}
+
+	// Load app names for breakdown strings
+	apps, err := h.apps.List(ctx)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load apps")
+		return
+	}
+	appNames := make(map[string]string, len(apps))
+	for _, a := range apps {
+		appNames[a.ID] = a.Name
+	}
+
+	// Aggregate rollups: group by event_type → sum counts, build breakdown
+	type rollupGroup struct {
+		perApp map[string]int
+		total  int
+	}
+	groups := map[string]*rollupGroup{}
+	groupOrder := []string{}
+	errorCount := 0
+
+	for _, rl := range rollups {
+		if _, ok := groups[rl.EventType]; !ok {
+			groups[rl.EventType] = &rollupGroup{perApp: make(map[string]int)}
+			groupOrder = append(groupOrder, rl.EventType)
+		}
+		g := groups[rl.EventType]
+		g.perApp[rl.AppID] += rl.Count
+		g.total += rl.Count
+
+		if rl.Severity == "error" || rl.Severity == "critical" {
+			errorCount += rl.Count
+		}
+	}
+
+	categories := make([]digestCategory, 0, len(groupOrder))
+	for _, label := range groupOrder {
+		g := groups[label]
+
+		// Build "AppName N, AppName N" breakdown
+		type appCount struct {
+			name  string
+			count int
+		}
+		var breakdown []appCount
+		for appID, n := range g.perApp {
+			name := appNames[appID]
+			if name == "" {
+				name = appID
+			}
+			breakdown = append(breakdown, appCount{name: name, count: n})
+		}
+		sort.Slice(breakdown, func(i, j int) bool { return breakdown[i].count > breakdown[j].count })
+		parts := make([]string, 0, len(breakdown))
+		for _, ac := range breakdown {
+			parts = append(parts, fmt.Sprintf("%s %d", ac.name, ac.count))
+		}
+
+		ok := errorCount == 0
+		categories = append(categories, digestCategory{
+			Label:     label,
+			Count:     g.total,
+			Breakdown: strings.Join(parts, ", "),
+			OK:        &ok,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, digestResponse{
+		Period:     periodStr,
+		Categories: categories,
+		UptimePct:  100.0,
+		ErrorCount: errorCount,
+	})
+}

--- a/internal/api/dashboard_test.go
+++ b/internal/api/dashboard_test.go
@@ -1,0 +1,542 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/api"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/profile"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+// newDashboardTestSetup creates an in-memory DB + router with the dashboard handler.
+func newDashboardTestSetup(t *testing.T, profiler profile.Loader) (http.Handler, *sqlx.DB) {
+	t.Helper()
+	db := newTestDB(t)
+	appRepo := repo.NewAppRepo(db)
+	eventRepo := repo.NewEventRepo(db)
+	checkRepo := repo.NewCheckRepo(db)
+	rollupRepo := repo.NewRollupRepo(db)
+	r := chi.NewRouter()
+	api.NewDashboardHandler(appRepo, eventRepo, checkRepo, rollupRepo, profiler).Routes(r)
+	return r, db
+}
+
+// insertApp inserts an app directly into the DB and returns it.
+func insertApp(t *testing.T, db *sqlx.DB, name, profileID string) models.App {
+	t.Helper()
+	app := models.App{
+		ID:        uuid.New().String(),
+		Name:      name,
+		Token:     uuid.New().String(),
+		ProfileID: profileID,
+		Config:    "{}",
+		RateLimit: 100,
+	}
+	_, err := db.ExecContext(context.Background(),
+		`INSERT INTO apps (id, name, token, profile_id, config, rate_limit) VALUES (?,?,?,?,?,?)`,
+		app.ID, app.Name, app.Token, app.ProfileID, app.Config, app.RateLimit)
+	if err != nil {
+		t.Fatalf("insertApp: %v", err)
+	}
+	return app
+}
+
+// insertEventWithFields inserts an event with the given fields JSON.
+func insertEventWithFields(t *testing.T, db *sqlx.DB, appID, severity, displayText, fieldsJSON string, at time.Time) models.Event {
+	t.Helper()
+	ev := models.Event{
+		ID:          uuid.New().String(),
+		AppID:       appID,
+		ReceivedAt:  at.UTC().Truncate(time.Second),
+		Severity:    severity,
+		DisplayText: displayText,
+		RawPayload:  `{}`,
+		Fields:      fieldsJSON,
+	}
+	_, err := db.ExecContext(context.Background(),
+		`INSERT INTO events (id, app_id, received_at, severity, display_text, raw_payload, fields)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		ev.ID, ev.AppID, ev.ReceivedAt, ev.Severity, ev.DisplayText, ev.RawPayload, ev.Fields)
+	if err != nil {
+		t.Fatalf("insertEventWithFields: %v", err)
+	}
+	return ev
+}
+
+// makeTestProfiler returns a Loader that serves a minimal profile with digest categories.
+func makeTestProfiler(profileID string, categories []profile.DigestCategory) profile.Loader {
+	return &staticTestLoader{
+		profileID: profileID,
+		profile: &profile.Profile{
+			Digest: profile.Digest{Categories: categories},
+		},
+	}
+}
+
+type staticTestLoader struct {
+	profileID string
+	profile   *profile.Profile
+}
+
+func (l *staticTestLoader) Get(id string) (*profile.Profile, error) {
+	if id == l.profileID {
+		return l.profile, nil
+	}
+	return nil, nil
+}
+
+// --- zero app scenario ---
+
+func TestDashboardSummary_ZeroApps(t *testing.T) {
+	handler, _ := newDashboardTestSetup(t, &profile.NoopLoader{})
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/summary", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// summary_bar must be an empty array
+	var summaryBar []interface{}
+	if err := json.Unmarshal(resp["summary_bar"], &summaryBar); err != nil {
+		t.Fatalf("unmarshal summary_bar: %v", err)
+	}
+	if len(summaryBar) != 0 {
+		t.Errorf("expected empty summary_bar, got %d items", len(summaryBar))
+	}
+
+	// apps must be an empty array
+	var apps []interface{}
+	if err := json.Unmarshal(resp["apps"], &apps); err != nil {
+		t.Fatalf("unmarshal apps: %v", err)
+	}
+	if len(apps) != 0 {
+		t.Errorf("expected empty apps, got %d items", len(apps))
+	}
+
+	// status must be "normal"
+	var status string
+	if err := json.Unmarshal(resp["status"], &status); err != nil {
+		t.Fatalf("unmarshal status: %v", err)
+	}
+	if status != "normal" {
+		t.Errorf("expected status=normal, got %q", status)
+	}
+}
+
+// --- single app scenario ---
+
+func TestDashboardSummary_SingleApp(t *testing.T) {
+	categories := []profile.DigestCategory{
+		{Label: "Downloads", MatchField: "event_type", MatchValue: "Download"},
+		{Label: "Errors", MatchSeverity: "error"},
+	}
+	profiler := makeTestProfiler("sonarr", categories)
+	handler, db := newDashboardTestSetup(t, profiler)
+
+	app := insertApp(t, db, "Sonarr", "sonarr")
+
+	now := time.Now().UTC()
+
+	// Insert events: 3 downloads, 1 error, 1 info (should not appear as Errors category)
+	for i := 0; i < 3; i++ {
+		insertEventWithFields(t, db, app.ID, "info", "Download — Show",
+			`{"event_type":"Download"}`, now.Add(-time.Duration(i)*time.Hour))
+	}
+	insertEventWithFields(t, db, app.ID, "error", "Health issue",
+		`{"event_type":"HealthIssue"}`, now.Add(-2*time.Hour))
+	insertEventWithFields(t, db, app.ID, "info", "Misc event",
+		`{"event_type":"Other"}`, now.Add(-3*time.Hour))
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/summary?period=week", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Status     string `json:"status"`
+		Period     string `json:"period"`
+		SummaryBar []struct {
+			Label     string `json:"label"`
+			Count     int    `json:"count"`
+			Sparkline [7]int `json:"sparkline"`
+		} `json:"summary_bar"`
+		Apps []struct {
+			ID        string `json:"id"`
+			Name      string `json:"name"`
+			Stats     []struct {
+				Label string `json:"label"`
+				Value string `json:"value"`
+			} `json:"stats"`
+			Sparkline [7]int `json:"sparkline"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// period echoed back
+	if resp.Period != "week" {
+		t.Errorf("expected period=week, got %q", resp.Period)
+	}
+
+	// summary_bar should have 2 entries: Downloads (3) and Errors (1)
+	if len(resp.SummaryBar) != 2 {
+		t.Fatalf("expected 2 summary_bar items, got %d: %+v", len(resp.SummaryBar), resp.SummaryBar)
+	}
+	for _, item := range resp.SummaryBar {
+		switch item.Label {
+		case "Downloads":
+			if item.Count != 3 {
+				t.Errorf("Downloads: expected count=3, got %d", item.Count)
+			}
+		case "Errors":
+			if item.Count != 1 {
+				t.Errorf("Errors: expected count=1, got %d", item.Count)
+			}
+		default:
+			t.Errorf("unexpected summary_bar label: %q", item.Label)
+		}
+		// sparkline always 7 elements — verify it's there (length guaranteed by [7]int)
+		_ = item.Sparkline
+	}
+
+	// apps should have 1 entry
+	if len(resp.Apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(resp.Apps))
+	}
+	if resp.Apps[0].Name != "Sonarr" {
+		t.Errorf("expected app name Sonarr, got %q", resp.Apps[0].Name)
+	}
+
+	// app stats should reflect the categories with data
+	if len(resp.Apps[0].Stats) == 0 {
+		t.Error("expected at least one app stat")
+	}
+}
+
+// --- multi-app scenario ---
+
+func TestDashboardSummary_MultiApp(t *testing.T) {
+	// Two apps sharing the same "Downloads" category label
+	sonarrCats := []profile.DigestCategory{
+		{Label: "Downloads", MatchField: "event_type", MatchValue: "Download"},
+	}
+	radarrCats := []profile.DigestCategory{
+		{Label: "Downloads", MatchField: "event_type", MatchValue: "Download"},
+		{Label: "Errors", MatchSeverity: "error"},
+	}
+
+	// Multi-profile loader
+	profiler := &multiTestLoader{
+		profiles: map[string]*profile.Profile{
+			"sonarr": {Digest: profile.Digest{Categories: sonarrCats}},
+			"radarr": {Digest: profile.Digest{Categories: radarrCats}},
+		},
+	}
+	handler, db := newDashboardTestSetup(t, profiler)
+
+	sonarr := insertApp(t, db, "Sonarr", "sonarr")
+	radarr := insertApp(t, db, "Radarr", "radarr")
+
+	now := time.Now().UTC()
+
+	// Sonarr: 5 downloads
+	for i := 0; i < 5; i++ {
+		insertEventWithFields(t, db, sonarr.ID, "info", "Download",
+			`{"event_type":"Download"}`, now.Add(-time.Duration(i)*time.Hour))
+	}
+	// Radarr: 3 downloads, 2 errors
+	for i := 0; i < 3; i++ {
+		insertEventWithFields(t, db, radarr.ID, "info", "Download",
+			`{"event_type":"Download"}`, now.Add(-time.Duration(i)*time.Hour))
+	}
+	for i := 0; i < 2; i++ {
+		insertEventWithFields(t, db, radarr.ID, "error", "Health issue",
+			`{"event_type":"HealthIssue"}`, now.Add(-time.Duration(i+3)*time.Hour))
+	}
+
+	// An app with no events this period should not create an empty category
+	_ = insertApp(t, db, "Duplicati", "duplicati")
+	// (no events inserted for duplicati)
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/summary?period=week", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		SummaryBar []struct {
+			Label string `json:"label"`
+			Count int    `json:"count"`
+			Sub   string `json:"sub"`
+		} `json:"summary_bar"`
+		Apps []struct {
+			ID        string `json:"id"`
+			Sparkline [7]int `json:"sparkline"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Downloads from both apps should be combined: 5+3=8
+	var downloadsItem *struct {
+		Label string `json:"label"`
+		Count int    `json:"count"`
+		Sub   string `json:"sub"`
+	}
+	for i := range resp.SummaryBar {
+		if resp.SummaryBar[i].Label == "Downloads" {
+			downloadsItem = &resp.SummaryBar[i]
+		}
+	}
+	if downloadsItem == nil {
+		t.Fatal("expected Downloads in summary_bar")
+	}
+	if downloadsItem.Count != 8 {
+		t.Errorf("Downloads: expected count=8, got %d", downloadsItem.Count)
+	}
+
+	// Errors (2) should be present
+	var errorsPresent bool
+	for _, item := range resp.SummaryBar {
+		if item.Label == "Errors" && item.Count == 2 {
+			errorsPresent = true
+		}
+	}
+	if !errorsPresent {
+		t.Errorf("expected Errors with count=2 in summary_bar, got: %+v", resp.SummaryBar)
+	}
+
+	// All 3 apps should appear in apps
+	if len(resp.Apps) != 3 {
+		t.Errorf("expected 3 apps, got %d", len(resp.Apps))
+	}
+
+	// Sparklines always have 7 elements (guaranteed by [7]int type)
+	for _, a := range resp.Apps {
+		_ = a.Sparkline
+	}
+}
+
+// multiTestLoader serves multiple profiles.
+type multiTestLoader struct {
+	profiles map[string]*profile.Profile
+}
+
+func (l *multiTestLoader) Get(id string) (*profile.Profile, error) {
+	if p, ok := l.profiles[id]; ok {
+		return p, nil
+	}
+	return nil, nil
+}
+
+// --- period parameter tests ---
+
+func TestDashboardSummary_PeriodDefault(t *testing.T) {
+	handler, _ := newDashboardTestSetup(t, &profile.NoopLoader{})
+
+	// no period param — should default to "week"
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/summary", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp struct {
+		Period string `json:"period"`
+	}
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Period != "week" {
+		t.Errorf("expected default period=week, got %q", resp.Period)
+	}
+}
+
+func TestDashboardSummary_PeriodDay(t *testing.T) {
+	handler, _ := newDashboardTestSetup(t, &profile.NoopLoader{})
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/summary?period=day", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp struct {
+		Period string `json:"period"`
+	}
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Period != "day" {
+		t.Errorf("expected period=day, got %q", resp.Period)
+	}
+}
+
+func TestDashboardSummary_PeriodMonth(t *testing.T) {
+	handler, _ := newDashboardTestSetup(t, &profile.NoopLoader{})
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/summary?period=month", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp struct {
+		Period string `json:"period"`
+	}
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Period != "month" {
+		t.Errorf("expected period=month, got %q", resp.Period)
+	}
+}
+
+// --- digest endpoint ---
+
+func TestDashboardDigest_Empty(t *testing.T) {
+	handler, _ := newDashboardTestSetup(t, &profile.NoopLoader{})
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/digest/2026-03", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Period     string        `json:"period"`
+		Categories []interface{} `json:"categories"`
+		UptimePct  float64       `json:"uptime_pct"`
+		ErrorCount int           `json:"error_count"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Period != "2026-03" {
+		t.Errorf("expected period=2026-03, got %q", resp.Period)
+	}
+	if len(resp.Categories) != 0 {
+		t.Errorf("expected empty categories, got %d", len(resp.Categories))
+	}
+}
+
+func TestDashboardDigest_WithRollups(t *testing.T) {
+	handler, db := newDashboardTestSetup(t, &profile.NoopLoader{})
+
+	app := insertApp(t, db, "Sonarr", "sonarr")
+
+	// Insert rollup rows
+	_, err := db.ExecContext(context.Background(),
+		`INSERT INTO rollups (app_id, year, month, event_type, severity, count) VALUES (?,?,?,?,?,?)`,
+		app.ID, 2026, 3, "Download", "info", 89)
+	if err != nil {
+		t.Fatalf("insert rollup: %v", err)
+	}
+	_, err = db.ExecContext(context.Background(),
+		`INSERT INTO rollups (app_id, year, month, event_type, severity, count) VALUES (?,?,?,?,?,?)`,
+		app.ID, 2026, 3, "HealthIssue", "error", 2)
+	if err != nil {
+		t.Fatalf("insert rollup: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/digest/2026-03", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Period     string `json:"period"`
+		ErrorCount int    `json:"error_count"`
+		Categories []struct {
+			Label string `json:"label"`
+			Count int    `json:"count"`
+		} `json:"categories"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if resp.ErrorCount != 2 {
+		t.Errorf("expected error_count=2, got %d", resp.ErrorCount)
+	}
+	if len(resp.Categories) != 2 {
+		t.Errorf("expected 2 categories, got %d", len(resp.Categories))
+	}
+}
+
+func TestDashboardDigest_InvalidPeriod(t *testing.T) {
+	handler, _ := newDashboardTestSetup(t, &profile.NoopLoader{})
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/digest/notaperiod", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+// --- category omission test ---
+
+// TestDashboardSummary_OmitsZeroCategories verifies that categories with count=0
+// are not included in summary_bar.
+func TestDashboardSummary_OmitsZeroCategories(t *testing.T) {
+	categories := []profile.DigestCategory{
+		{Label: "Downloads", MatchField: "event_type", MatchValue: "Download"},
+		{Label: "Backups", MatchField: "event_type", MatchValue: "Backup"},
+	}
+	profiler := makeTestProfiler("app1", categories)
+	handler, db := newDashboardTestSetup(t, profiler)
+
+	app := insertApp(t, db, "App1", "app1")
+
+	// Only download events — no backup events
+	insertEventWithFields(t, db, app.ID, "info", "Download",
+		`{"event_type":"Download"}`, time.Now().UTC().Add(-time.Hour))
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/summary?period=week", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		SummaryBar []struct {
+			Label string `json:"label"`
+		} `json:"summary_bar"`
+	}
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+
+	if len(resp.SummaryBar) != 1 {
+		t.Errorf("expected only 1 summary_bar item (Downloads), got %d: %+v", len(resp.SummaryBar), resp.SummaryBar)
+	}
+	if len(resp.SummaryBar) > 0 && resp.SummaryBar[0].Label != "Downloads" {
+		t.Errorf("expected label=Downloads, got %q", resp.SummaryBar[0].Label)
+	}
+}

--- a/internal/api/ingest_test.go
+++ b/internal/api/ingest_test.go
@@ -21,7 +21,7 @@ func newIngestRouter(t *testing.T) (http.Handler, *repo.Store) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	store := repo.NewStore(appRepo, eventRepo)
+	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db))
 	limiter := ingest.NewRateLimiter()
 	profiler := &profile.NoopLoader{}
 
@@ -44,7 +44,7 @@ func TestHandleIngest_HappyPath(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db))
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()
@@ -131,7 +131,7 @@ func TestHandleIngest_RateLimit(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db))
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()

--- a/internal/ingest/pipeline.go
+++ b/internal/ingest/pipeline.go
@@ -55,9 +55,9 @@ func Process(ctx context.Context, store *repo.Store, profiler profile.Loader, li
 	if profiler != nil && app.ProfileID != "" {
 		p, err := profiler.Get(app.ProfileID)
 		if err == nil && p != nil {
-			fieldsMap = extractFields(rawBody, p.FieldMappings)
-			severity = mapSeverity(fieldsMap, p.SeverityField, p.SeverityMapping)
-			displayText = renderTemplate(p.DisplayTemplate, fieldsMap)
+			fieldsMap = extractFields(rawBody, p.Webhook.FieldMappings)
+			severity = mapSeverity(fieldsMap, p.Webhook.SeverityField, p.Webhook.SeverityMapping)
+			displayText = renderTemplate(p.Webhook.DisplayTemplate, fieldsMap)
 		}
 	}
 

--- a/internal/ingest/pipeline_test.go
+++ b/internal/ingest/pipeline_test.go
@@ -24,7 +24,7 @@ func newTestStore(t *testing.T) *repo.Store {
 	t.Cleanup(func() { db.Close() })
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	return repo.NewStore(appRepo, eventRepo)
+	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db))
 }
 
 func seedApp(t *testing.T, store *repo.Store, token string, rateLimit int) models.App {
@@ -134,17 +134,19 @@ func TestProcess_ProfileFieldExtraction(t *testing.T) {
 
 	// Profile with field mappings, severity mapping, and display template.
 	p := &profile.Profile{
-		FieldMappings: map[string]string{
-			"eventType": "$.eventType",
-			"series":    "$.series.title",
+		Webhook: profile.Webhook{
+			FieldMappings: map[string]string{
+				"eventType": "$.eventType",
+				"series":    "$.series.title",
+			},
+			SeverityField: "eventType",
+			SeverityMapping: map[string]string{
+				"Test":    "info",
+				"Health":  "warn",
+				"Grabbed": "info",
+			},
+			DisplayTemplate: "{series} — {eventType}",
 		},
-		SeverityField: "eventType",
-		SeverityMapping: map[string]string{
-			"Test":    "info",
-			"Health":  "warn",
-			"Grabbed": "info",
-		},
-		DisplayTemplate: "{series} — {eventType}",
 	}
 
 	loader := &stubLoader{profile: p}

--- a/internal/models/monitor_check.go
+++ b/internal/models/monitor_check.go
@@ -1,0 +1,21 @@
+package models
+
+import "time"
+
+// MonitorCheck represents an active health check configured in NORA.
+type MonitorCheck struct {
+	ID             string     `db:"id"              json:"id"`
+	AppID          string     `db:"app_id"          json:"app_id,omitempty"`
+	Name           string     `db:"name"            json:"name"`
+	Type           string     `db:"type"            json:"type"`
+	Target         string     `db:"target"          json:"target"`
+	IntervalSecs   int        `db:"interval_secs"   json:"interval_secs"`
+	ExpectedStatus int        `db:"expected_status" json:"expected_status,omitempty"`
+	SSLWarnDays    int        `db:"ssl_warn_days"   json:"ssl_warn_days"`
+	SSLCritDays    int        `db:"ssl_crit_days"   json:"ssl_crit_days"`
+	Enabled        bool       `db:"enabled"         json:"enabled"`
+	LastCheckedAt  *time.Time `db:"last_checked_at" json:"last_checked_at,omitempty"`
+	LastStatus     string     `db:"last_status"     json:"last_status,omitempty"`
+	LastResult     string     `db:"last_result"     json:"last_result,omitempty"`
+	CreatedAt      time.Time  `db:"created_at"      json:"created_at"`
+}

--- a/internal/models/rollup.go
+++ b/internal/models/rollup.go
@@ -1,0 +1,11 @@
+package models
+
+// Rollup represents a monthly event count summary for an app.
+type Rollup struct {
+	AppID     string `db:"app_id"     json:"app_id"`
+	Year      int    `db:"year"       json:"year"`
+	Month     int    `db:"month"      json:"month"`
+	EventType string `db:"event_type" json:"event_type"`
+	Severity  string `db:"severity"   json:"severity"`
+	Count     int    `db:"count"      json:"count"`
+}

--- a/internal/profile/loader.go
+++ b/internal/profile/loader.go
@@ -1,24 +1,128 @@
 package profile
 
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
 // Loader retrieves app profiles by ID.
 type Loader interface {
 	Get(profileID string) (*Profile, error)
 }
 
-// Profile describes how to process a webhook payload for a specific app.
+// Meta holds the profile identification and classification fields.
+type Meta struct {
+	Name        string `yaml:"name"`
+	Category    string `yaml:"category"`
+	Logo        string `yaml:"logo"`
+	Description string `yaml:"description"`
+	Capability  string `yaml:"capability"`
+}
+
+// Webhook holds ingest processing configuration for the profile.
+type Webhook struct {
+	SetupInstructions string            `yaml:"setup_instructions"`
+	RecommendedEvents []string          `yaml:"recommended_events"`
+	NotRecommended    []string          `yaml:"not_recommended"`
+	FieldMappings     map[string]string `yaml:"field_mappings"`
+	DisplayTemplate   string            `yaml:"display_template"`
+	SeverityField     string            `yaml:"severity_field"`
+	SeverityMapping   map[string]string `yaml:"severity_mapping"`
+}
+
+// Monitor holds active check configuration for the profile.
+type Monitor struct {
+	CheckType     string `yaml:"check_type"`
+	CheckURL      string `yaml:"check_url"`
+	AuthHeader    string `yaml:"auth_header"`
+	HealthyStatus int    `yaml:"healthy_status"`
+	CheckInterval string `yaml:"check_interval"`
+}
+
+// DigestCategory defines a named event category used in the dashboard summary bar.
+// A category matches events where the given field equals the given value,
+// and/or where severity equals MatchSeverity. Empty strings are ignored.
+type DigestCategory struct {
+	Label         string `yaml:"label"`
+	MatchField    string `yaml:"match_field"`
+	MatchValue    string `yaml:"match_value"`
+	MatchSeverity string `yaml:"match_severity"`
+}
+
+// Digest holds digest category definitions for the dashboard.
+type Digest struct {
+	Categories []DigestCategory `yaml:"categories"`
+}
+
+// Profile describes how to process webhooks and render dashboard data for a specific app.
 type Profile struct {
-	// FieldMappings maps a tag name to a JSONPath expression (e.g. "$.eventType").
-	FieldMappings map[string]string
-	// SeverityMapping maps an extracted field value to a severity level.
-	SeverityMapping map[string]string
-	// DisplayTemplate is a template string with {field_name} tokens.
-	DisplayTemplate string
-	// SeverityField is the tag name whose extracted value drives severity mapping.
-	SeverityField string
+	Meta    Meta    `yaml:"meta"`
+	Webhook Webhook `yaml:"webhook"`
+	Monitor Monitor `yaml:"monitor"`
+	Digest  Digest  `yaml:"digest"`
+}
+
+// Registry loads all bundled YAML profiles from an embedded filesystem.
+type Registry struct {
+	profiles map[string]*Profile
+}
+
+// NewRegistry loads all *.yaml files from fsys and returns a populated Registry.
+// Each profile is keyed by its filename without extension (e.g. "sonarr").
+func NewRegistry(fsys fs.FS) (*Registry, error) {
+	reg := &Registry{profiles: make(map[string]*Profile)}
+
+	entries, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		return nil, fmt.Errorf("read profile dir: %w", err)
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
+			continue
+		}
+
+		data, err := fs.ReadFile(fsys, e.Name())
+		if err != nil {
+			return nil, fmt.Errorf("read profile %s: %w", e.Name(), err)
+		}
+
+		var p Profile
+		if err := yaml.Unmarshal(data, &p); err != nil {
+			return nil, fmt.Errorf("parse profile %s: %w", e.Name(), err)
+		}
+
+		id := strings.TrimSuffix(e.Name(), ".yaml")
+		reg.profiles[id] = &p
+	}
+
+	return reg, nil
+}
+
+// Get returns the profile for profileID, or nil if no profile is registered.
+// A nil profile is valid — it means passthrough (no field extraction or mapping).
+func (r *Registry) Get(profileID string) (*Profile, error) {
+	if p, ok := r.profiles[profileID]; ok {
+		return p, nil
+	}
+	return nil, nil
+}
+
+// List returns all registered profiles keyed by ID.
+func (r *Registry) List() map[string]*Profile {
+	out := make(map[string]*Profile, len(r.profiles))
+	for k, v := range r.profiles {
+		out[k] = v
+	}
+	return out
 }
 
 // NoopLoader returns nil for all profiles (passthrough mode).
-// Used until T-09 (profile loader) is merged.
+// Used in tests and when profile loading is not required.
 type NoopLoader struct{}
 
 func (n *NoopLoader) Get(_ string) (*Profile, error) { return nil, nil }

--- a/internal/repo/checks.go
+++ b/internal/repo/checks.go
@@ -1,0 +1,42 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/jmoiron/sqlx"
+)
+
+// CheckRepo defines read operations for the monitor_checks table.
+type CheckRepo interface {
+	List(ctx context.Context) ([]models.MonitorCheck, error)
+}
+
+type sqliteCheckRepo struct {
+	db *sqlx.DB
+}
+
+// NewCheckRepo returns a CheckRepo backed by the given SQLite database.
+func NewCheckRepo(db *sqlx.DB) CheckRepo {
+	return &sqliteCheckRepo{db: db}
+}
+
+func (r *sqliteCheckRepo) List(ctx context.Context) ([]models.MonitorCheck, error) {
+	var checks []models.MonitorCheck
+	err := r.db.SelectContext(ctx, &checks, `
+		SELECT id, COALESCE(app_id,'') AS app_id, name, type, target,
+		       interval_secs, COALESCE(expected_status,0) AS expected_status,
+		       ssl_warn_days, ssl_crit_days, enabled,
+		       last_checked_at, COALESCE(last_status,'') AS last_status,
+		       COALESCE(last_result,'') AS last_result, created_at
+		FROM monitor_checks
+		ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("list checks: %w", err)
+	}
+	if checks == nil {
+		checks = []models.MonitorCheck{}
+	}
+	return checks, nil
+}

--- a/internal/repo/events.go
+++ b/internal/repo/events.go
@@ -22,6 +22,17 @@ type ListFilter struct {
 	Offset   int
 }
 
+// CategoryFilter defines criteria for matching events to a digest category.
+// Empty strings are ignored (not applied to the query).
+type CategoryFilter struct {
+	AppIDs        []string  // empty = all apps
+	MatchField    string    // json_extract(fields, '$.{MatchField}') = MatchValue
+	MatchValue    string
+	MatchSeverity string    // severity = MatchSeverity
+	Since         time.Time // inclusive lower bound
+	Until         time.Time // inclusive upper bound
+}
+
 // EventRepo defines read/write operations for the events table.
 type EventRepo interface {
 	// Create persists a new event.
@@ -30,6 +41,13 @@ type EventRepo interface {
 	List(ctx context.Context, f ListFilter) (events []models.Event, total int, err error)
 	// Get returns a single event by ID, including raw_payload.
 	Get(ctx context.Context, id string) (*models.Event, error)
+	// CountForCategory returns the number of events matching f.
+	CountForCategory(ctx context.Context, f CategoryFilter) (int, error)
+	// SparklineBuckets returns exactly 7 event counts, one per time bucket.
+	// The window starts at startTime and each bucket covers bucketDur.
+	SparklineBuckets(ctx context.Context, f CategoryFilter, startTime time.Time, bucketDur time.Duration) ([7]int, error)
+	// LatestPerApp returns the most recent event per app, keyed by app ID.
+	LatestPerApp(ctx context.Context, appIDs []string) (map[string]*models.Event, error)
 }
 
 type sqliteEventRepo struct {
@@ -144,4 +162,103 @@ func (r *sqliteEventRepo) Get(ctx context.Context, id string) (*models.Event, er
 		return nil, fmt.Errorf("get event: %w", err)
 	}
 	return &ev, nil
+}
+
+// buildCategoryWhere builds the WHERE clause for a CategoryFilter.
+func buildCategoryWhere(f CategoryFilter) (string, []interface{}) {
+	var parts []string
+	var args []interface{}
+
+	if len(f.AppIDs) > 0 {
+		ph := strings.TrimRight(strings.Repeat("?,", len(f.AppIDs)), ",")
+		parts = append(parts, "app_id IN ("+ph+")")
+		for _, id := range f.AppIDs {
+			args = append(args, id)
+		}
+	}
+
+	if f.MatchField != "" && f.MatchValue != "" {
+		parts = append(parts, "json_extract(fields, '$."+f.MatchField+"') = ?")
+		args = append(args, f.MatchValue)
+	}
+
+	if f.MatchSeverity != "" {
+		parts = append(parts, "severity = ?")
+		args = append(args, f.MatchSeverity)
+	}
+
+	if !f.Since.IsZero() {
+		parts = append(parts, "datetime(received_at) >= datetime(?)")
+		args = append(args, f.Since.UTC().Format(time.RFC3339))
+	}
+
+	if !f.Until.IsZero() {
+		parts = append(parts, "datetime(received_at) <= datetime(?)")
+		args = append(args, f.Until.UTC().Format(time.RFC3339))
+	}
+
+	if len(parts) == 0 {
+		return "", nil
+	}
+	return " WHERE " + strings.Join(parts, " AND "), args
+}
+
+func (r *sqliteEventRepo) CountForCategory(ctx context.Context, f CategoryFilter) (int, error) {
+	where, args := buildCategoryWhere(f)
+	q := "SELECT COUNT(*) FROM events" + where
+	var count int
+	if err := r.db.GetContext(ctx, &count, q, args...); err != nil {
+		return 0, fmt.Errorf("count for category: %w", err)
+	}
+	return count, nil
+}
+
+func (r *sqliteEventRepo) SparklineBuckets(ctx context.Context, f CategoryFilter, startTime time.Time, bucketDur time.Duration) ([7]int, error) {
+	var counts [7]int
+	for i := 0; i < 7; i++ {
+		bucketStart := startTime.Add(time.Duration(i) * bucketDur)
+		bucketEnd := bucketStart.Add(bucketDur)
+		bf := f
+		bf.Since = bucketStart
+		bf.Until = bucketEnd
+		n, err := r.CountForCategory(ctx, bf)
+		if err != nil {
+			return counts, err
+		}
+		counts[i] = n
+	}
+	return counts, nil
+}
+
+func (r *sqliteEventRepo) LatestPerApp(ctx context.Context, appIDs []string) (map[string]*models.Event, error) {
+	if len(appIDs) == 0 {
+		return map[string]*models.Event{}, nil
+	}
+
+	ph := strings.TrimRight(strings.Repeat("?,", len(appIDs)), ",")
+	args := make([]interface{}, len(appIDs))
+	for i, id := range appIDs {
+		args[i] = id
+	}
+
+	q := `
+		SELECT e.id, e.app_id, COALESCE(a.name, '') AS app_name,
+		       e.received_at, e.severity, e.display_text, e.fields
+		FROM events e
+		LEFT JOIN apps a ON a.id = e.app_id
+		WHERE e.app_id IN (` + ph + `)
+		  AND e.received_at = (
+		        SELECT MAX(e2.received_at) FROM events e2 WHERE e2.app_id = e.app_id
+		      )`
+
+	var events []models.Event
+	if err := r.db.SelectContext(ctx, &events, q, args...); err != nil {
+		return nil, fmt.Errorf("latest per app: %w", err)
+	}
+
+	result := make(map[string]*models.Event, len(events))
+	for i := range events {
+		result[events[i].AppID] = &events[i]
+	}
+	return result, nil
 }

--- a/internal/repo/rollups.go
+++ b/internal/repo/rollups.go
@@ -1,0 +1,39 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/jmoiron/sqlx"
+)
+
+// RollupRepo defines read operations for the rollups table.
+type RollupRepo interface {
+	ListByPeriod(ctx context.Context, year, month int) ([]models.Rollup, error)
+}
+
+type sqliteRollupRepo struct {
+	db *sqlx.DB
+}
+
+// NewRollupRepo returns a RollupRepo backed by the given SQLite database.
+func NewRollupRepo(db *sqlx.DB) RollupRepo {
+	return &sqliteRollupRepo{db: db}
+}
+
+func (r *sqliteRollupRepo) ListByPeriod(ctx context.Context, year, month int) ([]models.Rollup, error) {
+	var rollups []models.Rollup
+	err := r.db.SelectContext(ctx, &rollups, `
+		SELECT app_id, year, month, event_type, severity, count
+		FROM rollups
+		WHERE year = ? AND month = ?
+		ORDER BY app_id, event_type, severity`, year, month)
+	if err != nil {
+		return nil, fmt.Errorf("list rollups: %w", err)
+	}
+	if rollups == nil {
+		rollups = []models.Rollup{}
+	}
+	return rollups, nil
+}

--- a/internal/repo/store.go
+++ b/internal/repo/store.go
@@ -2,11 +2,13 @@ package repo
 
 // Store bundles all repository interfaces into a single dependency.
 type Store struct {
-	Apps   AppRepo
-	Events EventRepo
+	Apps    AppRepo
+	Events  EventRepo
+	Checks  CheckRepo
+	Rollups RollupRepo
 }
 
 // NewStore creates a Store backed by the given repositories.
-func NewStore(apps AppRepo, events EventRepo) *Store {
-	return &Store{Apps: apps, Events: events}
+func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRepo) *Store {
+	return &Store{Apps: apps, Events: events, Checks: checks, Rollups: rollups}
 }

--- a/profiles/duplicati.yaml
+++ b/profiles/duplicati.yaml
@@ -1,0 +1,41 @@
+meta:
+  name: Duplicati
+  category: Storage
+  logo: duplicati.png
+  description: Open-source backup software
+  capability: webhook_only
+
+webhook:
+  setup_instructions: |
+    In Duplicati go to Settings → Default options → Send HTTP message.
+    Set the URL to {base_url}/ingest/{token}.
+  recommended_events:
+    - Backup completed
+    - Backup failed
+    - Restore completed
+  not_recommended: []
+  field_mappings:
+    event_type: "$.Data.ParsedResult"
+    backup_name: "$.Data.OperationName"
+    duration: "$.Data.Duration"
+    files_added: "$.Data.AddedFiles"
+    bytes_uploaded: "$.Data.SizeOfAddedFiles"
+    error_message: "$.Data.Message"
+  severity_field: event_type
+  display_template: "Backup {event_type} — {backup_name}"
+  severity_mapping:
+    Success: info
+    Warning: warn
+    Error: error
+    Fatal: critical
+
+digest:
+  categories:
+    - label: Backups
+      match_field: event_type
+      match_value: Success
+      match_severity: ""
+    - label: Backup Errors
+      match_field: ""
+      match_value: ""
+      match_severity: error

--- a/profiles/embed.go
+++ b/profiles/embed.go
@@ -1,0 +1,7 @@
+// Package profiles exposes the embedded YAML profile files.
+package profiles
+
+import "embed"
+
+//go:embed *.yaml
+var Files embed.FS

--- a/profiles/n8n.yaml
+++ b/profiles/n8n.yaml
@@ -1,0 +1,46 @@
+meta:
+  name: n8n
+  category: Automation
+  logo: n8n.png
+  description: Workflow automation platform
+  capability: full
+
+webhook:
+  setup_instructions: |
+    In n8n go to Settings → Log streaming or use the n8n webhook node to POST to
+    {base_url}/ingest/{token} on workflow completion and error events.
+  recommended_events:
+    - Workflow finished
+    - Workflow error
+    - Node error
+  not_recommended: []
+  field_mappings:
+    event_type: "$.eventName"
+    workflow_name: "$.workflowData.name"
+    workflow_id: "$.workflowData.id"
+    execution_id: "$.executionId"
+    error_message: "$.error.message"
+    error_node: "$.nodeName"
+  severity_field: event_type
+  display_template: "{event_type} — {workflow_name}"
+  severity_mapping:
+    "workflow.finished": info
+    "workflow.error": error
+    "node.error": warn
+
+monitor:
+  check_type: url
+  check_url: "{base_url}/healthz"
+  healthy_status: 200
+  check_interval: 5m
+
+digest:
+  categories:
+    - label: Workflows
+      match_field: event_type
+      match_value: "workflow.finished"
+      match_severity: ""
+    - label: Errors
+      match_field: ""
+      match_value: ""
+      match_severity: error

--- a/profiles/radarr.yaml
+++ b/profiles/radarr.yaml
@@ -1,0 +1,54 @@
+meta:
+  name: Radarr
+  category: Media
+  logo: radarr.png
+  description: Movie management and download automation
+  capability: full
+
+webhook:
+  setup_instructions: |
+    In Radarr go to Settings → Connect → Add → Webhook.
+    Set the URL to {base_url}/ingest/{token} and select the event types below.
+  recommended_events:
+    - On Download
+    - On Upgrade
+    - On Health Issue
+    - On Application Update
+  not_recommended:
+    - On Grab
+  field_mappings:
+    event_type: "$.eventType"
+    movie_title: "$.movie.title"
+    quality: "$.movieFile.quality.quality.name"
+    health_type: "$.healthCheck.type"
+    health_message: "$.healthCheck.message"
+  severity_field: event_type
+  display_template: "{event_type} — {movie_title}"
+  severity_mapping:
+    Download: info
+    Upgrade: info
+    HealthIssue: warn
+    HealthRestored: info
+    ApplicationUpdate: info
+
+monitor:
+  check_type: url
+  check_url: "{base_url}/api/v3/system/status"
+  auth_header: "X-Api-Key: {api_key}"
+  healthy_status: 200
+  check_interval: 5m
+
+digest:
+  categories:
+    - label: Downloads
+      match_field: event_type
+      match_value: Download
+      match_severity: ""
+    - label: Upgrades
+      match_field: event_type
+      match_value: Upgrade
+      match_severity: ""
+    - label: Health Issues
+      match_field: event_type
+      match_value: HealthIssue
+      match_severity: ""

--- a/profiles/sonarr.yaml
+++ b/profiles/sonarr.yaml
@@ -1,0 +1,57 @@
+meta:
+  name: Sonarr
+  category: Media
+  logo: sonarr.png
+  description: TV series management and download automation
+  capability: full
+
+webhook:
+  setup_instructions: |
+    In Sonarr go to Settings → Connect → Add → Webhook.
+    Set the URL to {base_url}/ingest/{token} and select the event types below.
+  recommended_events:
+    - On Download
+    - On Upgrade
+    - On Health Issue
+    - On Application Update
+  not_recommended:
+    - On Grab
+  field_mappings:
+    event_type: "$.eventType"
+    series_title: "$.series.title"
+    episode_title: "$.episodes[0].title"
+    season_number: "$.episodes[0].seasonNumber"
+    episode_number: "$.episodes[0].episodeNumber"
+    quality: "$.episodes[0].quality.quality.name"
+    health_type: "$.healthCheck.type"
+    health_message: "$.healthCheck.message"
+  severity_field: event_type
+  display_template: "{event_type} — {series_title} S{season_number}E{episode_number}"
+  severity_mapping:
+    Download: info
+    Upgrade: info
+    HealthIssue: warn
+    HealthRestored: info
+    ApplicationUpdate: info
+
+monitor:
+  check_type: url
+  check_url: "{base_url}/api/v3/system/status"
+  auth_header: "X-Api-Key: {api_key}"
+  healthy_status: 200
+  check_interval: 5m
+
+digest:
+  categories:
+    - label: Downloads
+      match_field: event_type
+      match_value: Download
+      match_severity: ""
+    - label: Upgrades
+      match_field: event_type
+      match_value: Upgrade
+      match_severity: ""
+    - label: Health Issues
+      match_field: event_type
+      match_value: HealthIssue
+      match_severity: ""


### PR DESCRIPTION
## What
Implements the dashboard summary and digest endpoints:
- `GET /api/v1/dashboard/summary?period=day|week|month`
- `GET /api/v1/dashboard/digest/{year}-{month}`

## Why
T-09: the frontend home screen needs a single efficient endpoint to render app statuses, event counts by category, sparkline data, and monitor check status.

## How
**Profile system (T-20 merged here):** Rewrote `internal/profile/loader.go` with a full YAML-backed schema (`Meta`/`Webhook`/`Monitor`/`Digest`). Added a `Registry` that loads all `profiles/*.yaml` via embedded FS. Created 4 bundled profiles: sonarr, radarr, n8n, duplicati — each with `digest.categories` definitions.

**Summary bar algorithm:** Fully dynamic — no hardcoded category strings. For each app, reads its profile's `digest.categories`, counts matching events from the DB using `json_extract(fields, '$.{field}') = value` and/or `severity = value`, deduplicates by label across apps, omits categories with zero events, builds 7-bucket sparklines.

**Sparkline bucketing:** 7 buckets per period — day=7×4h, week=7×1d, month=7×4d. Always exactly 7 elements.

**New repo additions:** `CheckRepo` (list monitor_checks), `RollupRepo` (list by year/month), `EventRepo.CountForCategory`, `EventRepo.SparklineBuckets`, `EventRepo.LatestPerApp`.

**Global status:** `"down"` if any check or app is down, `"warn"` if any are in warn state, otherwise `"normal"`.

## Test coverage
10 tests in `dashboard_test.go`:
- Zero apps → empty summary_bar and apps arrays
- Single app → correct category counts and sparklines
- Multi-app → Downloads combined across Sonarr+Radarr, Errors counted separately
- Category omission → zero-count categories absent from summary_bar
- All three period params (day/week/month)
- Digest endpoint with and without rollup data
- Invalid period format → 400

## Closes
Closes #9