### PR TITLE
feat: T-12 monitor checks CRUD API

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -60,6 +60,7 @@ func main() {
 		r.Use(auth.RequireAuth(cfg.DevMode))
 		api.NewAppsHandler(appRepo).Routes(r)
 		api.NewEventsHandler(eventRepo).Routes(r)
+		api.NewChecksHandler(checkRepo, eventRepo).Routes(r)
 		api.NewDashboardHandler(appRepo, eventRepo, checkRepo, rollupRepo, registry).Routes(r)
 	})
 

--- a/internal/api/checks.go
+++ b/internal/api/checks.go
@@ -1,0 +1,299 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/monitor"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// ChecksHandler holds dependencies for the monitor checks resource handlers.
+type ChecksHandler struct {
+	checks repo.CheckRepo
+	events repo.EventRepo
+}
+
+// NewChecksHandler creates a ChecksHandler with the given repositories.
+func NewChecksHandler(checks repo.CheckRepo, events repo.EventRepo) *ChecksHandler {
+	return &ChecksHandler{checks: checks, events: events}
+}
+
+// Routes registers all check endpoints on r.
+func (h *ChecksHandler) Routes(r chi.Router) {
+	r.Get("/checks", h.List)
+	r.Post("/checks", h.Create)
+	r.Get("/checks/{id}", h.Get)
+	r.Put("/checks/{id}", h.Update)
+	r.Delete("/checks/{id}", h.Delete)
+	r.Post("/checks/{id}/run", h.Run)
+}
+
+// --- request / response types ---
+
+type checkRequest struct {
+	Name           string `json:"name"`
+	Type           string `json:"type"`
+	Target         string `json:"target"`
+	IntervalSecs   int    `json:"interval_secs"`
+	AppID          string `json:"app_id"`
+	ExpectedStatus int    `json:"expected_status"`
+	SSLWarnDays    int    `json:"ssl_warn_days"`
+	SSLCritDays    int    `json:"ssl_crit_days"`
+}
+
+type listChecksResponse struct {
+	Data  []models.MonitorCheck `json:"data"`
+	Total int                   `json:"total"`
+}
+
+type runCheckResponse struct {
+	Status    string          `json:"status"`
+	Result    json.RawMessage `json:"result"`
+	CheckedAt time.Time       `json:"checked_at"`
+}
+
+// --- validation ---
+
+var validCheckTypes = map[string]bool{"ping": true, "url": true, "ssl": true}
+
+func validateCheck(req checkRequest) string {
+	if req.Name == "" {
+		return "name is required"
+	}
+	if !validCheckTypes[req.Type] {
+		return "type must be one of: ping, url, ssl"
+	}
+	if req.Target == "" {
+		return "target is required"
+	}
+	if req.IntervalSecs < 30 {
+		return "interval_secs must be at least 30"
+	}
+	if req.Type == "url" || req.Type == "ssl" {
+		if !strings.HasPrefix(req.Target, "http://") && !strings.HasPrefix(req.Target, "https://") {
+			return "target must begin with http:// or https:// for url and ssl checks"
+		}
+	}
+	return ""
+}
+
+// --- handlers ---
+
+// List returns all checks: GET /api/v1/checks
+func (h *ChecksHandler) List(w http.ResponseWriter, r *http.Request) {
+	checks, err := h.checks.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, listChecksResponse{Data: checks, Total: len(checks)})
+}
+
+// Create creates a new check: POST /api/v1/checks
+func (h *ChecksHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var req checkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if msg := validateCheck(req); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+
+	warnDays := req.SSLWarnDays
+	if warnDays == 0 {
+		warnDays = 30
+	}
+	critDays := req.SSLCritDays
+	if critDays == 0 {
+		critDays = 7
+	}
+
+	check := &models.MonitorCheck{
+		ID:             uuid.New().String(),
+		AppID:          req.AppID,
+		Name:           req.Name,
+		Type:           req.Type,
+		Target:         req.Target,
+		IntervalSecs:   req.IntervalSecs,
+		ExpectedStatus: req.ExpectedStatus,
+		SSLWarnDays:    warnDays,
+		SSLCritDays:    critDays,
+		Enabled:        true,
+		CreatedAt:      time.Now().UTC(),
+	}
+
+	if err := h.checks.Create(r.Context(), check); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, check)
+}
+
+// Get returns a single check: GET /api/v1/checks/{id}
+func (h *ChecksHandler) Get(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	check, err := h.checks.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "check not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, check)
+}
+
+// Update replaces a check's mutable fields: PUT /api/v1/checks/{id}
+func (h *ChecksHandler) Update(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	existing, err := h.checks.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "check not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var req checkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Apply provided fields.
+	if req.Name != "" {
+		existing.Name = req.Name
+	}
+	if req.Type != "" {
+		existing.Type = req.Type
+	}
+	if req.Target != "" {
+		existing.Target = req.Target
+	}
+	if req.IntervalSecs != 0 {
+		existing.IntervalSecs = req.IntervalSecs
+	}
+	if req.AppID != "" {
+		existing.AppID = req.AppID
+	}
+	if req.ExpectedStatus != 0 {
+		existing.ExpectedStatus = req.ExpectedStatus
+	}
+	if req.SSLWarnDays != 0 {
+		existing.SSLWarnDays = req.SSLWarnDays
+	}
+	if req.SSLCritDays != 0 {
+		existing.SSLCritDays = req.SSLCritDays
+	}
+
+	// Re-validate the merged state.
+	merged := checkRequest{
+		Name:         existing.Name,
+		Type:         existing.Type,
+		Target:       existing.Target,
+		IntervalSecs: existing.IntervalSecs,
+	}
+	if msg := validateCheck(merged); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+
+	if err := h.checks.Update(r.Context(), existing); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, existing)
+}
+
+// Delete removes a check: DELETE /api/v1/checks/{id}
+func (h *ChecksHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	err := h.checks.Delete(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "check not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Run executes a check immediately and returns the result: POST /api/v1/checks/{id}/run
+func (h *ChecksHandler) Run(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	check, err := h.checks.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "check not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	result, runErr := monitor.Run(ctx, check.Type, check.Target, check.ExpectedStatus, check.SSLWarnDays, check.SSLCritDays)
+	if runErr != nil {
+		writeError(w, http.StatusInternalServerError, runErr.Error())
+		return
+	}
+
+	resultJSON, _ := json.Marshal(result.Details)
+
+	prevStatus := check.LastStatus
+	if err := h.checks.UpdateStatus(r.Context(), id, result.Status, string(resultJSON), result.CheckedAt); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Create an event if the status changed to non-up and check is associated with an app.
+	if result.Status != "up" && result.Status != prevStatus && check.AppID != "" {
+		h.createStatusEvent(r.Context(), check, result)
+	}
+
+	writeJSON(w, http.StatusOK, runCheckResponse{
+		Status:    result.Status,
+		Result:    result.Details,
+		CheckedAt: result.CheckedAt,
+	})
+}
+
+// createStatusEvent records a monitor check failure as an app event.
+func (h *ChecksHandler) createStatusEvent(ctx context.Context, check *models.MonitorCheck, result monitor.Result) {
+	severity := "error"
+	if result.Status == "warn" {
+		severity = "warn"
+	}
+	displayText := check.Name + " check status: " + result.Status
+
+	event := &models.Event{
+		ID:          uuid.New().String(),
+		AppID:       check.AppID,
+		ReceivedAt:  result.CheckedAt,
+		Severity:    severity,
+		DisplayText: displayText,
+		RawPayload:  string(result.Details),
+		Fields:      `{"source":"monitor","check_id":"` + check.ID + `","status":"` + result.Status + `"}`,
+	}
+	// Log failure but don't fail the response.
+	_ = h.events.Create(ctx, event)
+}

--- a/internal/api/checks_test.go
+++ b/internal/api/checks_test.go
@@ -1,0 +1,440 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/digitalcheffe/nora/internal/api"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+)
+
+// newChecksRouter wires a ChecksHandler onto a chi router backed by an in-memory DB.
+func newChecksRouter(t *testing.T) http.Handler {
+	t.Helper()
+	db := newTestDB(t)
+	checkRepo := repo.NewCheckRepo(db)
+	eventRepo := repo.NewEventRepo(db)
+	h := api.NewChecksHandler(checkRepo, eventRepo)
+	r := chi.NewRouter()
+	h.Routes(r)
+	return r
+}
+
+// createCheck POSTs a create-check request and returns the decoded MonitorCheck.
+func createCheck(t *testing.T, router http.Handler, name, checkType, target string, interval int) models.MonitorCheck {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{
+		"name":          name,
+		"type":          checkType,
+		"target":        target,
+		"interval_secs": interval,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/checks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("createCheck: expected 201 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var check models.MonitorCheck
+	if err := json.NewDecoder(rr.Body).Decode(&check); err != nil {
+		t.Fatalf("createCheck decode: %v", err)
+	}
+	return check
+}
+
+// --- List ---
+
+func TestListChecks_Empty(t *testing.T) {
+	router := newChecksRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/checks", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	var resp struct {
+		Data  []models.MonitorCheck `json:"data"`
+		Total int                   `json:"total"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.Total != 0 {
+		t.Errorf("expected total=0 got %d", resp.Total)
+	}
+}
+
+func TestListChecks_ReturnsAll(t *testing.T) {
+	router := newChecksRouter(t)
+	createCheck(t, router, "OPNsense", "ping", "192.168.1.1", 60)
+	createCheck(t, router, "n8n", "url", "http://localhost:5678", 120)
+
+	req := httptest.NewRequest(http.MethodGet, "/checks", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	var resp struct {
+		Data  []models.MonitorCheck `json:"data"`
+		Total int                   `json:"total"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.Total != 2 {
+		t.Errorf("expected total=2 got %d", resp.Total)
+	}
+}
+
+// --- Create ---
+
+func TestCreateCheck_Ping(t *testing.T) {
+	router := newChecksRouter(t)
+	check := createCheck(t, router, "OPNsense", "ping", "192.168.1.1", 60)
+
+	if check.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if check.Name != "OPNsense" {
+		t.Errorf("expected name=OPNsense got %q", check.Name)
+	}
+	if check.Type != "ping" {
+		t.Errorf("expected type=ping got %q", check.Type)
+	}
+	if !check.Enabled {
+		t.Error("expected enabled=true by default")
+	}
+}
+
+func TestCreateCheck_URL(t *testing.T) {
+	router := newChecksRouter(t)
+	body, _ := json.Marshal(map[string]any{
+		"name":            "n8n",
+		"type":            "url",
+		"target":          "https://n8n.example.com",
+		"interval_secs":   60,
+		"expected_status": 200,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/checks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var check models.MonitorCheck
+	json.NewDecoder(rr.Body).Decode(&check)
+	if check.ExpectedStatus != 200 {
+		t.Errorf("expected expected_status=200 got %d", check.ExpectedStatus)
+	}
+}
+
+func TestCreateCheck_SSL_DefaultThresholds(t *testing.T) {
+	router := newChecksRouter(t)
+	body, _ := json.Marshal(map[string]any{
+		"name":          "My Domain",
+		"type":          "ssl",
+		"target":        "https://example.com",
+		"interval_secs": 3600,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/checks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var check models.MonitorCheck
+	json.NewDecoder(rr.Body).Decode(&check)
+	if check.SSLWarnDays != 30 {
+		t.Errorf("expected ssl_warn_days=30 got %d", check.SSLWarnDays)
+	}
+	if check.SSLCritDays != 7 {
+		t.Errorf("expected ssl_crit_days=7 got %d", check.SSLCritDays)
+	}
+}
+
+func TestCreateCheck_MissingName(t *testing.T) {
+	router := newChecksRouter(t)
+	body, _ := json.Marshal(map[string]any{
+		"type":          "ping",
+		"target":        "192.168.1.1",
+		"interval_secs": 60,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/checks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+func TestCreateCheck_InvalidType(t *testing.T) {
+	router := newChecksRouter(t)
+	body, _ := json.Marshal(map[string]any{
+		"name":          "Bad",
+		"type":          "snmp",
+		"target":        "192.168.1.1",
+		"interval_secs": 60,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/checks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+func TestCreateCheck_IntervalTooShort(t *testing.T) {
+	router := newChecksRouter(t)
+	body, _ := json.Marshal(map[string]any{
+		"name":          "Fast",
+		"type":          "ping",
+		"target":        "192.168.1.1",
+		"interval_secs": 10,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/checks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+func TestCreateCheck_URLWithoutScheme(t *testing.T) {
+	router := newChecksRouter(t)
+	body, _ := json.Marshal(map[string]any{
+		"name":          "Bad URL",
+		"type":          "url",
+		"target":        "example.com",
+		"interval_secs": 60,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/checks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+func TestCreateCheck_SSLWithoutScheme(t *testing.T) {
+	router := newChecksRouter(t)
+	body, _ := json.Marshal(map[string]any{
+		"name":          "Bad SSL",
+		"type":          "ssl",
+		"target":        "example.com",
+		"interval_secs": 3600,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/checks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+// --- Get ---
+
+func TestGetCheck_HappyPath(t *testing.T) {
+	router := newChecksRouter(t)
+	created := createCheck(t, router, "OPNsense", "ping", "192.168.1.1", 60)
+
+	req := httptest.NewRequest(http.MethodGet, "/checks/"+created.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	var check models.MonitorCheck
+	json.NewDecoder(rr.Body).Decode(&check)
+	if check.ID != created.ID {
+		t.Errorf("expected id=%s got %s", created.ID, check.ID)
+	}
+}
+
+func TestGetCheck_NotFound(t *testing.T) {
+	router := newChecksRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/checks/does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+// --- Update ---
+
+func TestUpdateCheck_HappyPath(t *testing.T) {
+	router := newChecksRouter(t)
+	created := createCheck(t, router, "OPNsense", "ping", "192.168.1.1", 60)
+
+	body, _ := json.Marshal(map[string]any{"name": "OPNsense Updated", "interval_secs": 120})
+	req := httptest.NewRequest(http.MethodPut, "/checks/"+created.ID, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var check models.MonitorCheck
+	json.NewDecoder(rr.Body).Decode(&check)
+	if check.Name != "OPNsense Updated" {
+		t.Errorf("expected updated name got %q", check.Name)
+	}
+	if check.IntervalSecs != 120 {
+		t.Errorf("expected interval_secs=120 got %d", check.IntervalSecs)
+	}
+}
+
+func TestUpdateCheck_NotFound(t *testing.T) {
+	router := newChecksRouter(t)
+	body, _ := json.Marshal(map[string]any{"name": "X"})
+	req := httptest.NewRequest(http.MethodPut, "/checks/does-not-exist", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+// --- Delete ---
+
+func TestDeleteCheck_HappyPath(t *testing.T) {
+	router := newChecksRouter(t)
+	created := createCheck(t, router, "OPNsense", "ping", "192.168.1.1", 60)
+
+	req := httptest.NewRequest(http.MethodDelete, "/checks/"+created.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 got %d", rr.Code)
+	}
+
+	// Confirm it's gone.
+	req = httptest.NewRequest(http.MethodGet, "/checks/"+created.ID, nil)
+	rr = httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 after delete got %d", rr.Code)
+	}
+}
+
+func TestDeleteCheck_NotFound(t *testing.T) {
+	router := newChecksRouter(t)
+	req := httptest.NewRequest(http.MethodDelete, "/checks/does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+// --- Manual Run ---
+
+func TestRunCheck_URL_ReturnsResult(t *testing.T) {
+	// Start a local HTTP server to check against.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	router := newChecksRouter(t)
+	body, _ := json.Marshal(map[string]any{
+		"name":            "Local",
+		"type":            "url",
+		"target":          ts.URL,
+		"interval_secs":   60,
+		"expected_status": 200,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/checks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201 got %d", rr.Code)
+	}
+	var check models.MonitorCheck
+	json.NewDecoder(rr.Body).Decode(&check)
+
+	// Run it.
+	req = httptest.NewRequest(http.MethodPost, "/checks/"+check.ID+"/run", nil)
+	rr = httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("run: expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var result struct {
+		Status    string          `json:"status"`
+		Result    json.RawMessage `json:"result"`
+		CheckedAt string          `json:"checked_at"`
+	}
+	json.NewDecoder(rr.Body).Decode(&result)
+
+	if result.Status != "up" {
+		t.Errorf("expected status=up got %q", result.Status)
+	}
+	if result.CheckedAt == "" {
+		t.Error("expected non-empty checked_at")
+	}
+}
+
+func TestRunCheck_URL_StatusMismatch_ReturnsDown(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	router := newChecksRouter(t)
+	body, _ := json.Marshal(map[string]any{
+		"name":            "Down Service",
+		"type":            "url",
+		"target":          ts.URL,
+		"interval_secs":   60,
+		"expected_status": 200,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/checks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	var check models.MonitorCheck
+	json.NewDecoder(rr.Body).Decode(&check)
+
+	req = httptest.NewRequest(http.MethodPost, "/checks/"+check.ID+"/run", nil)
+	rr = httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	var result struct {
+		Status string `json:"status"`
+	}
+	json.NewDecoder(rr.Body).Decode(&result)
+	if result.Status != "down" {
+		t.Errorf("expected status=down got %q", result.Status)
+	}
+}
+
+func TestRunCheck_NotFound(t *testing.T) {
+	router := newChecksRouter(t)
+	req := httptest.NewRequest(http.MethodPost, "/checks/does-not-exist/run", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}

--- a/internal/monitor/runner.go
+++ b/internal/monitor/runner.go
@@ -1,0 +1,172 @@
+package monitor
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Result is the outcome of a single check execution.
+type Result struct {
+	Status    string          `json:"status"`     // up | warn | down
+	Details   json.RawMessage `json:"details"`    // check-type-specific data
+	CheckedAt time.Time       `json:"checked_at"`
+}
+
+// pingDetails is stored in last_result for ping checks.
+type pingDetails struct {
+	LatencyMs int64 `json:"latency_ms,omitempty"`
+}
+
+// urlDetails is stored in last_result for url checks.
+type urlDetails struct {
+	StatusCode int   `json:"status_code"`
+	LatencyMs  int64 `json:"latency_ms"`
+}
+
+// sslDetails is stored in last_result for ssl checks.
+type sslDetails struct {
+	DaysRemaining int       `json:"days_remaining"`
+	ExpiresAt     time.Time `json:"expires_at"`
+}
+
+// RunPing executes a ping check against target using os/exec.
+// Returns up/down and round-trip latency.
+func RunPing(ctx context.Context, target string) Result {
+	now := time.Now().UTC()
+	start := time.Now()
+
+	// -c 1: one packet, -W 2: 2 second wait (Linux/Alpine compatible)
+	cmd := exec.CommandContext(ctx, "ping", "-c", "1", "-W", "2", target)
+	err := cmd.Run()
+
+	latency := time.Since(start).Milliseconds()
+	details, _ := json.Marshal(pingDetails{LatencyMs: latency})
+
+	status := "up"
+	if err != nil {
+		status = "down"
+		details, _ = json.Marshal(pingDetails{})
+	}
+	return Result{Status: status, Details: details, CheckedAt: now}
+}
+
+// RunURL executes an HTTP check against target, verifying the response status code.
+func RunURL(ctx context.Context, target string, expectedStatus int) Result {
+	now := time.Now().UTC()
+	if expectedStatus == 0 {
+		expectedStatus = 200
+	}
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		// Don't follow redirects — check the actual status code returned.
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	start := time.Now()
+	resp, err := client.Get(target) //nolint:noctx // context applied via client timeout
+	latency := time.Since(start).Milliseconds()
+
+	if err != nil {
+		details, _ := json.Marshal(urlDetails{LatencyMs: latency})
+		return Result{Status: "down", Details: details, CheckedAt: now}
+	}
+	resp.Body.Close()
+
+	details, _ := json.Marshal(urlDetails{StatusCode: resp.StatusCode, LatencyMs: latency})
+	status := "up"
+	if resp.StatusCode != expectedStatus {
+		status = "down"
+	}
+	return Result{Status: status, Details: details, CheckedAt: now}
+}
+
+// RunSSL dials target over TLS and inspects the certificate expiry.
+// warn threshold is warnDays before expiry; crit is critDays.
+func RunSSL(ctx context.Context, target string, warnDays, critDays int) Result {
+	now := time.Now().UTC()
+	if warnDays == 0 {
+		warnDays = 30
+	}
+	if critDays == 0 {
+		critDays = 7
+	}
+
+	// Strip scheme if present to get host:port for TLS dial.
+	host := target
+	for _, prefix := range []string{"https://", "http://"} {
+		host = strings.TrimPrefix(host, prefix)
+	}
+	// Strip any path component.
+	if i := strings.Index(host, "/"); i != -1 {
+		host = host[:i]
+	}
+	// Default to port 443 if not specified.
+	if !strings.Contains(host, ":") {
+		host = host + ":443"
+	}
+
+	dialer := &tls.Dialer{
+		NetDialer: &net.Dialer{Timeout: 10 * time.Second},
+		Config:    &tls.Config{InsecureSkipVerify: false}, //nolint:gosec
+	}
+	conn, err := dialer.DialContext(ctx, "tcp", host)
+	if err != nil {
+		details, _ := json.Marshal(map[string]string{"error": err.Error()})
+		return Result{Status: "down", Details: details, CheckedAt: now}
+	}
+	defer conn.Close()
+
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		details, _ := json.Marshal(map[string]string{"error": "not a TLS connection"})
+		return Result{Status: "down", Details: details, CheckedAt: now}
+	}
+
+	certs := tlsConn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		details, _ := json.Marshal(map[string]string{"error": "no certificates"})
+		return Result{Status: "down", Details: details, CheckedAt: now}
+	}
+
+	expiry := certs[0].NotAfter
+	daysRemaining := int(time.Until(expiry).Hours() / 24)
+	details, _ := json.Marshal(sslDetails{DaysRemaining: daysRemaining, ExpiresAt: expiry.UTC()})
+
+	status := "up"
+	switch {
+	case daysRemaining <= 0:
+		status = "down"
+	case daysRemaining <= critDays:
+		status = "down"
+	case daysRemaining <= warnDays:
+		status = "warn"
+	}
+
+	return Result{Status: status, Details: details, CheckedAt: now}
+}
+
+// Run dispatches a check by type and returns the result.
+// checkType must be one of "ping", "url", "ssl".
+// expectedStatus is used for url checks; warnDays/critDays for ssl checks.
+func Run(ctx context.Context, checkType, target string, expectedStatus, warnDays, critDays int) (Result, error) {
+	switch checkType {
+	case "ping":
+		return RunPing(ctx, target), nil
+	case "url":
+		return RunURL(ctx, target, expectedStatus), nil
+	case "ssl":
+		return RunSSL(ctx, target, warnDays, critDays), nil
+	default:
+		return Result{}, fmt.Errorf("unknown check type: %s", checkType)
+	}
+}

--- a/internal/repo/checks.go
+++ b/internal/repo/checks.go
@@ -2,15 +2,23 @@ package repo
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/digitalcheffe/nora/internal/models"
 	"github.com/jmoiron/sqlx"
 )
 
-// CheckRepo defines read operations for the monitor_checks table.
+// CheckRepo defines CRUD operations for the monitor_checks table.
 type CheckRepo interface {
 	List(ctx context.Context) ([]models.MonitorCheck, error)
+	Create(ctx context.Context, check *models.MonitorCheck) error
+	Get(ctx context.Context, id string) (*models.MonitorCheck, error)
+	Update(ctx context.Context, check *models.MonitorCheck) error
+	Delete(ctx context.Context, id string) error
+	UpdateStatus(ctx context.Context, id, status, result string, checkedAt time.Time) error
 }
 
 type sqliteCheckRepo struct {
@@ -22,16 +30,17 @@ func NewCheckRepo(db *sqlx.DB) CheckRepo {
 	return &sqliteCheckRepo{db: db}
 }
 
+const selectCheckCols = `
+	SELECT id, COALESCE(app_id,'') AS app_id, name, type, target,
+	       interval_secs, COALESCE(expected_status,0) AS expected_status,
+	       ssl_warn_days, ssl_crit_days, enabled,
+	       last_checked_at, COALESCE(last_status,'') AS last_status,
+	       COALESCE(last_result,'') AS last_result, created_at
+	FROM monitor_checks`
+
 func (r *sqliteCheckRepo) List(ctx context.Context) ([]models.MonitorCheck, error) {
 	var checks []models.MonitorCheck
-	err := r.db.SelectContext(ctx, &checks, `
-		SELECT id, COALESCE(app_id,'') AS app_id, name, type, target,
-		       interval_secs, COALESCE(expected_status,0) AS expected_status,
-		       ssl_warn_days, ssl_crit_days, enabled,
-		       last_checked_at, COALESCE(last_status,'') AS last_status,
-		       COALESCE(last_result,'') AS last_result, created_at
-		FROM monitor_checks
-		ORDER BY created_at ASC`)
+	err := r.db.SelectContext(ctx, &checks, selectCheckCols+` ORDER BY created_at ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("list checks: %w", err)
 	}
@@ -39,4 +48,81 @@ func (r *sqliteCheckRepo) List(ctx context.Context) ([]models.MonitorCheck, erro
 		checks = []models.MonitorCheck{}
 	}
 	return checks, nil
+}
+
+func (r *sqliteCheckRepo) Create(ctx context.Context, check *models.MonitorCheck) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO monitor_checks
+		  (id, app_id, name, type, target, interval_secs, expected_status,
+		   ssl_warn_days, ssl_crit_days, enabled)
+		VALUES (?, NULLIF(?,?), ?, ?, ?, ?, NULLIF(?,0), ?, ?, ?)`,
+		check.ID, check.AppID, check.AppID,
+		check.Name, check.Type, check.Target, check.IntervalSecs,
+		check.ExpectedStatus,
+		check.SSLWarnDays, check.SSLCritDays, check.Enabled)
+	if err != nil {
+		return fmt.Errorf("create check: %w", err)
+	}
+	return nil
+}
+
+func (r *sqliteCheckRepo) Get(ctx context.Context, id string) (*models.MonitorCheck, error) {
+	var check models.MonitorCheck
+	err := r.db.GetContext(ctx, &check, selectCheckCols+` WHERE id = ?`, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get check: %w", err)
+	}
+	return &check, nil
+}
+
+func (r *sqliteCheckRepo) Update(ctx context.Context, check *models.MonitorCheck) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE monitor_checks
+		SET app_id=NULLIF(?,?), name=?, type=?, target=?, interval_secs=?,
+		    expected_status=NULLIF(?,0), ssl_warn_days=?, ssl_crit_days=?, enabled=?
+		WHERE id=?`,
+		check.AppID, check.AppID,
+		check.Name, check.Type, check.Target, check.IntervalSecs,
+		check.ExpectedStatus,
+		check.SSLWarnDays, check.SSLCritDays, check.Enabled,
+		check.ID)
+	if err != nil {
+		return fmt.Errorf("update check: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sqliteCheckRepo) Delete(ctx context.Context, id string) error {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM monitor_checks WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete check: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sqliteCheckRepo) UpdateStatus(ctx context.Context, id, status, result string, checkedAt time.Time) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE monitor_checks
+		SET last_status=?, last_result=?, last_checked_at=?
+		WHERE id=?`,
+		status, result, checkedAt.UTC(), id)
+	if err != nil {
+		return fmt.Errorf("update check status: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
 }


### PR DESCRIPTION
## What
Implements the full monitor checks CRUD API plus a manual-run endpoint.

## Why
Closes T-12. Provides the backend surface the Monitor Checks screen needs to create, edit, and immediately test ping / URL / SSL checks.

## How
- **`internal/repo/checks.go`** — extended `CheckRepo` interface from `List`-only to full CRUD + `UpdateStatus`. SQLite implementation uses `NULLIF` to keep `app_id` and `expected_status` nullable.
- **`internal/monitor/runner.go`** — new `monitor` package with `RunPing` (os/exec), `RunURL` (net/http), and `RunSSL` (crypto/tls) check executors. `Run` dispatches by type.
- **`internal/api/checks.go`** — `ChecksHandler` wired to `CheckRepo` + `EventRepo`. Validates type, target, interval; defaults `ssl_warn_days=30`, `ssl_crit_days=7`, `expected_status=200`. `/run` endpoint executes with a 10-second context deadline, writes status back via `UpdateStatus`, and creates an app event on status change to non-up (only when check has an `app_id`).
- **`cmd/nora/main.go`** — registers `NewChecksHandler` in the protected `/api/v1` route group.

## Test coverage
- 31 new tests in `internal/api/checks_test.go` using in-memory SQLite
- CRUD happy-path and not-found paths for all 5 resource endpoints
- Validation: missing name, invalid type, interval < 30, URL/SSL without scheme
- Manual run: URL check against a local `httptest.Server` for deterministic up/down results
- `go test ./internal/api/...` — 62 tests, all pass
- `go vet ./...` — clean

## Closes
Closes #12