### PR TITLE
feat: T-17 Container resource polling

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -38,7 +38,8 @@ func main() {
 	eventRepo := repo.NewEventRepo(db)
 	checkRepo := repo.NewCheckRepo(db)
 	rollupRepo := repo.NewRollupRepo(db)
-	store := repo.NewStore(appRepo, eventRepo, checkRepo, rollupRepo)
+	resourceRepo := repo.NewResourceReadingRepo(db)
+	store := repo.NewStore(appRepo, eventRepo, checkRepo, rollupRepo, resourceRepo)
 
 	// Profile registry — load all bundled YAML profiles
 	registry, err := profile.NewRegistry(noraprofiles.Files)
@@ -54,13 +55,18 @@ func main() {
 	defer schedCancel()
 	go monitor.NewScheduler(store).Start(schedCtx)
 
-	// Docker socket watcher — optional; skipped if the socket is not available.
+	// Docker socket watcher and resource poller — optional; skipped if the socket is not available.
 	dockerCtx, dockerCancel := context.WithCancel(context.Background())
 	defer dockerCancel()
 	if watcher, err := docker.NewWatcher(store); err != nil {
 		log.Printf("docker watcher: socket not available, skipping (%v)", err)
 	} else {
 		go watcher.Start(dockerCtx)
+	}
+	if poller, err := docker.NewResourcePoller(store); err != nil {
+		log.Printf("resource poller: socket not available, skipping (%v)", err)
+	} else {
+		go poller.Start(dockerCtx)
 	}
 
 	// Router

--- a/internal/api/ingest_test.go
+++ b/internal/api/ingest_test.go
@@ -21,7 +21,7 @@ func newIngestRouter(t *testing.T) (http.Handler, *repo.Store) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db))
+	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil)
 	limiter := ingest.NewRateLimiter()
 	profiler := &profile.NoopLoader{}
 
@@ -44,7 +44,7 @@ func TestHandleIngest_HappyPath(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db))
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()
@@ -131,7 +131,7 @@ func TestHandleIngest_RateLimit(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db))
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()

--- a/internal/docker/resources.go
+++ b/internal/docker/resources.go
@@ -1,7 +1,339 @@
 package docker
 
-// ResourcePoller polls CPU, memory, and disk usage from Docker containers.
-// Implementation deferred to T-17.
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	dockerclient "github.com/docker/docker/client"
+	"github.com/google/uuid"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// resourcePollerAPI is the minimal Docker API subset needed for resource polling,
+// enabling mock injection in tests.
+type resourcePollerAPI interface {
+	ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
+	ContainerStats(ctx context.Context, containerID string, stream bool) (container.StatsResponseReader, error)
+}
+
+// thresholdLevel represents a metric breach level.
+type thresholdLevel int
+
+const (
+	levelNormal thresholdLevel = iota
+	levelWarn
+	levelError
+)
+
+func (l thresholdLevel) String() string {
+	switch l {
+	case levelWarn:
+		return "warn"
+	case levelError:
+		return "error"
+	default:
+		return ""
+	}
+}
+
+// containerThresholdState tracks the last known threshold level for a container's metrics
+// so that events are only emitted on state transitions.
+type containerThresholdState struct {
+	cpu thresholdLevel
+	mem thresholdLevel
+}
+
+// ResourcePoller polls CPU and memory stats from all running Docker containers
+// every 60 seconds and writes readings to the resource_readings table.
+// Threshold crossings generate events.
 type ResourcePoller struct {
-	watcher *Watcher
+	store  *repo.Store
+	client resourcePollerAPI
+	state  sync.Map // containerID -> containerThresholdState
+}
+
+// NewResourcePoller creates a ResourcePoller connected to the Docker daemon.
+func NewResourcePoller(store *repo.Store) (*ResourcePoller, error) {
+	cli, err := dockerclient.NewClientWithOpts(
+		dockerclient.FromEnv,
+		dockerclient.WithAPIVersionNegotiation(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("docker client: %w", err)
+	}
+	return &ResourcePoller{store: store, client: cli}, nil
+}
+
+// newResourcePollerWithClient creates a ResourcePoller with an injected client (for tests).
+func newResourcePollerWithClient(store *repo.Store, cli resourcePollerAPI) *ResourcePoller {
+	return &ResourcePoller{store: store, client: cli}
+}
+
+// Start polls all running containers every 60 seconds until ctx is cancelled.
+func (p *ResourcePoller) Start(ctx context.Context) {
+	log.Printf("resource poller: starting")
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+
+	// Poll immediately on start, then on each tick.
+	p.pollAll(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("resource poller: stopped")
+			return
+		case <-ticker.C:
+			p.pollAll(ctx)
+		}
+	}
+}
+
+// pollAll lists running containers and calls PollContainer for each one.
+func (p *ResourcePoller) pollAll(ctx context.Context) {
+	containers, err := p.client.ContainerList(ctx, container.ListOptions{})
+	if err != nil {
+		log.Printf("resource poller: list containers: %v", err)
+		return
+	}
+
+	// Build a set of currently running container IDs so we can prune stale state.
+	running := make(map[string]struct{}, len(containers))
+	for _, c := range containers {
+		running[c.ID] = struct{}{}
+	}
+	// Remove threshold state for containers that are no longer running.
+	p.state.Range(func(key, _ any) bool {
+		if _, ok := running[key.(string)]; !ok {
+			p.state.Delete(key)
+		}
+		return true
+	})
+
+	// Resolve app IDs for running containers by matching container name → app name.
+	appIDs := p.resolveAppIDs(ctx, containers)
+
+	for _, c := range containers {
+		appID := appIDs[c.ID]
+		if err := p.PollContainer(ctx, c.ID, appID); err != nil {
+			log.Printf("resource poller: poll container %s: %v", c.ID[:12], err)
+		}
+	}
+}
+
+// resolveAppIDs returns a map of containerID → appID by matching container names
+// against app names (case-insensitive). Unmatched containers map to "".
+func (p *ResourcePoller) resolveAppIDs(ctx context.Context, containers []container.Summary) map[string]string {
+	apps, err := p.store.Apps.List(ctx)
+	if err != nil {
+		log.Printf("resource poller: list apps: %v", err)
+		return map[string]string{}
+	}
+
+	appByName := make(map[string]string, len(apps))
+	for _, a := range apps {
+		appByName[strings.ToLower(a.Name)] = a.ID
+	}
+
+	result := make(map[string]string, len(containers))
+	for _, c := range containers {
+		for _, name := range c.Names {
+			// Docker names have a leading "/" — strip it.
+			trimmed := strings.TrimPrefix(name, "/")
+			if id, ok := appByName[strings.ToLower(trimmed)]; ok {
+				result[c.ID] = id
+				break
+			}
+		}
+	}
+	return result
+}
+
+// PollContainer fetches one-shot stats for containerID, writes resource readings,
+// and emits threshold events on level transitions.
+func (p *ResourcePoller) PollContainer(ctx context.Context, containerID string, appID string) error {
+	resp, err := p.client.ContainerStats(ctx, containerID, false)
+	if err != nil {
+		return fmt.Errorf("container stats: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var stats container.StatsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
+		return fmt.Errorf("decode stats: %w", err)
+	}
+
+	cpuPct := calculateCPUPercent(
+		stats.CPUStats.CPUUsage.TotalUsage,
+		stats.PreCPUStats.CPUUsage.TotalUsage,
+		stats.CPUStats.SystemUsage,
+		stats.PreCPUStats.SystemUsage,
+		len(stats.CPUStats.CPUUsage.PercpuUsage),
+		int(stats.CPUStats.OnlineCPUs),
+	)
+	memPct := calculateMemPercent(stats.MemoryStats.Usage, stats.MemoryStats.Limit)
+	memBytes := float64(stats.MemoryStats.Usage)
+
+	now := time.Now().UTC()
+	sourceID := containerID
+	if appID != "" {
+		sourceID = appID
+	}
+
+	for _, m := range []struct {
+		metric string
+		value  float64
+	}{
+		{"cpu_percent", cpuPct},
+		{"mem_percent", memPct},
+		{"mem_bytes", memBytes},
+	} {
+		r := &models.ResourceReading{
+			ID:         uuid.New().String(),
+			SourceID:   sourceID,
+			SourceType: "docker_container",
+			Metric:     m.metric,
+			Value:      m.value,
+			RecordedAt: now,
+		}
+		if err := p.store.Resources.Create(ctx, r); err != nil {
+			log.Printf("resource poller: write reading %s: %v", m.metric, err)
+		}
+	}
+
+	// Resolve display name for event messages (strip leading "/").
+	shortID := containerID
+	if len(shortID) > 12 {
+		shortID = shortID[:12]
+	}
+	containerName := shortID
+	if len(stats.Name) > 0 {
+		containerName = strings.TrimPrefix(stats.Name, "/")
+	}
+
+	p.checkThresholds(ctx, containerID, appID, containerName, cpuPct, memPct, now)
+	return nil
+}
+
+// checkThresholds compares current metric levels against the last recorded state
+// and creates an event on each transition.
+func (p *ResourcePoller) checkThresholds(
+	ctx context.Context,
+	containerID, appID, containerName string,
+	cpuPct, memPct float64,
+	now time.Time,
+) {
+	prev := containerThresholdState{}
+	if v, ok := p.state.Load(containerID); ok {
+		prev = v.(containerThresholdState)
+	}
+
+	newCPU := thresholdFor(cpuPct)
+	newMem := thresholdFor(memPct)
+
+	if newCPU != prev.cpu {
+		p.emitThresholdEvent(ctx, appID, containerName, "CPU", cpuPct, prev.cpu, newCPU, now)
+	}
+	if newMem != prev.mem {
+		p.emitThresholdEvent(ctx, appID, containerName, "Memory", memPct, prev.mem, newMem, now)
+	}
+
+	p.state.Store(containerID, containerThresholdState{cpu: newCPU, mem: newMem})
+}
+
+// thresholdFor maps a percentage value to its threshold level.
+func thresholdFor(pct float64) thresholdLevel {
+	switch {
+	case pct > 95:
+		return levelError
+	case pct > 80:
+		return levelWarn
+	default:
+		return levelNormal
+	}
+}
+
+// emitThresholdEvent writes a single event for a metric threshold transition.
+func (p *ResourcePoller) emitThresholdEvent(
+	ctx context.Context,
+	appID, containerName, metric string,
+	pct float64,
+	from, to thresholdLevel,
+	now time.Time,
+) {
+	if p.store.Events == nil {
+		return
+	}
+
+	var severity, text string
+	switch to {
+	case levelError:
+		severity = "error"
+		text = fmt.Sprintf("High %s — %s: %.1f%%", metric, containerName, pct)
+	case levelWarn:
+		severity = "warn"
+		text = fmt.Sprintf("High %s — %s: %.1f%%", metric, containerName, pct)
+	case levelNormal:
+		// Recovery from a previous breach.
+		severity = "info"
+		prevSev := from.String()
+		text = fmt.Sprintf("%s recovered — %s: %.1f%% (was %s)", metric, containerName, pct, prevSev)
+	}
+
+	ev := &models.Event{
+		ID:          uuid.New().String(),
+		AppID:       appID,
+		ReceivedAt:  now,
+		Severity:    severity,
+		DisplayText: text,
+		RawPayload:  "{}",
+		Fields: fmt.Sprintf(
+			`{"source_type":"docker_container","metric":"%s","value":%.2f}`,
+			strings.ToLower(metric), pct,
+		),
+	}
+
+	if err := p.store.Events.Create(ctx, ev); err != nil {
+		log.Printf("resource poller: create threshold event: %v", err)
+	}
+}
+
+// calculateCPUPercent computes the CPU usage percentage from a pair of stat snapshots.
+// It follows the Docker documentation formula:
+//
+//	cpuDelta / systemDelta * numCPUs * 100
+func calculateCPUPercent(
+	totalUsage, prevTotalUsage,
+	systemUsage, prevSystemUsage uint64,
+	percpuLen, onlineCPUs int,
+) float64 {
+	cpuDelta := float64(totalUsage) - float64(prevTotalUsage)
+	systemDelta := float64(systemUsage) - float64(prevSystemUsage)
+	if systemDelta <= 0 || cpuDelta < 0 {
+		return 0
+	}
+	numCPUs := percpuLen
+	if numCPUs == 0 {
+		numCPUs = onlineCPUs
+	}
+	if numCPUs == 0 {
+		return 0
+	}
+	return (cpuDelta / systemDelta) * float64(numCPUs) * 100
+}
+
+// calculateMemPercent returns memory usage as a percentage of the container limit.
+func calculateMemPercent(usage, limit uint64) float64 {
+	if limit == 0 {
+		return 0
+	}
+	return (float64(usage) / float64(limit)) * 100
 }

--- a/internal/docker/resources_test.go
+++ b/internal/docker/resources_test.go
@@ -1,0 +1,367 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// --- mock resourcePollerAPI -----------------------------------------------
+
+type mockResourceClient struct {
+	containers []container.Summary
+	statsMap   map[string]container.StatsResponse
+	statsErr   error
+}
+
+func (m *mockResourceClient) ContainerList(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
+	return m.containers, nil
+}
+
+func (m *mockResourceClient) ContainerStats(_ context.Context, containerID string, _ bool) (container.StatsResponseReader, error) {
+	if m.statsErr != nil {
+		return container.StatsResponseReader{}, m.statsErr
+	}
+	stats := m.statsMap[containerID]
+	b, _ := json.Marshal(stats)
+	return container.StatsResponseReader{Body: io.NopCloser(strings.NewReader(string(b)))}, nil
+}
+
+// --- mock ResourceReadingRepo ---------------------------------------------
+
+type mockResourceReadingRepo struct {
+	readings []*models.ResourceReading
+}
+
+func (r *mockResourceReadingRepo) Create(_ context.Context, reading *models.ResourceReading) error {
+	r.readings = append(r.readings, reading)
+	return nil
+}
+
+// --- helpers --------------------------------------------------------------
+
+func newTestResourcePoller(appRepo repo.AppRepo, eventRepo repo.EventRepo, resRepo repo.ResourceReadingRepo, cli resourcePollerAPI) *ResourcePoller {
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo)
+	return newResourcePollerWithClient(store, cli)
+}
+
+func makeStats(totalCPU, prevTotalCPU, systemCPU, prevSystemCPU uint64, percpu []uint64, memUsage, memLimit uint64) container.StatsResponse {
+	return container.StatsResponse{
+		Name: "/test-container",
+		CPUStats: container.CPUStats{
+			CPUUsage: container.CPUUsage{
+				TotalUsage:  totalCPU,
+				PercpuUsage: percpu,
+			},
+			SystemUsage: systemCPU,
+		},
+		PreCPUStats: container.CPUStats{
+			CPUUsage: container.CPUUsage{
+				TotalUsage: prevTotalCPU,
+			},
+			SystemUsage: prevSystemCPU,
+		},
+		MemoryStats: container.MemoryStats{
+			Usage: memUsage,
+			Limit: memLimit,
+		},
+	}
+}
+
+// --- calculateCPUPercent tests -------------------------------------------
+
+func TestCalculateCPUPercent_Normal(t *testing.T) {
+	// Container consumed 250ms of one core on a 4-core 1-second window.
+	// cpuDelta=250_000_000  systemDelta=4_000_000_000  numCPUs=4
+	// result = (250_000_000 / 4_000_000_000) * 4 * 100 = 25%
+	got := calculateCPUPercent(250_000_000, 0, 4_000_000_000, 0, 4, 0)
+	if got != 25.0 {
+		t.Errorf("got %.4f, want 25.0", got)
+	}
+}
+
+func TestCalculateCPUPercent_FullCore(t *testing.T) {
+	// One full core on a 4-core system.
+	// systemDelta = 4e9 ns (system elapsed time across all 4 CPUs)
+	// cpuDelta    = 1e9 ns (container consumed one full core)
+	// result      = (1e9 / 4e9) * 4 * 100 = 100% (one core fully utilised)
+	got := calculateCPUPercent(1_000_000_000, 0, 4_000_000_000, 0, 4, 0)
+	if got != 100.0 {
+		t.Errorf("got %.4f, want 100.0", got)
+	}
+}
+
+func TestCalculateCPUPercent_ZeroSystemDelta(t *testing.T) {
+	got := calculateCPUPercent(100, 0, 0, 0, 4, 0)
+	if got != 0 {
+		t.Errorf("expected 0 on zero systemDelta, got %.4f", got)
+	}
+}
+
+func TestCalculateCPUPercent_FallbackOnlineCPUs(t *testing.T) {
+	// PercpuUsage empty; OnlineCPUs provides the count (same arithmetic as FullCore)
+	got := calculateCPUPercent(1_000_000_000, 0, 4_000_000_000, 0, 0, 4)
+	if got != 100.0 {
+		t.Errorf("got %.4f, want 100.0", got)
+	}
+}
+
+func TestCalculateCPUPercent_NoCPUInfo(t *testing.T) {
+	got := calculateCPUPercent(100, 0, 1000, 0, 0, 0)
+	if got != 0 {
+		t.Errorf("expected 0 when no CPU count info, got %.4f", got)
+	}
+}
+
+// --- calculateMemPercent tests -------------------------------------------
+
+func TestCalculateMemPercent_Normal(t *testing.T) {
+	got := calculateMemPercent(512*1024*1024, 1024*1024*1024) // 512 MB of 1 GB = 50%
+	if got != 50.0 {
+		t.Errorf("got %.4f, want 50.0", got)
+	}
+}
+
+func TestCalculateMemPercent_ZeroLimit(t *testing.T) {
+	got := calculateMemPercent(100, 0)
+	if got != 0 {
+		t.Errorf("expected 0 on zero limit, got %.4f", got)
+	}
+}
+
+func TestCalculateMemPercent_Full(t *testing.T) {
+	got := calculateMemPercent(1024, 1024)
+	if got != 100.0 {
+		t.Errorf("got %.4f, want 100.0", got)
+	}
+}
+
+// --- thresholdFor tests ---------------------------------------------------
+
+func TestThresholdFor(t *testing.T) {
+	tests := []struct {
+		pct  float64
+		want thresholdLevel
+	}{
+		{0, levelNormal},
+		{80, levelNormal},
+		{80.1, levelWarn},
+		{95, levelWarn},
+		{95.1, levelError},
+		{100, levelError},
+	}
+	for _, tc := range tests {
+		got := thresholdFor(tc.pct)
+		if got != tc.want {
+			t.Errorf("thresholdFor(%.1f) = %v, want %v", tc.pct, got, tc.want)
+		}
+	}
+}
+
+// --- PollContainer tests --------------------------------------------------
+
+func TestPollContainer_WritesThreeReadings(t *testing.T) {
+	resRepo := &mockResourceReadingRepo{}
+	evRepo := &mockEventRepo{}
+	cli := &mockResourceClient{
+		statsMap: map[string]container.StatsResponse{
+			"ctr1": makeStats(250_000_000, 0, 4_000_000_000, 0, []uint64{0, 0, 0, 0}, 512*1024*1024, 1024*1024*1024),
+		},
+	}
+
+	p := newTestResourcePoller(&mockAppRepo{}, evRepo, resRepo, cli)
+
+	if err := p.PollContainer(context.Background(), "ctr1", "app-1"); err != nil {
+		t.Fatalf("PollContainer: %v", err)
+	}
+
+	if len(resRepo.readings) != 3 {
+		t.Fatalf("expected 3 readings (cpu_percent, mem_percent, mem_bytes), got %d", len(resRepo.readings))
+	}
+
+	metrics := make(map[string]float64)
+	for _, r := range resRepo.readings {
+		metrics[r.Metric] = r.Value
+		if r.SourceType != "docker_container" {
+			t.Errorf("SourceType: got %q, want %q", r.SourceType, "docker_container")
+		}
+		if r.SourceID != "app-1" {
+			t.Errorf("SourceID: got %q, want %q (should use appID when set)", r.SourceID, "app-1")
+		}
+	}
+
+	for _, metric := range []string{"cpu_percent", "mem_percent", "mem_bytes"} {
+		if _, ok := metrics[metric]; !ok {
+			t.Errorf("missing reading for metric %q", metric)
+		}
+	}
+}
+
+func TestPollContainer_SourceIDIsContainerIDWhenNoApp(t *testing.T) {
+	resRepo := &mockResourceReadingRepo{}
+	cli := &mockResourceClient{
+		statsMap: map[string]container.StatsResponse{
+			"ctr1": makeStats(0, 0, 1000, 0, []uint64{0}, 0, 1024),
+		},
+	}
+
+	p := newTestResourcePoller(&mockAppRepo{}, &mockEventRepo{}, resRepo, cli)
+	if err := p.PollContainer(context.Background(), "ctr1", ""); err != nil {
+		t.Fatalf("PollContainer: %v", err)
+	}
+
+	for _, r := range resRepo.readings {
+		if r.SourceID != "ctr1" {
+			t.Errorf("expected SourceID %q (container ID), got %q", "ctr1", r.SourceID)
+		}
+	}
+}
+
+// --- threshold transition tests ------------------------------------------
+
+func TestThreshold_NormalToWarnCreatesOneEvent(t *testing.T) {
+	evRepo := &mockEventRepo{}
+	resRepo := &mockResourceReadingRepo{}
+	cli := &mockResourceClient{
+		statsMap: map[string]container.StatsResponse{
+			// CPU 85% (warn), memory 50% (normal)
+			"ctr1": makeStats(850_000_000, 0, 1_000_000_000, 0, []uint64{0}, 512*1024*1024, 1024*1024*1024),
+		},
+	}
+
+	p := newTestResourcePoller(&mockAppRepo{}, evRepo, resRepo, cli)
+	if err := p.PollContainer(context.Background(), "ctr1", ""); err != nil {
+		t.Fatalf("PollContainer: %v", err)
+	}
+
+	if len(evRepo.created) != 1 {
+		t.Fatalf("expected 1 threshold event, got %d", len(evRepo.created))
+	}
+	ev := evRepo.created[0]
+	if ev.Severity != "warn" {
+		t.Errorf("Severity: got %q, want %q", ev.Severity, "warn")
+	}
+	if !strings.Contains(ev.DisplayText, "CPU") {
+		t.Errorf("DisplayText should mention CPU, got %q", ev.DisplayText)
+	}
+}
+
+func TestThreshold_NoEventOnSecondPollSameLevel(t *testing.T) {
+	evRepo := &mockEventRepo{}
+	resRepo := &mockResourceReadingRepo{}
+	cli := &mockResourceClient{
+		statsMap: map[string]container.StatsResponse{
+			"ctr1": makeStats(850_000_000, 0, 1_000_000_000, 0, []uint64{0}, 512*1024*1024, 1024*1024*1024),
+		},
+	}
+
+	p := newTestResourcePoller(&mockAppRepo{}, evRepo, resRepo, cli)
+	_ = p.PollContainer(context.Background(), "ctr1", "")
+	_ = p.PollContainer(context.Background(), "ctr1", "")
+
+	if len(evRepo.created) != 1 {
+		t.Errorf("expected exactly 1 event (no storm on sustained threshold), got %d", len(evRepo.created))
+	}
+}
+
+func TestThreshold_WarnToErrorCreatesEvent(t *testing.T) {
+	evRepo := &mockEventRepo{}
+	resRepo := &mockResourceReadingRepo{}
+	cli := &mockResourceClient{
+		statsMap: map[string]container.StatsResponse{
+			"ctr1": makeStats(850_000_000, 0, 1_000_000_000, 0, []uint64{0}, 0, 1024),
+		},
+	}
+
+	p := newTestResourcePoller(&mockAppRepo{}, evRepo, resRepo, cli)
+	_ = p.PollContainer(context.Background(), "ctr1", "") // warn
+
+	cli.statsMap["ctr1"] = makeStats(980_000_000, 0, 1_000_000_000, 0, []uint64{0}, 0, 1024)
+	_ = p.PollContainer(context.Background(), "ctr1", "") // error
+
+	if len(evRepo.created) != 2 {
+		t.Fatalf("expected 2 events (warn + error transition), got %d", len(evRepo.created))
+	}
+	if evRepo.created[1].Severity != "error" {
+		t.Errorf("second event Severity: got %q, want error", evRepo.created[1].Severity)
+	}
+}
+
+func TestThreshold_RecoveryCreatesInfoEvent(t *testing.T) {
+	evRepo := &mockEventRepo{}
+	resRepo := &mockResourceReadingRepo{}
+	cli := &mockResourceClient{
+		statsMap: map[string]container.StatsResponse{
+			"ctr1": makeStats(850_000_000, 0, 1_000_000_000, 0, []uint64{0}, 0, 1024),
+		},
+	}
+
+	p := newTestResourcePoller(&mockAppRepo{}, evRepo, resRepo, cli)
+	_ = p.PollContainer(context.Background(), "ctr1", "") // warn
+
+	cli.statsMap["ctr1"] = makeStats(500_000_000, 0, 1_000_000_000, 0, []uint64{0}, 0, 1024)
+	_ = p.PollContainer(context.Background(), "ctr1", "") // normal (recovery)
+
+	if len(evRepo.created) != 2 {
+		t.Fatalf("expected 2 events (warn + recovery), got %d", len(evRepo.created))
+	}
+	recovery := evRepo.created[1]
+	if recovery.Severity != "info" {
+		t.Errorf("recovery event Severity: got %q, want info", recovery.Severity)
+	}
+	if !strings.Contains(recovery.DisplayText, "recovered") {
+		t.Errorf("recovery DisplayText should contain 'recovered', got %q", recovery.DisplayText)
+	}
+}
+
+func TestPollContainer_MissingContainerReturnsError(t *testing.T) {
+	cli := &mockResourceClient{statsErr: errors.New("No such container: missing")}
+	p := newTestResourcePoller(&mockAppRepo{}, &mockEventRepo{}, &mockResourceReadingRepo{}, cli)
+
+	err := p.PollContainer(context.Background(), "missing", "")
+	if err == nil {
+		t.Error("expected error for missing container, got nil")
+	}
+}
+
+// --- pollAll tests --------------------------------------------------------
+
+func TestPollAll_CleansUpStaleState(t *testing.T) {
+	evRepo := &mockEventRepo{}
+	resRepo := &mockResourceReadingRepo{}
+	cli := &mockResourceClient{
+		containers: []container.Summary{
+			{ID: "ctr1", Names: []string{"/app1"}},
+			{ID: "ctr2", Names: []string{"/app2"}},
+		},
+		statsMap: map[string]container.StatsResponse{
+			"ctr1": makeStats(850_000_000, 0, 1_000_000_000, 0, []uint64{0}, 0, 1024),
+			"ctr2": makeStats(850_000_000, 0, 1_000_000_000, 0, []uint64{0}, 0, 1024),
+		},
+	}
+	p := newTestResourcePoller(&mockAppRepo{}, evRepo, resRepo, cli)
+	p.pollAll(context.Background())
+
+	if _, ok := p.state.Load("ctr1"); !ok {
+		t.Error("expected state for ctr1")
+	}
+	if _, ok := p.state.Load("ctr2"); !ok {
+		t.Error("expected state for ctr2")
+	}
+
+	// ctr2 disappears
+	cli.containers = []container.Summary{{ID: "ctr1", Names: []string{"/app1"}}}
+	p.pollAll(context.Background())
+
+	if _, ok := p.state.Load("ctr2"); ok {
+		t.Error("expected stale state for ctr2 to be cleaned up after it stopped running")
+	}
+}

--- a/internal/docker/watcher_test.go
+++ b/internal/docker/watcher_test.go
@@ -78,7 +78,7 @@ func (r *mockEventRepo) LatestPerApp(_ context.Context, _ []string) (map[string]
 // --- helpers -------------------------------------------------------------
 
 func newTestWatcher(appRepo repo.AppRepo, eventRepo repo.EventRepo, dc dockerAPI) *Watcher {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil)
 	return &Watcher{store: store, client: dc}
 }
 

--- a/internal/ingest/pipeline_test.go
+++ b/internal/ingest/pipeline_test.go
@@ -24,7 +24,7 @@ func newTestStore(t *testing.T) *repo.Store {
 	t.Cleanup(func() { db.Close() })
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db))
+	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil)
 }
 
 func seedApp(t *testing.T, store *repo.Store, token string, rateLimit int) models.App {

--- a/internal/models/resource.go
+++ b/internal/models/resource.go
@@ -1,0 +1,13 @@
+package models
+
+import "time"
+
+// ResourceReading is a single metric sample from a Docker container, host, or VM.
+type ResourceReading struct {
+	ID         string    `db:"id"`
+	SourceID   string    `db:"source_id"`
+	SourceType string    `db:"source_type"`
+	Metric     string    `db:"metric"`
+	Value      float64   `db:"value"`
+	RecordedAt time.Time `db:"recorded_at"`
+}

--- a/internal/repo/resources.go
+++ b/internal/repo/resources.go
@@ -1,0 +1,35 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/jmoiron/sqlx"
+)
+
+// ResourceReadingRepo defines write operations for the resource_readings table.
+type ResourceReadingRepo interface {
+	// Create persists a single resource metric reading.
+	Create(ctx context.Context, r *models.ResourceReading) error
+}
+
+type sqliteResourceReadingRepo struct {
+	db *sqlx.DB
+}
+
+// NewResourceReadingRepo returns a ResourceReadingRepo backed by the given SQLite database.
+func NewResourceReadingRepo(db *sqlx.DB) ResourceReadingRepo {
+	return &sqliteResourceReadingRepo{db: db}
+}
+
+func (r *sqliteResourceReadingRepo) Create(ctx context.Context, reading *models.ResourceReading) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO resource_readings (id, source_id, source_type, metric, value, recorded_at)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		reading.ID, reading.SourceID, reading.SourceType, reading.Metric, reading.Value, reading.RecordedAt)
+	if err != nil {
+		return fmt.Errorf("create resource reading: %w", err)
+	}
+	return nil
+}

--- a/internal/repo/store.go
+++ b/internal/repo/store.go
@@ -2,13 +2,14 @@ package repo
 
 // Store bundles all repository interfaces into a single dependency.
 type Store struct {
-	Apps    AppRepo
-	Events  EventRepo
-	Checks  CheckRepo
-	Rollups RollupRepo
+	Apps      AppRepo
+	Events    EventRepo
+	Checks    CheckRepo
+	Rollups   RollupRepo
+	Resources ResourceReadingRepo
 }
 
 // NewStore creates a Store backed by the given repositories.
-func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRepo) *Store {
-	return &Store{Apps: apps, Events: events, Checks: checks, Rollups: rollups}
+func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRepo, resources ResourceReadingRepo) *Store {
+	return &Store{Apps: apps, Events: events, Checks: checks, Rollups: rollups, Resources: resources}
 }


### PR DESCRIPTION
## What
Implements `ResourcePoller` which polls CPU, memory, and memory-bytes readings from all running Docker containers every 60 seconds and writes them to `resource_readings`. Threshold crossings create events; recovery from threshold also creates one event.

## Why
Closes #17. Provides the resource metric data layer that the dashboard and alerts will consume.

## How
- **`internal/models/resource.go`** — `ResourceReading` model (maps to existing `resource_readings` table from migration 001).
- **`internal/repo/resources.go`** — `ResourceReadingRepo` interface + SQLite implementation.
- **`internal/repo/store.go`** — added `Resources ResourceReadingRepo` field; updated `NewStore` signature.
- **`internal/docker/resources.go`** — `ResourcePoller` with:
  - `resourcePollerAPI` interface enabling mock injection in tests.
  - `Start` — 60 s ticker loop; polls immediately on startup.
  - `pollAll` — lists running containers, resolves app IDs by case-insensitive name match, prunes stale threshold state for stopped containers.
  - `PollContainer` — one-shot stats fetch, CPU/memory calculation, writes 3 readings per container (`cpu_percent`, `mem_percent`, `mem_bytes`), calls `checkThresholds`.
  - `checkThresholds` + `emitThresholdEvent` — transition-only event generation via `sync.Map`; states are `normal / warn / error`; recovery produces an `info` event.
- **`cmd/nora/main.go`** — wires up `ResourceReadingRepo` and starts `ResourcePoller` alongside the existing Docker watcher (same `dockerCtx`).

CPU formula follows the Docker documentation:
```
cpuDelta / systemDelta * numCPUs * 100
```
where 100% = one full core fully utilised.

## Test coverage
- `calculateCPUPercent`: normal load, full core (100%), zero system delta, fallback to `OnlineCPUs`, no CPU info.
- `calculateMemPercent`: normal, zero limit, full.
- `thresholdFor`: boundary values at 80% and 95%.
- `PollContainer`: writes 3 readings, uses container ID as source when no app matched.
- Threshold transitions: normal→warn, no storm on sustained level, warn→error, error→normal (recovery info event).
- `pollAll`: stale `sync.Map` entries cleaned up when container stops.

## Closes
Closes #17