### PR TITLE
feat: T-15 SSL certificate check runner

### DIFF
--- a/internal/monitor/runner.go
+++ b/internal/monitor/runner.go
@@ -31,9 +31,13 @@ type urlDetails struct {
 }
 
 // sslDetails is stored in last_result for ssl checks.
+// All fields are pointers so they serialise as null on TLS failure.
 type sslDetails struct {
-	DaysRemaining int       `json:"days_remaining"`
-	ExpiresAt     time.Time `json:"expires_at"`
+	DaysRemaining *int       `json:"days_remaining"`
+	ExpiresAt     *time.Time `json:"expires_at"`
+	Issuer        *string    `json:"issuer"`
+	Subject       *string    `json:"subject"`
+	Error         *string    `json:"error"`
 }
 
 // RunPing executes a ping check against target using os/exec.
@@ -121,33 +125,44 @@ func RunSSL(ctx context.Context, target string, warnDays, critDays int) Result {
 	}
 	conn, err := dialer.DialContext(ctx, "tcp", host)
 	if err != nil {
-		details, _ := json.Marshal(map[string]string{"error": err.Error()})
+		errStr := err.Error()
+		details, _ := json.Marshal(sslDetails{Error: &errStr})
 		return Result{Status: "down", Details: details, CheckedAt: now}
 	}
 	defer conn.Close()
 
 	tlsConn, ok := conn.(*tls.Conn)
 	if !ok {
-		details, _ := json.Marshal(map[string]string{"error": "not a TLS connection"})
+		errStr := "not a TLS connection"
+		details, _ := json.Marshal(sslDetails{Error: &errStr})
 		return Result{Status: "down", Details: details, CheckedAt: now}
 	}
 
 	certs := tlsConn.ConnectionState().PeerCertificates
 	if len(certs) == 0 {
-		details, _ := json.Marshal(map[string]string{"error": "no certificates"})
+		errStr := "no certificates"
+		details, _ := json.Marshal(sslDetails{Error: &errStr})
 		return Result{Status: "down", Details: details, CheckedAt: now}
 	}
 
-	expiry := certs[0].NotAfter
+	cert := certs[0]
+	expiry := cert.NotAfter.UTC()
 	daysRemaining := int(time.Until(expiry).Hours() / 24)
-	details, _ := json.Marshal(sslDetails{DaysRemaining: daysRemaining, ExpiresAt: expiry.UTC()})
+	issuer := cert.Issuer.CommonName
+	subject := cert.Subject.CommonName
+	details, _ := json.Marshal(sslDetails{
+		DaysRemaining: &daysRemaining,
+		ExpiresAt:     &expiry,
+		Issuer:        &issuer,
+		Subject:       &subject,
+	})
 
 	status := "up"
 	switch {
 	case daysRemaining <= 0:
 		status = "down"
 	case daysRemaining <= critDays:
-		status = "down"
+		status = "critical"
 	case daysRemaining <= warnDays:
 		status = "warn"
 	}

--- a/internal/monitor/scheduler.go
+++ b/internal/monitor/scheduler.go
@@ -10,9 +10,6 @@ import (
 	"github.com/digitalcheffe/nora/internal/repo"
 )
 
-// SSLChecker is a stub for the SSL check runner, implemented in T-15.
-type SSLChecker struct{ store *repo.Store }
-
 // Scheduler loads monitor checks from the database and runs each one on its
 // configured interval. Every check runs in its own goroutine, so a slow or
 // blocked check cannot delay others. The check list is refreshed every 5
@@ -33,7 +30,7 @@ func NewScheduler(store *repo.Store) *Scheduler {
 		store:  store,
 		ping:   NewPingChecker(store),
 		url:    NewURLChecker(store),
-		ssl:    &SSLChecker{store: store},
+		ssl:    NewSSLChecker(store),
 		active: make(map[string]context.CancelFunc),
 	}
 }
@@ -150,8 +147,7 @@ func (s *Scheduler) dispatch(ctx context.Context, check *models.MonitorCheck) {
 	case "url":
 		err = s.url.Run(ctx, check)
 	case "ssl":
-		// T-15: SSL checker not yet implemented.
-		log.Printf("monitor scheduler: ssl check %q skipped — ssl checker not yet implemented (T-15)", check.Name)
+		err = s.ssl.Run(ctx, check)
 	default:
 		log.Printf("monitor scheduler: unknown check type %q for check %q", check.Type, check.Name)
 	}

--- a/internal/monitor/ssl.go
+++ b/internal/monitor/ssl.go
@@ -1,0 +1,117 @@
+package monitor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+// SSLChecker executes TLS certificate expiry checks and persists results via the store.
+type SSLChecker struct {
+	store  *repo.Store
+	runner func(ctx context.Context, target string, warnDays, critDays int) Result
+}
+
+// NewSSLChecker returns an SSLChecker backed by store.
+func NewSSLChecker(store *repo.Store) *SSLChecker {
+	return &SSLChecker{store: store, runner: RunSSL}
+}
+
+// Run executes one SSL certificate expiry check cycle for check.
+//
+// It dials the target over TLS, reads the leaf certificate, and maps days
+// remaining to one of four statuses: up / warn / critical / down.
+// On a status transition, an event is created — but only when the check is
+// linked to an app (events require a valid app_id).
+func (s *SSLChecker) Run(ctx context.Context, check *models.MonitorCheck) error {
+	warnDays := check.SSLWarnDays
+	if warnDays == 0 {
+		warnDays = 30
+	}
+	critDays := check.SSLCritDays
+	if critDays == 0 {
+		critDays = 7
+	}
+
+	result := s.runner(ctx, check.Target, warnDays, critDays)
+	now := time.Now().UTC()
+
+	// Parse days remaining from result details for use in event messages.
+	var parsed sslDetails
+	_ = json.Unmarshal(result.Details, &parsed)
+
+	days := 0
+	if parsed.DaysRemaining != nil {
+		days = *parsed.DaysRemaining
+	}
+
+	domain := extractDomain(check.Target)
+
+	prevStatus := check.LastStatus
+	newStatus := result.Status
+	if prevStatus != "" && prevStatus != newStatus && check.AppID != "" {
+		if evErr := s.createStatusEvent(ctx, check, newStatus, domain, days, now); evErr != nil {
+			log.Printf("ssl checker: create event for check %s: %v", check.ID, evErr)
+		}
+	}
+
+	if updateErr := s.store.Checks.UpdateStatus(ctx, check.ID, newStatus, string(result.Details), now); updateErr != nil {
+		return fmt.Errorf("ssl checker: update status for %s: %w", check.ID, updateErr)
+	}
+	return nil
+}
+
+// extractDomain strips the scheme and path from a URL, returning host[:port].
+func extractDomain(target string) string {
+	d := target
+	for _, prefix := range []string{"https://", "http://"} {
+		d = strings.TrimPrefix(d, prefix)
+	}
+	if i := strings.Index(d, "/"); i != -1 {
+		d = d[:i]
+	}
+	return d
+}
+
+// createStatusEvent persists a status-change event for an SSL check.
+func (s *SSLChecker) createStatusEvent(
+	ctx context.Context,
+	check *models.MonitorCheck,
+	newStatus, domain string,
+	daysRemaining int,
+	now time.Time,
+) error {
+	var severity, displayText string
+	switch newStatus {
+	case "warn":
+		severity = "warn"
+		displayText = fmt.Sprintf("SSL expiring soon — %s: %d days remaining", domain, daysRemaining)
+	case "critical":
+		severity = "critical"
+		displayText = fmt.Sprintf("SSL expiry critical — %s: %d days remaining", domain, daysRemaining)
+	case "down":
+		severity = "error"
+		displayText = fmt.Sprintf("SSL invalid or expired — %s", domain)
+	default: // "up" = recovery
+		severity = "info"
+		displayText = fmt.Sprintf("SSL renewed — %s: %d days remaining", domain, daysRemaining)
+	}
+
+	event := &models.Event{
+		ID:          uuid.New().String(),
+		AppID:       check.AppID,
+		ReceivedAt:  now,
+		Severity:    severity,
+		DisplayText: displayText,
+		RawPayload:  "{}",
+		Fields:      `{"source":"monitor","check_id":"` + check.ID + `","type":"ssl"}`,
+	}
+	return s.store.Events.Create(ctx, event)
+}

--- a/internal/monitor/ssl_test.go
+++ b/internal/monitor/ssl_test.go
@@ -1,0 +1,444 @@
+package monitor
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+)
+
+// makeSSLCheck returns a MonitorCheck suitable for SSL checker tests.
+func makeSSLCheck(target, lastStatus, appID string, warnDays, critDays int) *models.MonitorCheck {
+	return &models.MonitorCheck{
+		ID:           "ssl-check-1",
+		AppID:        appID,
+		Name:         "My SSL",
+		Type:         "ssl",
+		Target:       target,
+		IntervalSecs: 3600,
+		SSLWarnDays:  warnDays,
+		SSLCritDays:  critDays,
+		LastStatus:   lastStatus,
+	}
+}
+
+// fakeSSLRunner returns an injectable runner that simulates a cert result.
+// Pass errMsg non-empty to simulate a TLS failure.
+func fakeSSLRunner(status string, days int, errMsg string) func(ctx context.Context, target string, warnDays, critDays int) Result {
+	return func(_ context.Context, _ string, _, _ int) Result {
+		if errMsg != "" {
+			errStr := errMsg
+			details, _ := json.Marshal(sslDetails{Error: &errStr})
+			return Result{Status: "down", Details: details, CheckedAt: time.Now()}
+		}
+		expiresAt := time.Now().Add(time.Duration(days) * 24 * time.Hour).UTC()
+		issuer := "Test CA"
+		subject := "test.example.com"
+		details, _ := json.Marshal(sslDetails{
+			DaysRemaining: &days,
+			ExpiresAt:     &expiresAt,
+			Issuer:        &issuer,
+			Subject:       &subject,
+		})
+		return Result{Status: status, Details: details, CheckedAt: time.Now()}
+	}
+}
+
+func newSSLChecker(checks *mockCheckRepo, events *mockEventRepo, runner func(ctx context.Context, target string, warnDays, critDays int) Result) *SSLChecker {
+	return &SSLChecker{
+		store:  newTestStore(checks, events),
+		runner: runner,
+	}
+}
+
+// TestSSLChecker_HappyPath verifies that a cert with many days remaining is "up".
+func TestSSLChecker_HappyPath(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newSSLChecker(checks, events, fakeSSLRunner("up", 90, ""))
+
+	check := makeSSLCheck("https://example.com", "up", "", 30, 7)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(checks.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 UpdateStatus call, got %d", len(checks.updateStatusCalls))
+	}
+	if checks.updateStatusCalls[0].status != "up" {
+		t.Errorf("expected status=up, got %s", checks.updateStatusCalls[0].status)
+	}
+	if len(events.created) != 0 {
+		t.Errorf("expected no events, got %d", len(events.created))
+	}
+}
+
+// TestSSLChecker_WarnStatus verifies warn fires at ≤30 days remaining (default threshold).
+func TestSSLChecker_WarnStatus(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newSSLChecker(checks, events, fakeSSLRunner("warn", 20, ""))
+
+	check := makeSSLCheck("https://example.com", "up", "app-1", 30, 7)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if checks.updateStatusCalls[0].status != "warn" {
+		t.Errorf("expected status=warn, got %s", checks.updateStatusCalls[0].status)
+	}
+	if len(events.created) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events.created))
+	}
+	ev := events.created[0]
+	if ev.Severity != "warn" {
+		t.Errorf("expected severity=warn, got %s", ev.Severity)
+	}
+}
+
+// TestSSLChecker_CriticalStatus verifies critical fires at ≤7 days remaining.
+func TestSSLChecker_CriticalStatus(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newSSLChecker(checks, events, fakeSSLRunner("critical", 3, ""))
+
+	check := makeSSLCheck("https://example.com", "up", "app-1", 30, 7)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if checks.updateStatusCalls[0].status != "critical" {
+		t.Errorf("expected status=critical, got %s", checks.updateStatusCalls[0].status)
+	}
+	if len(events.created) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events.created))
+	}
+	ev := events.created[0]
+	if ev.Severity != "critical" {
+		t.Errorf("expected severity=critical, got %s", ev.Severity)
+	}
+}
+
+// TestSSLChecker_DownOnTLSError verifies TLS dial failure results in "down" with severity "error".
+func TestSSLChecker_DownOnTLSError(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newSSLChecker(checks, events, fakeSSLRunner("down", 0, "x509: certificate has expired"))
+
+	check := makeSSLCheck("https://expired.example.com", "up", "app-1", 30, 7)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if checks.updateStatusCalls[0].status != "down" {
+		t.Errorf("expected status=down, got %s", checks.updateStatusCalls[0].status)
+	}
+	if len(events.created) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events.created))
+	}
+	ev := events.created[0]
+	if ev.Severity != "error" {
+		t.Errorf("expected severity=error, got %s", ev.Severity)
+	}
+}
+
+// TestSSLChecker_Recovery verifies down→up transition creates an info event.
+func TestSSLChecker_Recovery(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newSSLChecker(checks, events, fakeSSLRunner("up", 90, ""))
+
+	check := makeSSLCheck("https://example.com", "down", "app-1", 30, 7)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(events.created) != 1 {
+		t.Fatalf("expected 1 recovery event, got %d", len(events.created))
+	}
+	ev := events.created[0]
+	if ev.Severity != "info" {
+		t.Errorf("expected severity=info for recovery, got %s", ev.Severity)
+	}
+}
+
+// TestSSLChecker_NoEventWithoutApp verifies no event is created for checks not linked to an app.
+func TestSSLChecker_NoEventWithoutApp(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newSSLChecker(checks, events, fakeSSLRunner("warn", 20, ""))
+
+	check := makeSSLCheck("https://example.com", "up", "", 30, 7) // no AppID
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(events.created) != 0 {
+		t.Errorf("expected no events for check without app, got %d", len(events.created))
+	}
+}
+
+// TestSSLChecker_NoEventOnFirstRun verifies no event fires on the first execution (LastStatus="").
+func TestSSLChecker_NoEventOnFirstRun(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newSSLChecker(checks, events, fakeSSLRunner("warn", 20, ""))
+
+	check := makeSSLCheck("https://example.com", "", "app-1", 30, 7) // no previous status
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(events.created) != 0 {
+		t.Errorf("expected no event on first run, got %d", len(events.created))
+	}
+}
+
+// TestSSLChecker_LastResultPopulated verifies last_result contains all required fields.
+func TestSSLChecker_LastResultPopulated(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newSSLChecker(checks, events, fakeSSLRunner("up", 90, ""))
+
+	check := makeSSLCheck("https://example.com", "up", "", 30, 7)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(checks.updateStatusCalls) == 0 {
+		t.Fatal("expected UpdateStatus to be called")
+	}
+
+	var result sslDetails
+	if err := json.Unmarshal([]byte(checks.updateStatusCalls[0].details), &result); err != nil {
+		t.Fatalf("last_result is not valid JSON: %v", err)
+	}
+	if result.DaysRemaining == nil {
+		t.Error("expected days_remaining to be set")
+	}
+	if result.ExpiresAt == nil {
+		t.Error("expected expires_at to be set")
+	}
+	if result.Issuer == nil {
+		t.Error("expected issuer to be set")
+	}
+	if result.Subject == nil {
+		t.Error("expected subject to be set")
+	}
+	if result.Error != nil {
+		t.Errorf("expected error=null on success, got %q", *result.Error)
+	}
+}
+
+// TestSSLChecker_LastResultOnError verifies last_result has error set and numeric fields null on failure.
+func TestSSLChecker_LastResultOnError(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newSSLChecker(checks, events, fakeSSLRunner("down", 0, "connection refused"))
+
+	check := makeSSLCheck("https://unreachable.example.com", "", "", 30, 7)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result sslDetails
+	if err := json.Unmarshal([]byte(checks.updateStatusCalls[0].details), &result); err != nil {
+		t.Fatalf("last_result is not valid JSON: %v", err)
+	}
+	if result.Error == nil || *result.Error == "" {
+		t.Error("expected error to be set on TLS failure")
+	}
+	if result.DaysRemaining != nil {
+		t.Error("expected days_remaining=null on TLS failure")
+	}
+}
+
+// TestSSLChecker_DefaultThresholds verifies SSLWarnDays=0 and SSLCritDays=0 default to 30/7.
+func TestSSLChecker_DefaultThresholds(t *testing.T) {
+	// Runner captures the warnDays/critDays it was called with.
+	var capturedWarn, capturedCrit int
+	runner := func(_ context.Context, _ string, warnDays, critDays int) Result {
+		capturedWarn = warnDays
+		capturedCrit = critDays
+		days := 90
+		expiresAt := time.Now().Add(90 * 24 * time.Hour).UTC()
+		issuer := "CA"
+		subject := "example.com"
+		details, _ := json.Marshal(sslDetails{
+			DaysRemaining: &days,
+			ExpiresAt:     &expiresAt,
+			Issuer:        &issuer,
+			Subject:       &subject,
+		})
+		return Result{Status: "up", Details: details, CheckedAt: time.Now()}
+	}
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newSSLChecker(checks, events, runner)
+
+	check := makeSSLCheck("https://example.com", "up", "", 0, 0) // 0 = use defaults
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedWarn != 30 {
+		t.Errorf("expected warnDays=30, got %d", capturedWarn)
+	}
+	if capturedCrit != 7 {
+		t.Errorf("expected critDays=7, got %d", capturedCrit)
+	}
+}
+
+// TestSSLChecker_RealTLSServer_InvalidCert verifies that a TLS server with
+// an unverifiable certificate results in a "down" status (cert validation fails).
+func TestSSLChecker_RealTLSServer_InvalidCert(t *testing.T) {
+	// httptest.NewTLSServer uses a self-signed cert; RunSSL with InsecureSkipVerify=false
+	// will reject it, resulting in a "down" status.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+
+	// Use the real RunSSL runner (InsecureSkipVerify: false rejects self-signed certs).
+	checker := &SSLChecker{store: newTestStore(checks, events), runner: RunSSL}
+
+	check := makeSSLCheck(srv.URL, "", "", 30, 7)
+	_ = checker.Run(context.Background(), check)
+
+	if len(checks.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 UpdateStatus call, got %d", len(checks.updateStatusCalls))
+	}
+	if checks.updateStatusCalls[0].status != "down" {
+		t.Errorf("expected status=down for untrusted cert, got %s", checks.updateStatusCalls[0].status)
+	}
+}
+
+// TestSSLChecker_RealTLSServer_ValidCert verifies that a trusted TLS server
+// results in "up" when the cert has sufficient days remaining.
+func TestSSLChecker_RealTLSServer_ValidCert(t *testing.T) {
+	// Use httptest's TLS server cert and trust it explicitly via custom runner.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// httptest.Server.Client() returns an *http.Client whose TLS config trusts
+	// the test server's self-signed certificate.
+	transport := srv.Client().Transport.(*http.Transport)
+	trustedRunner := func(ctx context.Context, target string, warnDays, critDays int) Result {
+		return runSSLWithConfig(ctx, target, warnDays, critDays, transport.TLSClientConfig)
+	}
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newSSLChecker(checks, events, trustedRunner)
+
+	check := makeSSLCheck(srv.URL, "", "", 30, 7)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(checks.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 UpdateStatus call, got %d", len(checks.updateStatusCalls))
+	}
+	// The httptest cert is valid for ~10 years, so status must be "up".
+	got := checks.updateStatusCalls[0].status
+	if got != "up" {
+		t.Errorf("expected status=up for valid trusted cert, got %s", got)
+	}
+
+	// Verify last_result has the required fields populated.
+	var result sslDetails
+	if err := json.Unmarshal([]byte(checks.updateStatusCalls[0].details), &result); err != nil {
+		t.Fatalf("last_result is not valid JSON: %v", err)
+	}
+	if result.DaysRemaining == nil || *result.DaysRemaining <= 0 {
+		t.Error("expected days_remaining > 0 for a valid cert")
+	}
+	if result.ExpiresAt == nil {
+		t.Error("expected expires_at to be set")
+	}
+}
+
+// runSSLWithConfig is a variant of RunSSL that uses the provided *tls.Config
+// to trust a specific set of certificates — used only in tests.
+func runSSLWithConfig(ctx context.Context, target string, warnDays, critDays int, cfg *tls.Config) Result {
+	now := time.Now().UTC()
+	if warnDays == 0 {
+		warnDays = 30
+	}
+	if critDays == 0 {
+		critDays = 7
+	}
+
+	host := extractDomain(target)
+	if len(host) > 0 && host[0] == '[' {
+		// IPv6 literal — strip brackets for port check.
+	}
+	// Default to 443 if no port; httptest servers use a random port so we keep whatever's there.
+	if !containsPort(host) {
+		host += ":443"
+	}
+
+	dialer := &tls.Dialer{
+		Config: cfg,
+	}
+	conn, err := dialer.DialContext(ctx, "tcp", host)
+	if err != nil {
+		errStr := err.Error()
+		details, _ := json.Marshal(sslDetails{Error: &errStr})
+		return Result{Status: "down", Details: details, CheckedAt: now}
+	}
+	defer conn.Close()
+
+	tlsConn := conn.(*tls.Conn)
+	certs := tlsConn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		errStr := "no certificates"
+		details, _ := json.Marshal(sslDetails{Error: &errStr})
+		return Result{Status: "down", Details: details, CheckedAt: now}
+	}
+
+	cert := certs[0]
+	expiry := cert.NotAfter.UTC()
+	daysRemaining := int(time.Until(expiry).Hours() / 24)
+	issuer := cert.Issuer.CommonName
+	subject := cert.Subject.CommonName
+	details, _ := json.Marshal(sslDetails{
+		DaysRemaining: &daysRemaining,
+		ExpiresAt:     &expiry,
+		Issuer:        &issuer,
+		Subject:       &subject,
+	})
+
+	status := "up"
+	switch {
+	case daysRemaining <= 0:
+		status = "down"
+	case daysRemaining <= critDays:
+		status = "critical"
+	case daysRemaining <= warnDays:
+		status = "warn"
+	}
+	return Result{Status: status, Details: details, CheckedAt: now}
+}
+
+// containsPort reports whether host already contains a port number.
+func containsPort(host string) bool {
+	// IPv6: [::1]:443
+	if len(host) > 0 && host[0] == '[' {
+		i := strings.Index(host, "]:")
+		return i != -1
+	}
+	return strings.Contains(host, ":")
+}


### PR DESCRIPTION
## What
Implements the SSL certificate expiry check runner (`/internal/monitor/ssl.go`), replacing the scheduler stub from T-13.

## Why
Closes #15 — SSL cert expiry is a silent failure mode that needs automated monitoring with tiered alerting (warn → critical → down).

## How
- **`runner.go`** — Updated `sslDetails` struct to include `issuer`, `subject`, and `error` (all nullable pointers). Fixed `RunSSL` status logic: `<= critDays` now returns `"critical"` instead of `"down"`.
- **`ssl.go`** — Full `SSLChecker` implementation with injectable runner for testability. `Run()` maps `up / warn / critical / down` to events with correct severities (`info / warn / critical / error`). Event display text matches spec.
- **`scheduler.go`** — Removed the `SSLChecker` stub, wired `NewSSLChecker(store)` into `NewScheduler`, and updated `dispatch` to call `s.ssl.Run(ctx, check)`.
- **`ssl_test.go`** — 11 tests covering: happy path, warn threshold, critical threshold, TLS dial failure, recovery, no-event-without-app, no-event-on-first-run, last_result field population, error last_result, default thresholds (0 → 30/7), and two real TLS server tests (untrusted cert → down, trusted cert → up with fields populated).

## Test coverage
- `go test ./...` — all pass
- `go vet ./...` — clean

## Closes
Closes #15