### PR TITLE
feat: T-14 URL check runner

### DIFF
--- a/internal/monitor/ping_test.go
+++ b/internal/monitor/ping_test.go
@@ -19,12 +19,13 @@ type mockCheckRepo struct {
 }
 
 type updateStatusCall struct {
-	id     string
-	status string
+	id      string
+	status  string
+	details string
 }
 
-func (m *mockCheckRepo) UpdateStatus(_ context.Context, id, status, _ string, _ time.Time) error {
-	m.updateStatusCalls = append(m.updateStatusCalls, updateStatusCall{id: id, status: status})
+func (m *mockCheckRepo) UpdateStatus(_ context.Context, id, status, details string, _ time.Time) error {
+	m.updateStatusCalls = append(m.updateStatusCalls, updateStatusCall{id: id, status: status, details: details})
 	return m.updateErr
 }
 

--- a/internal/monitor/scheduler.go
+++ b/internal/monitor/scheduler.go
@@ -10,9 +10,6 @@ import (
 	"github.com/digitalcheffe/nora/internal/repo"
 )
 
-// URLChecker is a stub for the URL check runner, implemented in T-14.
-type URLChecker struct{ store *repo.Store }
-
 // SSLChecker is a stub for the SSL check runner, implemented in T-15.
 type SSLChecker struct{ store *repo.Store }
 
@@ -35,7 +32,7 @@ func NewScheduler(store *repo.Store) *Scheduler {
 	return &Scheduler{
 		store:  store,
 		ping:   NewPingChecker(store),
-		url:    &URLChecker{store: store},
+		url:    NewURLChecker(store),
 		ssl:    &SSLChecker{store: store},
 		active: make(map[string]context.CancelFunc),
 	}
@@ -151,8 +148,7 @@ func (s *Scheduler) dispatch(ctx context.Context, check *models.MonitorCheck) {
 	case "ping":
 		err = s.ping.Run(ctx, check)
 	case "url":
-		// T-14: URL checker not yet implemented.
-		log.Printf("monitor scheduler: url check %q skipped — url checker not yet implemented (T-14)", check.Name)
+		err = s.url.Run(ctx, check)
 	case "ssl":
 		// T-15: SSL checker not yet implemented.
 		log.Printf("monitor scheduler: ssl check %q skipped — ssl checker not yet implemented (T-15)", check.Name)

--- a/internal/monitor/url.go
+++ b/internal/monitor/url.go
@@ -1,0 +1,169 @@
+package monitor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+// URLChecker executes HTTP GET health checks and persists results via the store.
+type URLChecker struct {
+	store  *repo.Store
+	client *http.Client
+}
+
+// NewURLChecker returns a URLChecker backed by store with a 10-second timeout.
+func NewURLChecker(store *repo.Store) *URLChecker {
+	return &URLChecker{
+		store: store,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+			// Do not follow redirects automatically — a 3xx should be treated
+			// as a non-match unless the check explicitly expects one.
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+}
+
+// urlResult is the JSON payload stored in last_result.
+type urlResult struct {
+	StatusCode int    `json:"status_code"`
+	LatencyMs  int64  `json:"latency_ms"`
+	Error      *string `json:"error"`
+}
+
+// authConfig is the subset of last_result we parse to find an auth header.
+type authConfig struct {
+	AuthHeader string `json:"auth_header"`
+}
+
+// Run performs one URL health check cycle for check.
+//
+// It makes an HTTP GET to check.Target, optionally adding an auth header from
+// last_result, and compares the response status code to check.ExpectedStatus
+// (defaulting to 200). On a status transition, an event is created — but only
+// when the check is linked to an app (events require a valid app_id).
+func (u *URLChecker) Run(ctx context.Context, check *models.MonitorCheck) error {
+	expected := check.ExpectedStatus
+	if expected == 0 {
+		expected = 200
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, check.Target, nil)
+	if err != nil {
+		return u.recordError(ctx, check, fmt.Sprintf("build request: %v", err))
+	}
+
+	// If last_result contains an auth_header, add it to the request.
+	if check.LastResult != "" {
+		var cfg authConfig
+		if jsonErr := json.Unmarshal([]byte(check.LastResult), &cfg); jsonErr == nil && cfg.AuthHeader != "" {
+			req.Header.Set("Authorization", cfg.AuthHeader)
+		}
+	}
+
+	start := time.Now()
+	resp, err := u.client.Do(req)
+	latencyMs := time.Since(start).Milliseconds()
+
+	now := time.Now().UTC()
+
+	if err != nil {
+		return u.recordError(ctx, check, err.Error())
+	}
+	resp.Body.Close()
+
+	newStatus := "up"
+	if resp.StatusCode != expected {
+		newStatus = "down"
+	}
+
+	errPtr := (*string)(nil)
+	result := urlResult{
+		StatusCode: resp.StatusCode,
+		LatencyMs:  latencyMs,
+		Error:      errPtr,
+	}
+	details, _ := json.Marshal(result)
+
+	// Emit a status-change event when there is a known previous state and the
+	// check is linked to an app.
+	prevStatus := check.LastStatus
+	if prevStatus != "" && prevStatus != newStatus && check.AppID != "" {
+		if evErr := u.createStatusEvent(ctx, check, newStatus, resp.StatusCode, expected, now); evErr != nil {
+			log.Printf("url checker: create event for check %s: %v", check.ID, evErr)
+		}
+	}
+
+	if updateErr := u.store.Checks.UpdateStatus(ctx, check.ID, newStatus, string(details), now); updateErr != nil {
+		return fmt.Errorf("url checker: update status for %s: %w", check.ID, updateErr)
+	}
+	return nil
+}
+
+// recordError handles a network-level failure: records the check as "down",
+// persists an error last_result, emits a status-change event if needed, and
+// returns the wrapped error.
+func (u *URLChecker) recordError(ctx context.Context, check *models.MonitorCheck, errMsg string) error {
+	now := time.Now().UTC()
+	newStatus := "down"
+
+	result := urlResult{StatusCode: 0, LatencyMs: 0, Error: &errMsg}
+	details, _ := json.Marshal(result)
+
+	expected := check.ExpectedStatus
+	if expected == 0 {
+		expected = 200
+	}
+
+	prevStatus := check.LastStatus
+	if prevStatus != "" && prevStatus != newStatus && check.AppID != "" {
+		if evErr := u.createStatusEvent(ctx, check, newStatus, 0, expected, now); evErr != nil {
+			log.Printf("url checker: create event for check %s: %v", check.ID, evErr)
+		}
+	}
+
+	if updateErr := u.store.Checks.UpdateStatus(ctx, check.ID, newStatus, string(details), now); updateErr != nil {
+		return fmt.Errorf("url checker: update status for %s: %w", check.ID, updateErr)
+	}
+	return fmt.Errorf("url checker: %s: %s", check.Name, errMsg)
+}
+
+// createStatusEvent persists a down or recovery event for check.
+func (u *URLChecker) createStatusEvent(
+	ctx context.Context,
+	check *models.MonitorCheck,
+	newStatus string,
+	gotStatus, expectedStatus int,
+	now time.Time,
+) error {
+	var severity, displayText string
+	if newStatus == "down" {
+		severity = "error"
+		displayText = fmt.Sprintf("URL check failed — %s: got %d, expected %d",
+			check.Name, gotStatus, expectedStatus)
+	} else {
+		severity = "info"
+		displayText = fmt.Sprintf("URL check restored — %s", check.Name)
+	}
+
+	event := &models.Event{
+		ID:          uuid.New().String(),
+		AppID:       check.AppID,
+		ReceivedAt:  now,
+		Severity:    severity,
+		DisplayText: displayText,
+		RawPayload:  "{}",
+		Fields:      `{"source":"monitor","check_id":"` + check.ID + `","type":"url"}`,
+	}
+	return u.store.Events.Create(ctx, event)
+}

--- a/internal/monitor/url_test.go
+++ b/internal/monitor/url_test.go
@@ -1,0 +1,308 @@
+package monitor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/digitalcheffe/nora/internal/models"
+)
+
+// makeURLCheck returns a MonitorCheck suitable for URL checker tests.
+func makeURLCheck(target, lastStatus, appID string, expectedStatus int) *models.MonitorCheck {
+	return &models.MonitorCheck{
+		ID:             "url-check-1",
+		AppID:          appID,
+		Name:           "My Service",
+		Type:           "url",
+		Target:         target,
+		IntervalSecs:   60,
+		ExpectedStatus: expectedStatus,
+		LastStatus:     lastStatus,
+	}
+}
+
+func newURLChecker(checks *mockCheckRepo, events *mockEventRepo) *URLChecker {
+	return &URLChecker{
+		store: newTestStore(checks, events),
+		client: &http.Client{
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+}
+
+// TestURLChecker_HappyPath verifies a 200 response marks the check "up".
+func TestURLChecker_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newURLChecker(checks, events)
+
+	check := makeURLCheck(srv.URL, "up", "", 200)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(checks.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 UpdateStatus call, got %d", len(checks.updateStatusCalls))
+	}
+	if checks.updateStatusCalls[0].status != "up" {
+		t.Errorf("expected status=up, got %s", checks.updateStatusCalls[0].status)
+	}
+	if len(events.created) != 0 {
+		t.Errorf("expected no events, got %d", len(events.created))
+	}
+}
+
+// TestURLChecker_WrongStatusDown verifies a non-matching status code marks the check "down".
+func TestURLChecker_WrongStatusDown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newURLChecker(checks, events)
+
+	check := makeURLCheck(srv.URL, "up", "app-1", 200)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(checks.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 UpdateStatus call, got %d", len(checks.updateStatusCalls))
+	}
+	if checks.updateStatusCalls[0].status != "down" {
+		t.Errorf("expected status=down, got %s", checks.updateStatusCalls[0].status)
+	}
+	if len(events.created) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events.created))
+	}
+	if events.created[0].Severity != "error" {
+		t.Errorf("expected severity=error, got %s", events.created[0].Severity)
+	}
+}
+
+// TestURLChecker_Recovery verifies down→up transition creates an info event.
+func TestURLChecker_Recovery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newURLChecker(checks, events)
+
+	check := makeURLCheck(srv.URL, "down", "app-1", 200)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(events.created) != 1 {
+		t.Fatalf("expected 1 recovery event, got %d", len(events.created))
+	}
+	if events.created[0].Severity != "info" {
+		t.Errorf("expected severity=info, got %s", events.created[0].Severity)
+	}
+}
+
+// TestURLChecker_RedirectDown verifies that an unexpected redirect (3xx) is treated as "down".
+func TestURLChecker_RedirectDown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/other", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newURLChecker(checks, events)
+
+	// Expect 200 but server returns 302 → should be "down".
+	check := makeURLCheck(srv.URL, "up", "app-1", 200)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if checks.updateStatusCalls[0].status != "down" {
+		t.Errorf("expected status=down for redirect, got %s", checks.updateStatusCalls[0].status)
+	}
+}
+
+// TestURLChecker_RedirectExpected verifies that a 3xx is treated as "up" when explicitly expected.
+func TestURLChecker_RedirectExpected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/other", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newURLChecker(checks, events)
+
+	check := makeURLCheck(srv.URL, "up", "", 302)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if checks.updateStatusCalls[0].status != "up" {
+		t.Errorf("expected status=up for expected redirect, got %s", checks.updateStatusCalls[0].status)
+	}
+}
+
+// TestURLChecker_Timeout verifies that a connection timeout results in "down".
+func TestURLChecker_Timeout(t *testing.T) {
+	// Use a non-routable address to force a connection timeout quickly.
+	// context.WithTimeout simulates the 10s timeout in unit tests.
+	ctx, cancel := context.WithTimeout(context.Background(), 50)
+	defer cancel()
+
+	// Point to a closed port on localhost to get a fast connection refused.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	srv.Close() // immediately close so requests get "connection refused"
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newURLChecker(checks, events)
+
+	check := makeURLCheck(srv.URL, "up", "app-1", 200)
+	// Run may return an error (network error) — that's acceptable.
+	_ = checker.Run(ctx, check)
+
+	if len(checks.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 UpdateStatus call, got %d", len(checks.updateStatusCalls))
+	}
+	if checks.updateStatusCalls[0].status != "down" {
+		t.Errorf("expected status=down on network error, got %s", checks.updateStatusCalls[0].status)
+	}
+}
+
+// TestURLChecker_AuthHeader verifies the auth_header from last_result is sent.
+func TestURLChecker_AuthHeader(t *testing.T) {
+	var receivedAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newURLChecker(checks, events)
+
+	lastResult, _ := json.Marshal(map[string]string{"auth_header": "Bearer secret-token"})
+	check := makeURLCheck(srv.URL, "up", "", 200)
+	check.LastResult = string(lastResult)
+
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedAuth != "Bearer secret-token" {
+		t.Errorf("expected Authorization header to be sent, got %q", receivedAuth)
+	}
+}
+
+// TestURLChecker_DefaultExpected200 verifies that ExpectedStatus=0 defaults to 200.
+func TestURLChecker_DefaultExpected200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newURLChecker(checks, events)
+
+	check := makeURLCheck(srv.URL, "up", "", 0) // 0 = unset, should default to 200
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if checks.updateStatusCalls[0].status != "up" {
+		t.Errorf("expected status=up with default 200, got %s", checks.updateStatusCalls[0].status)
+	}
+}
+
+// TestURLChecker_NoEventWithoutApp verifies no event is created for app-less checks.
+func TestURLChecker_NoEventWithoutApp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newURLChecker(checks, events)
+
+	check := makeURLCheck(srv.URL, "up", "", 200) // no AppID
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(events.created) != 0 {
+		t.Errorf("expected no events for check without app, got %d", len(events.created))
+	}
+}
+
+// TestURLChecker_NoEventOnFirstRun verifies no event on first execution (LastStatus="").
+func TestURLChecker_NoEventOnFirstRun(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newURLChecker(checks, events)
+
+	check := makeURLCheck(srv.URL, "", "app-1", 200) // no previous status
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(events.created) != 0 {
+		t.Errorf("expected no event on first run, got %d", len(events.created))
+	}
+}
+
+// TestURLChecker_LastResultStoredCorrectly verifies the last_result JSON structure.
+func TestURLChecker_LastResultStoredCorrectly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newURLChecker(checks, events)
+
+	check := makeURLCheck(srv.URL, "up", "", 200)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(checks.updateStatusCalls) == 0 {
+		t.Fatal("expected UpdateStatus to be called")
+	}
+
+	var result urlResult
+	if err := json.Unmarshal([]byte(checks.updateStatusCalls[0].details), &result); err != nil {
+		t.Fatalf("last_result is not valid JSON: %v", err)
+	}
+	if result.StatusCode != 200 {
+		t.Errorf("expected status_code=200, got %d", result.StatusCode)
+	}
+	if result.Error != nil {
+		t.Errorf("expected error=null, got %v", *result.Error)
+	}
+}


### PR DESCRIPTION
## What
Implements the URL health check runner (`URLChecker`) for NORA.

## Why
Closes T-14. Enables HTTP GET checks against configured endpoints (e.g. Sonarr `/api/v3/health`) and verifies response status codes, completing the second of three check types in the monitor package.

## How
- `URLChecker` in `/internal/monitor/url.go` with a 10s timeout `http.Client` and redirect-blocking `CheckRedirect`
- Auth header support: if `last_result` JSON contains `auth_header`, it's sent as `Authorization` on every request
- `ExpectedStatus=0` defaults to 200
- Status logic: match → `up`; non-match or network error → `down`; 3xx when not expected → `down`
- Status-change events follow the same pattern as the ping checker (error severity on down, info on recovery; only when `app_id` is set)
- `last_result` stores `{"status_code": N, "latency_ms": N, "error": null|"msg"}`
- Scheduler `dispatch` wired to call `s.url.Run()` (replacing the T-14 stub log line)
- `mockCheckRepo.updateStatusCall` extended with `details` field so URL tests can assert `last_result` shape

## Test coverage
- Happy path (200 → up)
- Wrong status (500 when expecting 200 → down + error event)
- Recovery (down → up → info event)
- Redirect treated as down when not expected
- Redirect treated as up when explicitly expected (ExpectedStatus=302)
- Network error / timeout → down
- Auth header forwarded from last_result
- Default ExpectedStatus=0 → 200
- No event without app_id
- No event on first run (LastStatus="")
- last_result JSON structure validated

## Closes
Closes #14