### PR TITLE
feat: T-10 dashboard home screen

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -10,7 +10,7 @@ import type {
   CreateAppInput,
   CreateCheckInput,
   CreateUserInput,
-  DashboardSummary,
+  DashboardSummaryResponse,
   DockerEngine,
   Event,
   EventFilter,
@@ -35,7 +35,7 @@ async function request<T>(
     headers['Content-Type'] = 'application/json'
   }
 
-  const res = await fetch(path, {
+  const res = await fetch(`/api/v1${path}`, {
     method,
     headers,
     body: body !== undefined ? JSON.stringify(body) : undefined,
@@ -196,8 +196,8 @@ export const topology = {
 // ── Dashboard ─────────────────────────────────────────────────────────────────
 
 export const dashboard = {
-  summary: () =>
-    request<DashboardSummary>('GET', '/dashboard/summary'),
+  summary: (period: string = 'week') =>
+    request<DashboardSummaryResponse>('GET', `/dashboard/summary?period=${period}`),
 
   digest: (period: string) =>
     request<unknown>('GET', `/dashboard/digest/${period}`),

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -150,19 +150,54 @@ export interface DockerEngine {
 
 // ── Dashboard ─────────────────────────────────────────────────────────────
 
-export interface DashboardSummary {
-  status: 'ok' | 'warn' | 'down'
-  categories: SummaryCategory[]
-  checks_total: number
-  checks_up: number
-  checks_warn: number
-  checks_down: number
-}
-
-export interface SummaryCategory {
+export interface SummaryBarItem {
   label: string
   count: number
-  trend: number[]
+  sub: string
+  sparkline: number[]
+}
+
+export interface AppStat {
+  label: string
+  value: string
+  color?: string
+}
+
+export interface AppSummary {
+  id: string
+  name: string
+  profile_id: string
+  status: 'online' | 'warn' | 'down'
+  last_event_at: string | null
+  last_event_text: string | null
+  stats: AppStat[]
+  sparkline: number[]
+}
+
+export interface CheckSummary {
+  id: string
+  name: string
+  type: string
+  target: string
+  status: string
+  uptime_pct: number
+  last_checked_at?: string
+}
+
+export interface SSLCert {
+  domain: string
+  days_remaining: number
+  expires_at: string
+  status: string
+}
+
+export interface DashboardSummaryResponse {
+  status: 'normal' | 'warn' | 'down'
+  period: string
+  summary_bar: SummaryBarItem[]
+  apps: AppSummary[]
+  checks: CheckSummary[]
+  ssl_certs: SSLCert[]
 }
 
 // ── Profile Library ──────────────────────────────────────────────────────────

--- a/frontend/src/components/AppWidget.tsx
+++ b/frontend/src/components/AppWidget.tsx
@@ -1,0 +1,91 @@
+import type { AppSummary } from '../api/types'
+
+function monogram(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean)
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase()
+  return (words[0][0] + words[1][0]).toUpperCase()
+}
+
+function sparklinePoints(data: number[], width: number, height: number): string {
+  if (!data || data.length < 2) return ''
+  const max = Math.max(...data, 1)
+  const n = data.length
+  return data
+    .map((v, i) => {
+      const x = ((i / (n - 1)) * width).toFixed(1)
+      const y = (height - 2 - (v / max) * (height - 4)).toFixed(1)
+      return `${x},${y}`
+    })
+    .join(' ')
+}
+
+interface Props {
+  app: AppSummary
+  onClick: () => void
+}
+
+export function AppWidget({ app, onClick }: Props) {
+  const pts = sparklinePoints(app.sparkline, 180, 28)
+  const closedPts = pts ? `${pts} 180,28 0,28` : ''
+
+  const sparkColor =
+    app.status === 'warn'
+      ? 'var(--yellow)'
+      : app.status === 'down'
+      ? 'var(--red)'
+      : 'var(--accent)'
+
+  const dotClass =
+    app.status === 'online' ? 'green' : app.status === 'warn' ? 'yellow' : app.status === 'down' ? 'red' : 'grey'
+
+  const statusText =
+    app.status === 'online' ? 'Online' : app.status === 'warn' ? 'Warn' : app.status === 'down' ? 'Down' : 'Unknown'
+
+  const lastEventStyle: Record<string, string> =
+    app.status === 'warn' ? { color: 'var(--yellow)' } : app.status === 'down' ? { color: 'var(--red)' } : {}
+
+  return (
+    <div
+      className={`app-widget${app.status !== 'online' ? ` ${app.status}` : ''}`}
+      onClick={onClick}
+    >
+      <div className="app-widget-header">
+        <div className="app-icon">{monogram(app.name)}</div>
+        <div className="app-name">{app.name}</div>
+        <div className={`app-status ${app.status}`}>
+          <div className={`dot ${dotClass}`} />
+          {statusText}
+        </div>
+      </div>
+
+      {app.stats && app.stats.length > 0 && (
+        <div className="app-widget-stats">
+          {app.stats.slice(0, 4).map(stat => (
+            <div key={stat.label} className="stat-item">
+              <div className="stat-label">{stat.label}</div>
+              <div
+                className="stat-value"
+                style={stat.color ? { color: stat.color } : {}}
+              >
+                {stat.value}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {pts && (
+        <svg className="app-widget-sparkline" viewBox="0 0 180 28" preserveAspectRatio="none">
+          <polyline points={pts} fill="none" stroke={sparkColor} strokeWidth="1.5" opacity="0.7" />
+          <polyline points={closedPts} fill={sparkColor} stroke="none" opacity="0.07" />
+        </svg>
+      )}
+
+      {app.last_event_text && (
+        <div className="app-last-event" style={lastEventStyle}>
+          {app.last_event_text}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/BookmarkWidget.tsx
+++ b/frontend/src/components/BookmarkWidget.tsx
@@ -1,0 +1,39 @@
+export interface BookmarkData {
+  id: string
+  name: string
+  url: string
+}
+
+interface Props {
+  bookmark: BookmarkData
+}
+
+export function BookmarkWidget({ bookmark }: Props) {
+  return (
+    <a
+      className="bookmark-widget"
+      href={bookmark.url}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <div className="bookmark-icon">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <circle cx="12" cy="12" r="10" />
+          <line x1="2" y1="12" x2="22" y2="12" />
+          <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+        </svg>
+      </div>
+      <div className="bookmark-info">
+        <div className="bookmark-name">{bookmark.name}</div>
+        <div className="bookmark-url">{bookmark.url}</div>
+      </div>
+      <div className="bookmark-arrow">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+          <polyline points="15 3 21 3 21 9" />
+          <line x1="10" y1="14" x2="21" y2="3" />
+        </svg>
+      </div>
+    </a>
+  )
+}

--- a/frontend/src/components/EventRow.tsx
+++ b/frontend/src/components/EventRow.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+import { events as eventsApi } from '../api/client'
+import type { Event } from '../api/types'
+
+function formatEventTime(iso: string): string {
+  const d = new Date(iso)
+  const now = new Date()
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const startOfYesterday = new Date(startOfToday.getTime() - 86400000)
+  if (d >= startOfToday) {
+    return d
+      .toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+      .toLowerCase()
+  }
+  if (d >= startOfYesterday) return 'Yesterday'
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+interface Props {
+  event: Event
+  appName: string
+}
+
+export function EventRow({ event, appName }: Props) {
+  const [expanded, setExpanded] = useState(false)
+  const [detail, setDetail] = useState<Record<string, unknown> | null>(null)
+  const [fetching, setFetching] = useState(false)
+  const sev = event.severity
+
+  function handleClick() {
+    if (!expanded && detail === null) {
+      setFetching(true)
+      eventsApi
+        .get(event.id)
+        .then(e => setDetail((e as Event & { raw_payload: Record<string, unknown> }).raw_payload ?? e.fields ?? {}))
+        .catch(() => setDetail({}))
+        .finally(() => setFetching(false))
+    }
+    setExpanded(!expanded)
+  }
+
+  return (
+    <div className={`event-row-wrapper${expanded ? ' expanded' : ''}`}>
+      <div className="event-row" onClick={handleClick}>
+        <div className="event-time">{formatEventTime(event.received_at)}</div>
+        <div className={`severity-badge ${sev}`} />
+        <div className="event-app">{appName || event.app_id}</div>
+        <div className="event-text">{event.display_text}</div>
+        <div className={`event-sev-label ${sev}`}>{sev}</div>
+      </div>
+      {expanded && (
+        <div className="event-expand">
+          {fetching ? 'Loading…' : JSON.stringify(detail, null, 2)}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/HostWidget.tsx
+++ b/frontend/src/components/HostWidget.tsx
@@ -1,0 +1,75 @@
+export interface ResourceBar {
+  label: string
+  pct: number
+}
+
+export interface HostData {
+  id: string
+  name: string
+  type: string
+  ip: string
+  status: 'online' | 'warn' | 'down' | 'unknown'
+  resources: ResourceBar[]
+}
+
+function barFillClass(pct: number): string {
+  if (pct >= 90) return 'resource-bar-fill crit'
+  if (pct >= 70) return 'resource-bar-fill warn'
+  return 'resource-bar-fill'
+}
+
+interface Props {
+  host: HostData
+}
+
+export function HostWidget({ host }: Props) {
+  const dotClass =
+    host.status === 'online'
+      ? 'green'
+      : host.status === 'warn'
+      ? 'yellow'
+      : host.status === 'down'
+      ? 'red'
+      : 'grey'
+
+  return (
+    <div className="host-widget">
+      <div className="host-widget-header">
+        <div className="host-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <rect x="2" y="2" width="20" height="8" rx="2" />
+            <rect x="2" y="14" width="20" height="8" rx="2" />
+            <line x1="6" y1="6" x2="6.01" y2="6" />
+            <line x1="6" y1="18" x2="6.01" y2="18" />
+          </svg>
+        </div>
+        <div className="host-meta">
+          <div className="host-name">{host.name}</div>
+          <div className="host-type">{host.type} · {host.ip}</div>
+        </div>
+        <div className={`app-status ${host.status}`}>
+          <div className={`dot ${dotClass}`} />
+        </div>
+      </div>
+      <div className="resource-bars">
+        {host.resources.map(r => (
+          <div key={r.label} className="resource-row">
+            <div className="resource-label">{r.label}</div>
+            <div className="resource-bar-track">
+              <div
+                className={barFillClass(r.pct)}
+                style={{ width: `${r.pct}%` }}
+              />
+            </div>
+            <div
+              className="resource-pct"
+              style={r.pct >= 90 ? { color: 'var(--red)' } : r.pct >= 70 ? { color: 'var(--yellow)' } : {}}
+            >
+              {r.pct}%
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/MonitorWidget.tsx
+++ b/frontend/src/components/MonitorWidget.tsx
@@ -1,0 +1,55 @@
+import type { CheckSummary } from '../api/types'
+
+function statusBlockLabel(check: CheckSummary): string {
+  if (check.type === 'ssl') return 'SSL'
+  if (check.status === 'up') return 'UP'
+  if (check.status === 'down') return 'DOWN'
+  if (check.status === 'warn') return 'WARN'
+  return '?'
+}
+
+function statusBlockClass(status: string): string {
+  if (status === 'up') return 'monitor-status-block up'
+  if (status === 'warn') return 'monitor-status-block warn'
+  if (status === 'down') return 'monitor-status-block down'
+  return 'monitor-status-block unknown'
+}
+
+function uptimeClass(status: string): string {
+  if (status === 'down') return 'monitor-uptime down'
+  if (status === 'warn') return 'monitor-uptime warn'
+  return 'monitor-uptime'
+}
+
+function formatTimeAgo(iso?: string): string {
+  if (!iso) return '—'
+  const diffMs = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diffMs / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return `${Math.floor(hrs / 24)}d ago`
+}
+
+interface Props {
+  check: CheckSummary
+}
+
+export function MonitorWidget({ check }: Props) {
+  return (
+    <div className="monitor-widget">
+      <div className={statusBlockClass(check.status)}>{statusBlockLabel(check)}</div>
+      <div className="monitor-info">
+        <div className="monitor-name">{check.name}</div>
+        <div className="monitor-target">{check.target} · {check.type}</div>
+      </div>
+      <div className="monitor-meta">
+        <div className={uptimeClass(check.status)}>
+          {check.uptime_pct.toFixed(1)}%
+        </div>
+        <div className="monitor-last">{formatTimeAgo(check.last_checked_at)}</div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/SSLRow.tsx
+++ b/frontend/src/components/SSLRow.tsx
@@ -1,0 +1,29 @@
+import type { SSLCert } from '../api/types'
+
+function daysClass(days: number): string {
+  if (days <= 10) return 'ssl-days crit'
+  if (days <= 30) return 'ssl-days warn'
+  return 'ssl-days good'
+}
+
+function formatSSLDate(dateStr: string): string {
+  if (!dateStr) return ''
+  const d = new Date(dateStr + 'T00:00:00Z')
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })
+}
+
+interface Props {
+  cert: SSLCert
+}
+
+export function SSLRow({ cert }: Props) {
+  return (
+    <div className="ssl-row">
+      <div className={daysClass(cert.days_remaining)}>
+        {cert.days_remaining}d
+      </div>
+      <div className="ssl-domain">{cert.domain}</div>
+      <div className="ssl-date">{formatSSLDate(cert.expires_at)}</div>
+    </div>
+  )
+}

--- a/frontend/src/components/SummaryCard.tsx
+++ b/frontend/src/components/SummaryCard.tsx
@@ -1,0 +1,52 @@
+import type { SummaryBarItem } from '../api/types'
+
+function sparklineColor(label: string): string {
+  const l = label.toLowerCase()
+  if (l.includes('error') || l.includes('fail') || l.includes('down')) return 'var(--red)'
+  if (l.includes('uptime') || l.includes('backup') || l.includes('success')) return 'var(--green)'
+  return 'var(--accent)'
+}
+
+function valueColorClass(label: string): string {
+  const l = label.toLowerCase()
+  if (l.includes('error') || l.includes('fail') || l.includes('down')) return 'summary-value red'
+  if (l.includes('uptime') || l.includes('backup') || l.includes('success')) return 'summary-value green'
+  return 'summary-value'
+}
+
+function sparklinePoints(data: number[], width: number, height: number): string {
+  if (!data || data.length < 2) return ''
+  const max = Math.max(...data, 1)
+  const n = data.length
+  return data
+    .map((v, i) => {
+      const x = ((i / (n - 1)) * width).toFixed(1)
+      const y = (height - 2 - (v / max) * (height - 4)).toFixed(1)
+      return `${x},${y}`
+    })
+    .join(' ')
+}
+
+interface Props {
+  item: SummaryBarItem
+}
+
+export function SummaryCard({ item }: Props) {
+  const color = sparklineColor(item.label)
+  const pts = sparklinePoints(item.sparkline, 120, 24)
+  const closedPts = pts ? `${pts} 120,24 0,24` : ''
+
+  return (
+    <div className="summary-card">
+      <div className="summary-label">{item.label}</div>
+      <div className={valueColorClass(item.label)}>{item.count}</div>
+      <div className="summary-sub">{item.sub}</div>
+      {pts && (
+        <svg className="sparkline" viewBox="0 0 120 24" preserveAspectRatio="none">
+          <polyline points={pts} fill="none" stroke={color} strokeWidth="1.5" opacity="0.8" />
+          <polyline points={closedPts} fill={color} stroke="none" opacity="0.08" />
+        </svg>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -1,3 +1,572 @@
+/* ── SUMMARY BAR ── */
+.summary-bar {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 10px;
+}
+
+.summary-card {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border-color 0.15s;
+  animation: fadeUp 0.3s ease both;
+}
+
+.summary-card:hover { border-color: var(--border2); }
+
+.summary-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.summary-value {
+  font-family: var(--mono);
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1;
+}
+
+.summary-value.green { color: var(--green); }
+.summary-value.yellow { color: var(--yellow); }
+.summary-value.red { color: var(--red); }
+
+.summary-sub {
+  font-size: 11px;
+  color: var(--text3);
+}
+
+.sparkline {
+  height: 24px;
+  margin-top: 2px;
+}
+
+/* ── SECTION HEADER ── */
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.section-title {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.section-title::before {
+  content: '';
+  width: 2px;
+  height: 12px;
+  background: var(--accent);
+  border-radius: 1px;
+  display: block;
+}
+
+.section-action {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0.7;
+  transition: opacity 0.15s;
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+.section-action:hover { opacity: 1; }
+
+/* ── WIDGET GRID ── */
+.widget-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+/* ── APP WIDGET ── */
+.app-widget {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  position: relative;
+  overflow: hidden;
+  animation: fadeUp 0.3s ease both;
+}
+
+.app-widget::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--green);
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.app-widget:hover { border-color: var(--border2); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
+.app-widget:hover::before { opacity: 1; }
+.app-widget.warn::before { background: var(--yellow); opacity: 1; }
+.app-widget.down::before { background: var(--red); opacity: 1; }
+
+.app-widget:nth-child(1) { animation-delay: 0.05s; }
+.app-widget:nth-child(2) { animation-delay: 0.10s; }
+.app-widget:nth-child(3) { animation-delay: 0.15s; }
+.app-widget:nth-child(4) { animation-delay: 0.20s; }
+.app-widget:nth-child(5) { animation-delay: 0.25s; }
+.app-widget:nth-child(6) { animation-delay: 0.30s; }
+
+.app-widget-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.app-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text2);
+  flex-shrink: 0;
+}
+
+.app-name {
+  font-weight: 500;
+  font-size: 13px;
+  color: var(--text);
+  flex: 1;
+}
+
+.app-status {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--mono);
+  font-size: 10px;
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dot.green { background: var(--green); }
+.dot.yellow { background: var(--yellow); }
+.dot.red { background: var(--red); }
+.dot.grey { background: var(--text3); }
+
+.app-status.online { color: var(--green); }
+.app-status.warn { color: var(--yellow); }
+.app-status.down { color: var(--red); }
+.app-status.unknown { color: var(--text3); }
+
+.app-widget-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.stat-item {
+  background: var(--bg3);
+  border-radius: 4px;
+  padding: 6px 8px;
+}
+
+.stat-label {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 2px;
+}
+
+.stat-value {
+  font-family: var(--mono);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1;
+}
+
+.app-widget-sparkline {
+  height: 28px;
+  width: 100%;
+}
+
+.app-last-event {
+  font-size: 11px;
+  color: var(--text3);
+  font-family: var(--mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── HOST WIDGET ── */
+.host-widget {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  animation: fadeUp 0.3s ease both;
+}
+
+.host-widget:hover { border-color: var(--border2); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
+
+.host-widget-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.host-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.host-icon svg { width: 14px; height: 14px; color: var(--text3); }
+
+.host-meta { flex: 1; }
+.host-name { font-weight: 500; font-size: 13px; color: var(--text); }
+.host-type { font-family: var(--mono); font-size: 10px; color: var(--text3); }
+
+.resource-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.resource-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.resource-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  width: 28px;
+  flex-shrink: 0;
+}
+
+.resource-bar-track {
+  flex: 1;
+  height: 4px;
+  background: var(--bg4);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.resource-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--accent);
+  transition: width 0.3s ease;
+}
+
+.resource-bar-fill.warn { background: var(--yellow); }
+.resource-bar-fill.crit { background: var(--red); }
+
+.resource-pct {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text2);
+  width: 28px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+/* ── MONITOR WIDGET ── */
+.monitor-widget {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.monitor-widget:hover { border-color: var(--border2); }
+
+.monitor-status-block {
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.monitor-status-block.up     { background: var(--green-dim);  color: var(--green);  border: 1px solid #166534; }
+.monitor-status-block.warn   { background: var(--yellow-dim); color: var(--yellow); border: 1px solid #854d0e; }
+.monitor-status-block.down   { background: var(--red-dim);    color: var(--red);    border: 1px solid #991b1b; }
+.monitor-status-block.unknown{ background: var(--bg4);        color: var(--text3);  border: 1px solid var(--border); }
+
+.monitor-info { flex: 1; min-width: 0; }
+.monitor-name { font-size: 13px; font-weight: 500; color: var(--text); }
+.monitor-target { font-family: var(--mono); font-size: 10px; color: var(--text3); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+.monitor-meta { text-align: right; flex-shrink: 0; }
+
+.monitor-uptime { font-family: var(--mono); font-size: 12px; font-weight: 600; color: var(--green); }
+.monitor-uptime.warn { color: var(--yellow); }
+.monitor-uptime.down { color: var(--red); }
+.monitor-last { font-family: var(--mono); font-size: 10px; color: var(--text3); }
+
+/* ── BOOKMARK WIDGET ── */
+.bookmark-widget {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+}
+
+.bookmark-widget:hover { border-color: var(--border2); background: var(--bg3); }
+
+.bookmark-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.bookmark-icon svg { width: 12px; height: 12px; color: var(--text3); }
+.bookmark-info { flex: 1; min-width: 0; }
+.bookmark-name { font-size: 13px; color: var(--text); }
+.bookmark-url { font-family: var(--mono); font-size: 10px; color: var(--text3); }
+.bookmark-arrow { color: var(--text3); margin-left: auto; flex-shrink: 0; }
+.bookmark-arrow svg { width: 12px; height: 12px; }
+
+/* ── RECENT EVENTS ── */
+.events-panel {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.event-row-wrapper:last-child .event-row { border-bottom: none; }
+.event-row-wrapper.expanded .event-row { border-bottom: 1px solid var(--border); }
+.event-row-wrapper.expanded:last-child .event-expand { border-bottom: none; }
+
+.event-row {
+  display: grid;
+  grid-template-columns: 80px 20px 140px 1fr 80px;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 16px;
+  border-bottom: 1px solid var(--border);
+  transition: background 0.1s;
+  cursor: pointer;
+}
+
+.event-row:hover { background: var(--bg3); }
+
+.event-time {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+}
+
+.severity-badge {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.severity-badge.debug    { background: var(--text3); }
+.severity-badge.info     { background: var(--accent); }
+.severity-badge.warn     { background: var(--yellow); }
+.severity-badge.error    { background: var(--red); }
+.severity-badge.critical { background: var(--red); }
+
+.event-app {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.event-text {
+  font-size: 12px;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.event-sev-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-align: right;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.event-sev-label.debug    { color: var(--text3); }
+.event-sev-label.info     { color: var(--accent); }
+.event-sev-label.warn     { color: var(--yellow); }
+.event-sev-label.error    { color: var(--red); }
+.event-sev-label.critical { color: var(--red); }
+
+.event-expand {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg3);
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-x: auto;
+  line-height: 1.6;
+}
+
+/* ── SSL PANEL ── */
+.ssl-panel {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.ssl-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.ssl-row:last-child { border-bottom: none; }
+.ssl-row:hover { background: var(--bg3); }
+
+.ssl-days {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  width: 50px;
+  flex-shrink: 0;
+}
+
+.ssl-days.good { color: var(--green); }
+.ssl-days.warn { color: var(--yellow); }
+.ssl-days.crit { color: var(--red); }
+
+.ssl-domain { font-size: 12px; color: var(--text); flex: 1; font-family: var(--mono); }
+.ssl-date { font-family: var(--mono); font-size: 10px; color: var(--text3); }
+
+/* ── TWO-COLUMN LAYOUT ── */
+.two-col {
+  display: grid;
+  grid-template-columns: 1fr 380px;
+  gap: 20px;
+  align-items: start;
+}
+
+.col-left,
+.col-right {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* ── SKELETON SHIMMER ── */
+.skeleton {
+  border-radius: 8px;
+  background: linear-gradient(90deg, var(--bg3) 25%, var(--bg4) 50%, var(--bg3) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+.skeleton-bar  { height: 96px; }
+.skeleton-card { height: 160px; }
+
+@keyframes shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* ── ANIMATIONS ── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── EMPTY STATE ── */
 .dashboard-empty {
   display: flex;
   flex-direction: column;
@@ -7,9 +576,38 @@
   color: var(--text3);
 }
 
+.dashboard-empty-icon {
+  width: 48px;
+  height: 48px;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text3);
+}
+
+.dashboard-empty-title {
+  font-family: var(--mono);
+  font-size: 14px;
+  color: var(--text2);
+  font-weight: 500;
+}
+
 .dashboard-empty-text {
   font-family: var(--mono);
-  font-size: 13px;
+  font-size: 12px;
+  color: var(--text3);
+  text-align: center;
+  max-width: 320px;
+  line-height: 1.6;
+}
+
+.dashboard-empty-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 8px;
 }
 
 .dashboard-empty-btn {
@@ -27,4 +625,16 @@
 .dashboard-empty-btn:hover {
   background: var(--accent);
   color: white;
+}
+
+.dashboard-empty-btn.secondary {
+  background: var(--bg3);
+  border-color: var(--border);
+  color: var(--text2);
+}
+
+.dashboard-empty-btn.secondary:hover {
+  background: var(--bg4);
+  border-color: var(--border2);
+  color: var(--text);
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,25 +1,252 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Topbar } from '../components/Topbar'
+import { SummaryCard } from '../components/SummaryCard'
+import { AppWidget } from '../components/AppWidget'
+import { MonitorWidget } from '../components/MonitorWidget'
+import { SSLRow } from '../components/SSLRow'
+import { EventRow } from '../components/EventRow'
+import { dashboard as dashboardApi, events as eventsApi } from '../api/client'
+import type { DashboardSummaryResponse, Event } from '../api/types'
 import './Dashboard.css'
 
 type TimeFilter = 'day' | 'week' | 'month'
 
 export function Dashboard() {
+  const navigate = useNavigate()
   const [timeFilter, setTimeFilter] = useState<TimeFilter>('week')
+  const [data, setData] = useState<DashboardSummaryResponse | null>(null)
+  const [recentEvents, setRecentEvents] = useState<Event[]>([])
+  const [loading, setLoading] = useState(true)
 
+  useEffect(() => {
+    setLoading(true)
+    Promise.all([
+      dashboardApi.summary(timeFilter),
+      eventsApi.list({ limit: 5 }),
+    ])
+      .then(([summary, evts]) => {
+        setData(summary)
+        setRecentEvents(evts.data)
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [timeFilter])
+
+  const topbarStatus =
+    data == null
+      ? 'ok'
+      : data.status === 'normal'
+      ? 'ok'
+      : (data.status as 'warn' | 'down')
+
+  // ── Loading skeleton ──────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <>
+        <Topbar title="Dashboard" timeFilter={timeFilter} onTimeFilter={setTimeFilter} />
+        <div className="content">
+          <div className="summary-bar">
+            {[0, 1, 2, 3, 4].map(i => (
+              <div key={i} className="skeleton skeleton-bar" />
+            ))}
+          </div>
+          <div className="two-col">
+            <div className="col-left">
+              <div className="widget-grid">
+                {[0, 1, 2, 3].map(i => (
+                  <div key={i} className="skeleton skeleton-card" />
+                ))}
+              </div>
+            </div>
+            <div className="col-right">
+              {[0, 1, 2].map(i => (
+                <div key={i} className="skeleton skeleton-bar" style={{ marginBottom: 6 }} />
+              ))}
+            </div>
+          </div>
+        </div>
+      </>
+    )
+  }
+
+  // ── Empty state ───────────────────────────────────────────────────────────
+  if (!data || data.apps.length === 0) {
+    return (
+      <>
+        <Topbar title="Dashboard" timeFilter={timeFilter} onTimeFilter={setTimeFilter} />
+        <div className="content">
+          <div className="dashboard-empty">
+            <div className="dashboard-empty-icon">
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              >
+                <rect x="2" y="3" width="20" height="14" rx="2" />
+                <line x1="8" y1="21" x2="16" y2="21" />
+                <line x1="12" y1="17" x2="12" y2="21" />
+              </svg>
+            </div>
+            <div className="dashboard-empty-title">No apps configured yet</div>
+            <div className="dashboard-empty-text">
+              Add your first app to start receiving webhooks and monitoring events.
+            </div>
+            <div className="dashboard-empty-actions">
+              <button
+                className="dashboard-empty-btn"
+                onClick={() => navigate('/apps')}
+              >
+                + Add your first app
+              </button>
+              <button
+                className="dashboard-empty-btn secondary"
+                onClick={() => navigate('/checks')}
+              >
+                + Add a monitor check
+              </button>
+            </div>
+          </div>
+        </div>
+      </>
+    )
+  }
+
+  // ── App name map for event rows ───────────────────────────────────────────
+  const appNameMap: Record<string, string> = {}
+  data.apps.forEach(a => {
+    appNameMap[a.id] = a.name
+  })
+
+  // ── Full dashboard ────────────────────────────────────────────────────────
   return (
     <>
       <Topbar
         title="Dashboard"
+        status={topbarStatus}
         timeFilter={timeFilter}
         onTimeFilter={setTimeFilter}
-        onAdd={() => {}}
+        onAdd={() => navigate('/apps')}
       />
       <div className="content">
-        {/* Summary bar, app widgets, infrastructure, events, checks — T-06+ */}
-        <div className="dashboard-empty">
-          <p className="dashboard-empty-text">No apps configured yet.</p>
-          <button className="dashboard-empty-btn" onClick={() => {}}>+ Add your first app</button>
+
+        {/* Summary Bar — only when there are digest categories */}
+        {data.summary_bar.length > 0 && (
+          <div className="summary-bar">
+            {data.summary_bar.map(item => (
+              <SummaryCard key={item.label} item={item} />
+            ))}
+          </div>
+        )}
+
+        {/* Two-column layout */}
+        <div className="two-col">
+
+          {/* ── LEFT COLUMN ── */}
+          <div className="col-left">
+
+            {/* Apps */}
+            <div>
+              <div className="section-header">
+                <div className="section-title">Apps</div>
+                <button className="section-action" onClick={() => navigate('/apps')}>
+                  <svg
+                    width="10"
+                    height="10"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <line x1="12" y1="5" x2="12" y2="19" />
+                    <line x1="5" y1="12" x2="19" y2="12" />
+                  </svg>
+                  Add app
+                </button>
+              </div>
+              <div className="widget-grid">
+                {data.apps.map(app => (
+                  <AppWidget
+                    key={app.id}
+                    app={app}
+                    onClick={() => navigate(`/apps/${app.id}`)}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Recent Events */}
+            {recentEvents.length > 0 && (
+              <div>
+                <div className="section-header">
+                  <div className="section-title">Recent Events</div>
+                  <button className="section-action" onClick={() => navigate('/events')}>
+                    View all →
+                  </button>
+                </div>
+                <div className="events-panel">
+                  {recentEvents.map(event => (
+                    <EventRow
+                      key={event.id}
+                      event={event}
+                      appName={appNameMap[event.app_id] ?? event.app_id}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+          </div>
+
+          {/* ── RIGHT COLUMN ── */}
+          <div className="col-right">
+
+            {/* Monitor Checks */}
+            {data.checks.length > 0 && (
+              <div>
+                <div className="section-header">
+                  <div className="section-title">Monitor Checks</div>
+                  <button className="section-action" onClick={() => navigate('/checks')}>
+                    <svg
+                      width="10"
+                      height="10"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
+                      <line x1="12" y1="5" x2="12" y2="19" />
+                      <line x1="5" y1="12" x2="19" y2="12" />
+                    </svg>
+                    Add check
+                  </button>
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                  {data.checks.map(check => (
+                    <MonitorWidget key={check.id} check={check} />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* SSL Certificates */}
+            {data.ssl_certs.length > 0 && (
+              <div>
+                <div className="section-header">
+                  <div className="section-title">SSL Certificates</div>
+                </div>
+                <div className="ssl-panel">
+                  {data.ssl_certs.map((cert, i) => (
+                    <SSLRow key={cert.domain || i} cert={cert} />
+                  ))}
+                </div>
+              </div>
+            )}
+
+          </div>
         </div>
       </div>
     </>


### PR DESCRIPTION
## What
Brings T-10 dashboard home screen work into main. These commits were merged into `feat/t09-dashboard-summary-api` via PR #47 but that branch was never itself merged to main.

## Why
Closes #10. PR #47 landed in the wrong base — this PR corrects the merge target.

## How
- 7 new frontend components: SummaryCard, AppWidget, MonitorWidget, SSLRow, EventRow, HostWidget, BookmarkWidget
- Dashboard.tsx rewritten: fetches /dashboard/summary and /events, skeleton loading, empty state
- Dashboard.css rewritten to match mockup spec
- types.ts updated with DashboardSummaryResponse and related types
- client.ts updated: dashboard.summary(period) accepts period param

## Closes
Closes #10