### PR TITLE
feat: T-13 ping check runner and monitor scheduler

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"log"
@@ -11,6 +12,7 @@ import (
 	"github.com/digitalcheffe/nora/internal/config"
 	"github.com/digitalcheffe/nora/internal/frontend"
 	"github.com/digitalcheffe/nora/internal/ingest"
+	"github.com/digitalcheffe/nora/internal/monitor"
 	"github.com/digitalcheffe/nora/internal/profile"
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/digitalcheffe/nora/migrations"
@@ -45,6 +47,11 @@ func main() {
 	log.Printf("loaded %d profiles", len(registry.List()))
 
 	limiter := ingest.NewRateLimiter()
+
+	// Monitor scheduler — runs all enabled checks on their configured intervals.
+	schedCtx, schedCancel := context.WithCancel(context.Background())
+	defer schedCancel()
+	go monitor.NewScheduler(store).Start(schedCtx)
 
 	// Router
 	r := chi.NewRouter()

--- a/internal/monitor/ping.go
+++ b/internal/monitor/ping.go
@@ -1,0 +1,108 @@
+package monitor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+// PingChecker executes ping health checks and persists results via the store.
+//
+// Implementation note: we use os/exec to invoke the system ping binary rather
+// than raw ICMP sockets. Raw ICMP requires CAP_NET_RAW (root or a specific
+// capability), which is not available in unprivileged containers. The trade-off
+// is a dependency on the ping binary being present in the image — Alpine
+// provides it via busybox. If ICMP is unavailable, consider using a TCP
+// connect approach instead (e.g. net.DialTimeout to port 80/443).
+type PingChecker struct {
+	store  *repo.Store
+	pinger func(ctx context.Context, target string) Result // injectable for tests
+}
+
+// NewPingChecker returns a PingChecker backed by store.
+func NewPingChecker(store *repo.Store) *PingChecker {
+	return &PingChecker{store: store, pinger: RunPing}
+}
+
+// Run executes a ping health check for the given MonitorCheck.
+//
+// It sends up to 3 pings with a 5-second timeout each. The check is considered
+// down only if all 3 pings fail, reducing false positives from transient packet
+// loss. On a status transition (up→down or down→up), an event is created —
+// but only when the check is associated with an app, because the events table
+// requires a valid app_id foreign key.
+func (p *PingChecker) Run(ctx context.Context, check *models.MonitorCheck) error {
+	const attempts = 3
+
+	downCount := 0
+	var latencyMs int64
+
+	for i := 0; i < attempts; i++ {
+		pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		result := p.pinger(pingCtx, check.Target)
+		cancel()
+
+		if result.Status == "down" {
+			downCount++
+		} else {
+			var d pingDetails
+			_ = json.Unmarshal(result.Details, &d)
+			latencyMs = d.LatencyMs
+		}
+	}
+
+	now := time.Now().UTC()
+
+	newStatus := "up"
+	var detailsBytes []byte
+	if downCount == attempts {
+		newStatus = "down"
+		detailsBytes, _ = json.Marshal(pingDetails{})
+	} else {
+		detailsBytes, _ = json.Marshal(pingDetails{LatencyMs: latencyMs})
+	}
+
+	// Emit a status-change event when there is a known previous state and the
+	// check is linked to an app. Checks without an app_id are tracked in
+	// last_status only — the events table requires a valid app_id reference.
+	prevStatus := check.LastStatus
+	if prevStatus != "" && prevStatus != newStatus && check.AppID != "" {
+		if err := p.createStatusEvent(ctx, check, newStatus, now); err != nil {
+			log.Printf("ping checker: create event for check %s: %v", check.ID, err)
+		}
+	}
+
+	if err := p.store.Checks.UpdateStatus(ctx, check.ID, newStatus, string(detailsBytes), now); err != nil {
+		return fmt.Errorf("ping checker: update status for %s: %w", check.ID, err)
+	}
+	return nil
+}
+
+// createStatusEvent persists a down or recovery event for a check.
+func (p *PingChecker) createStatusEvent(ctx context.Context, check *models.MonitorCheck, newStatus string, now time.Time) error {
+	var severity, displayText string
+	if newStatus == "down" {
+		severity = "error"
+		displayText = fmt.Sprintf("Ping failed — %s (%s)", check.Name, check.Target)
+	} else {
+		severity = "info"
+		displayText = fmt.Sprintf("Ping restored — %s (%s)", check.Name, check.Target)
+	}
+
+	event := &models.Event{
+		ID:          uuid.New().String(),
+		AppID:       check.AppID,
+		ReceivedAt:  now,
+		Severity:    severity,
+		DisplayText: displayText,
+		RawPayload:  "{}",
+		Fields:      `{"source":"monitor","check_id":"` + check.ID + `","type":"ping"}`,
+	}
+	return p.store.Events.Create(ctx, event)
+}

--- a/internal/monitor/ping_test.go
+++ b/internal/monitor/ping_test.go
@@ -1,0 +1,187 @@
+package monitor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// --- mock repos ---
+
+type mockCheckRepo struct {
+	repo.CheckRepo
+	updateStatusCalls []updateStatusCall
+	updateErr         error
+}
+
+type updateStatusCall struct {
+	id     string
+	status string
+}
+
+func (m *mockCheckRepo) UpdateStatus(_ context.Context, id, status, _ string, _ time.Time) error {
+	m.updateStatusCalls = append(m.updateStatusCalls, updateStatusCall{id: id, status: status})
+	return m.updateErr
+}
+
+type mockEventRepo struct {
+	repo.EventRepo
+	created  []*models.Event
+	createErr error
+}
+
+func (m *mockEventRepo) Create(_ context.Context, event *models.Event) error {
+	m.created = append(m.created, event)
+	return m.createErr
+}
+
+func newTestStore(checks *mockCheckRepo, events *mockEventRepo) *repo.Store {
+	return &repo.Store{Checks: checks, Events: events}
+}
+
+// --- helpers ---
+
+func alwaysUp(_ context.Context, _ string) Result {
+	return Result{Status: "up", Details: []byte(`{"latency_ms":10}`), CheckedAt: time.Now()}
+}
+
+func alwaysDown(_ context.Context, _ string) Result {
+	return Result{Status: "down", Details: []byte(`{}`), CheckedAt: time.Now()}
+}
+
+func makeCheck(lastStatus, appID string) *models.MonitorCheck {
+	return &models.MonitorCheck{
+		ID:         "check-1",
+		AppID:      appID,
+		Name:       "My Host",
+		Type:       "ping",
+		Target:     "192.168.1.1",
+		LastStatus: lastStatus,
+	}
+}
+
+// --- tests ---
+
+// TestPingChecker_HappyPath verifies that a successful ping marks the check "up".
+func TestPingChecker_HappyPath(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := &PingChecker{store: newTestStore(checks, events), pinger: alwaysUp}
+
+	check := makeCheck("up", "")
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(checks.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 UpdateStatus call, got %d", len(checks.updateStatusCalls))
+	}
+	if checks.updateStatusCalls[0].status != "up" {
+		t.Errorf("expected status=up, got %s", checks.updateStatusCalls[0].status)
+	}
+	if len(events.created) != 0 {
+		t.Errorf("expected no events, got %d", len(events.created))
+	}
+}
+
+// TestPingChecker_AllFailsDown verifies that 3/3 ping failures mark the check "down".
+func TestPingChecker_AllFailsDown(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := &PingChecker{store: newTestStore(checks, events), pinger: alwaysDown}
+
+	check := makeCheck("up", "app-1") // previous status "up" so we get a state change
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(checks.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 UpdateStatus call, got %d", len(checks.updateStatusCalls))
+	}
+	if checks.updateStatusCalls[0].status != "down" {
+		t.Errorf("expected status=down, got %s", checks.updateStatusCalls[0].status)
+	}
+
+	// An error event should have been created because status changed up→down.
+	if len(events.created) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events.created))
+	}
+	ev := events.created[0]
+	if ev.Severity != "error" {
+		t.Errorf("expected severity=error, got %s", ev.Severity)
+	}
+	if ev.AppID != "app-1" {
+		t.Errorf("expected app_id=app-1, got %s", ev.AppID)
+	}
+}
+
+// TestPingChecker_Recovery verifies that a down→up transition creates an info event.
+func TestPingChecker_Recovery(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := &PingChecker{store: newTestStore(checks, events), pinger: alwaysUp}
+
+	check := makeCheck("down", "app-1") // was down, now pings succeed
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(events.created) != 1 {
+		t.Fatalf("expected 1 recovery event, got %d", len(events.created))
+	}
+	ev := events.created[0]
+	if ev.Severity != "info" {
+		t.Errorf("expected severity=info, got %s", ev.Severity)
+	}
+}
+
+// TestPingChecker_NoEventWithoutApp verifies that no event is created for checks
+// not linked to an app (the events table requires a valid app_id).
+func TestPingChecker_NoEventWithoutApp(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := &PingChecker{store: newTestStore(checks, events), pinger: alwaysDown}
+
+	check := makeCheck("up", "") // AppID is empty
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(events.created) != 0 {
+		t.Errorf("expected no events for check without app, got %d", len(events.created))
+	}
+}
+
+// TestPingChecker_NoEventOnFirstRun verifies that the first execution of a
+// check (LastStatus == "") does not emit an event even if the result is down.
+func TestPingChecker_NoEventOnFirstRun(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := &PingChecker{store: newTestStore(checks, events), pinger: alwaysDown}
+
+	check := makeCheck("", "app-1") // no previous status
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(events.created) != 0 {
+		t.Errorf("expected no event on first run, got %d", len(events.created))
+	}
+}
+
+// TestPingChecker_UpdateStatusError verifies that an UpdateStatus failure is
+// surfaced as an error return.
+func TestPingChecker_UpdateStatusError(t *testing.T) {
+	checks := &mockCheckRepo{updateErr: errors.New("db error")}
+	events := &mockEventRepo{}
+	checker := &PingChecker{store: newTestStore(checks, events), pinger: alwaysUp}
+
+	check := makeCheck("up", "")
+	if err := checker.Run(context.Background(), check); err == nil {
+		t.Fatal("expected error from UpdateStatus, got nil")
+	}
+}

--- a/internal/monitor/scheduler.go
+++ b/internal/monitor/scheduler.go
@@ -1,0 +1,165 @@
+package monitor
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// URLChecker is a stub for the URL check runner, implemented in T-14.
+type URLChecker struct{ store *repo.Store }
+
+// SSLChecker is a stub for the SSL check runner, implemented in T-15.
+type SSLChecker struct{ store *repo.Store }
+
+// Scheduler loads monitor checks from the database and runs each one on its
+// configured interval. Every check runs in its own goroutine, so a slow or
+// blocked check cannot delay others. The check list is refreshed every 5
+// minutes to pick up newly added or disabled checks without a restart.
+type Scheduler struct {
+	store *repo.Store
+	ping  *PingChecker
+	url   *URLChecker
+	ssl   *SSLChecker
+
+	mu     sync.Mutex
+	active map[string]context.CancelFunc // check ID → cancel for that goroutine
+}
+
+// NewScheduler returns a Scheduler wired to store.
+func NewScheduler(store *repo.Store) *Scheduler {
+	return &Scheduler{
+		store:  store,
+		ping:   NewPingChecker(store),
+		url:    &URLChecker{store: store},
+		ssl:    &SSLChecker{store: store},
+		active: make(map[string]context.CancelFunc),
+	}
+}
+
+// Start performs an initial sync then loops, re-syncing every 5 minutes.
+// It blocks until ctx is cancelled, at which point all check goroutines are
+// stopped before Start returns.
+func (s *Scheduler) Start(ctx context.Context) {
+	log.Printf("monitor scheduler: starting")
+
+	if err := s.syncChecks(ctx); err != nil {
+		log.Printf("monitor scheduler: initial load: %v", err)
+	}
+
+	reloadTicker := time.NewTicker(5 * time.Minute)
+	defer reloadTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("monitor scheduler: context cancelled — shutting down")
+			s.cancelAll()
+			return
+		case <-reloadTicker.C:
+			if err := s.syncChecks(ctx); err != nil {
+				log.Printf("monitor scheduler: reload: %v", err)
+			}
+		}
+	}
+}
+
+// syncChecks reconciles the set of running goroutines against the current
+// database state. New enabled checks are started; goroutines for checks that
+// have been disabled or deleted are cancelled.
+func (s *Scheduler) syncChecks(ctx context.Context) error {
+	checks, err := s.store.Checks.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Build the set of currently-enabled check IDs.
+	enabled := make(map[string]struct{}, len(checks))
+	for i := range checks {
+		c := &checks[i]
+		if !c.Enabled {
+			continue
+		}
+		enabled[c.ID] = struct{}{}
+
+		if _, running := s.active[c.ID]; running {
+			continue // already running — do not restart
+		}
+
+		checkCtx, cancel := context.WithCancel(ctx)
+		s.active[c.ID] = cancel
+		go s.runCheckLoop(checkCtx, c)
+	}
+
+	// Cancel goroutines for checks that are no longer enabled or have been deleted.
+	for id, cancel := range s.active {
+		if _, ok := enabled[id]; !ok {
+			cancel()
+			delete(s.active, id)
+		}
+	}
+
+	log.Printf("monitor scheduler: %d checks active", len(s.active))
+	return nil
+}
+
+// cancelAll cancels every running check goroutine and clears the active map.
+func (s *Scheduler) cancelAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, cancel := range s.active {
+		cancel()
+		delete(s.active, id)
+	}
+}
+
+// runCheckLoop ticks at check.IntervalSecs and dispatches to the appropriate
+// checker on every tick. The loop exits when ctx is cancelled.
+func (s *Scheduler) runCheckLoop(ctx context.Context, check *models.MonitorCheck) {
+	interval := time.Duration(check.IntervalSecs) * time.Second
+	if interval < 30*time.Second {
+		interval = 30 * time.Second
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	log.Printf("monitor scheduler: started %s check %q target=%s interval=%s",
+		check.Type, check.Name, check.Target, interval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.dispatch(ctx, check)
+		}
+	}
+}
+
+// dispatch runs the appropriate checker for one cycle of check.
+func (s *Scheduler) dispatch(ctx context.Context, check *models.MonitorCheck) {
+	var err error
+	switch check.Type {
+	case "ping":
+		err = s.ping.Run(ctx, check)
+	case "url":
+		// T-14: URL checker not yet implemented.
+		log.Printf("monitor scheduler: url check %q skipped — url checker not yet implemented (T-14)", check.Name)
+	case "ssl":
+		// T-15: SSL checker not yet implemented.
+		log.Printf("monitor scheduler: ssl check %q skipped — ssl checker not yet implemented (T-15)", check.Name)
+	default:
+		log.Printf("monitor scheduler: unknown check type %q for check %q", check.Type, check.Name)
+	}
+	if err != nil {
+		log.Printf("monitor scheduler: check %q (%s) failed: %v", check.Name, check.Type, err)
+	}
+}

--- a/internal/monitor/scheduler_test.go
+++ b/internal/monitor/scheduler_test.go
@@ -1,0 +1,123 @@
+package monitor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// mockListCheckRepo is a CheckRepo that returns a fixed list from List.
+type mockListCheckRepo struct {
+	repo.CheckRepo
+	checks []models.MonitorCheck
+}
+
+func (m *mockListCheckRepo) List(_ context.Context) ([]models.MonitorCheck, error) {
+	return m.checks, nil
+}
+
+func (m *mockListCheckRepo) UpdateStatus(_ context.Context, _, _, _ string, _ time.Time) error {
+	return nil
+}
+
+// TestScheduler_StartStop verifies that the scheduler starts cleanly with an
+// empty check list and shuts down when the context is cancelled, without
+// blocking or leaking goroutines.
+func TestScheduler_StartStop(t *testing.T) {
+	store := &repo.Store{
+		Checks: &mockListCheckRepo{checks: []models.MonitorCheck{}},
+		Events: &mockEventRepo{},
+	}
+
+	sched := NewScheduler(store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		sched.Start(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+		// clean shutdown
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler did not shut down within 2 seconds after context cancel")
+	}
+}
+
+// TestScheduler_StartsCheckGoroutine verifies that an enabled check causes a
+// goroutine to be registered in the active map after syncChecks.
+func TestScheduler_StartsCheckGoroutine(t *testing.T) {
+	check := models.MonitorCheck{
+		ID:           "chk-1",
+		Name:         "Test Ping",
+		Type:         "ping",
+		Target:       "127.0.0.1",
+		IntervalSecs: 300,
+		Enabled:      true,
+	}
+
+	store := &repo.Store{
+		Checks: &mockListCheckRepo{checks: []models.MonitorCheck{check}},
+		Events: &mockEventRepo{},
+	}
+
+	sched := NewScheduler(store)
+	// Override the pinger so the goroutine never makes real network calls.
+	sched.ping.pinger = alwaysUp
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := sched.syncChecks(ctx); err != nil {
+		t.Fatalf("syncChecks: %v", err)
+	}
+
+	sched.mu.Lock()
+	n := len(sched.active)
+	sched.mu.Unlock()
+
+	if n != 1 {
+		t.Errorf("expected 1 active goroutine after sync, got %d", n)
+	}
+}
+
+// TestScheduler_DisabledCheckNotStarted verifies that a disabled check does not
+// get a goroutine in the active map.
+func TestScheduler_DisabledCheckNotStarted(t *testing.T) {
+	check := models.MonitorCheck{
+		ID:           "chk-disabled",
+		Name:         "Disabled",
+		Type:         "ping",
+		Target:       "192.168.0.1",
+		IntervalSecs: 300,
+		Enabled:      false, // disabled
+	}
+
+	store := &repo.Store{
+		Checks: &mockListCheckRepo{checks: []models.MonitorCheck{check}},
+		Events: &mockEventRepo{},
+	}
+
+	sched := NewScheduler(store)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := sched.syncChecks(ctx); err != nil {
+		t.Fatalf("syncChecks: %v", err)
+	}
+
+	sched.mu.Lock()
+	n := len(sched.active)
+	sched.mu.Unlock()
+
+	if n != 0 {
+		t.Errorf("expected 0 active goroutines for disabled check, got %d", n)
+	}
+}


### PR DESCRIPTION
## What
Implements the ping check runner and monitor scheduler for NORA.

- `internal/monitor/ping.go` — `PingChecker` with injectable pinger function, 3-attempt logic, status-change event creation
- `internal/monitor/scheduler.go` — `Scheduler` that loads enabled checks from DB, runs each in its own goroutine at `interval_secs`, reloads every 5 minutes to pick up new checks, and shuts down cleanly on context cancellation. Stubs for `URLChecker` (T-14) and `SSLChecker` (T-15) included.
- `cmd/nora/main.go` — starts the scheduler as a goroutine on app startup

## Why
Closes T-13. NORA needs to actively ping hosts on a schedule to detect when they go offline and emit events on status transitions.

## How
- **3 pings per cycle, all must fail** to count as "down" — reduces false positives from single packet loss
- **os/exec ping** used instead of raw ICMP sockets (which require CAP_NET_RAW / root). Trade-off documented in a code comment; Alpine provides ping via busybox
- **Status-change events** only emitted when `LastStatus != ""` (not first run) and check has an `app_id` (events table requires valid FK)
- **Pinger is injectable** via a function field on `PingChecker` — enables unit testing without real network calls
- **Scheduler tracks active goroutines** in a `map[string]context.CancelFunc`; `syncChecks` adds new and cancels removed/disabled checks

## Test coverage
- `ping_test.go`: happy path (up), all-fail (down + error event), recovery (info event), no event without app_id, no event on first run, UpdateStatus error propagation
- `scheduler_test.go`: start/stop with context cancel (no hang), goroutine started for enabled check, no goroutine for disabled check
- `go test ./...` passes across all packages

## Closes
Closes #13