### PR TITLE
feat: T-18 Topology CRUD API

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -39,7 +39,10 @@ func main() {
 	checkRepo := repo.NewCheckRepo(db)
 	rollupRepo := repo.NewRollupRepo(db)
 	resourceRepo := repo.NewResourceReadingRepo(db)
-	store := repo.NewStore(appRepo, eventRepo, checkRepo, rollupRepo, resourceRepo)
+	physicalHostRepo := repo.NewPhysicalHostRepo(db)
+	virtualHostRepo := repo.NewVirtualHostRepo(db)
+	dockerEngineRepo := repo.NewDockerEngineRepo(db)
+	store := repo.NewStore(appRepo, eventRepo, checkRepo, rollupRepo, resourceRepo, physicalHostRepo, virtualHostRepo, dockerEngineRepo)
 
 	// Profile registry — load all bundled YAML profiles
 	registry, err := profile.NewRegistry(noraprofiles.Files)
@@ -85,6 +88,7 @@ func main() {
 		api.NewEventsHandler(eventRepo).Routes(r)
 		api.NewChecksHandler(checkRepo, eventRepo).Routes(r)
 		api.NewDashboardHandler(appRepo, eventRepo, checkRepo, rollupRepo, registry).Routes(r)
+		api.NewTopologyHandler(physicalHostRepo, virtualHostRepo, dockerEngineRepo, appRepo).Routes(r)
 	})
 
 	// Frontend — serve embedded React app, SPA fallback to index.html

--- a/internal/api/ingest_test.go
+++ b/internal/api/ingest_test.go
@@ -21,7 +21,7 @@ func newIngestRouter(t *testing.T) (http.Handler, *repo.Store) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil)
+	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 	profiler := &profile.NoopLoader{}
 
@@ -44,7 +44,7 @@ func TestHandleIngest_HappyPath(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()
@@ -131,7 +131,7 @@ func TestHandleIngest_RateLimit(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()

--- a/internal/api/topology.go
+++ b/internal/api/topology.go
@@ -1,0 +1,656 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// TopologyHandler holds dependencies for all topology endpoints.
+type TopologyHandler struct {
+	physicalHosts repo.PhysicalHostRepo
+	virtualHosts  repo.VirtualHostRepo
+	dockerEngines repo.DockerEngineRepo
+	apps          repo.AppRepo
+}
+
+// NewTopologyHandler creates a TopologyHandler.
+func NewTopologyHandler(ph repo.PhysicalHostRepo, vh repo.VirtualHostRepo, de repo.DockerEngineRepo, apps repo.AppRepo) *TopologyHandler {
+	return &TopologyHandler{
+		physicalHosts: ph,
+		virtualHosts:  vh,
+		dockerEngines: de,
+		apps:          apps,
+	}
+}
+
+// Routes registers all topology endpoints on r.
+func (h *TopologyHandler) Routes(r chi.Router) {
+	// Physical hosts
+	r.Get("/hosts/physical", h.ListPhysical)
+	r.Post("/hosts/physical", h.CreatePhysical)
+	r.Get("/hosts/physical/{id}", h.GetPhysical)
+	r.Put("/hosts/physical/{id}", h.UpdatePhysical)
+	r.Delete("/hosts/physical/{id}", h.DeletePhysical)
+
+	// Virtual hosts
+	r.Get("/hosts/virtual", h.ListVirtual)
+	r.Post("/hosts/virtual", h.CreateVirtual)
+	r.Get("/hosts/virtual/{id}", h.GetVirtual)
+	r.Put("/hosts/virtual/{id}", h.UpdateVirtual)
+	r.Delete("/hosts/virtual/{id}", h.DeleteVirtual)
+
+	// Docker engines
+	r.Get("/docker-engines", h.ListDockerEngines)
+	r.Post("/docker-engines", h.CreateDockerEngine)
+	r.Get("/docker-engines/{id}", h.GetDockerEngine)
+	r.Put("/docker-engines/{id}", h.UpdateDockerEngine)
+	r.Delete("/docker-engines/{id}", h.DeleteDockerEngine)
+
+	// Full topology chain
+	r.Get("/topology", h.GetTopology)
+}
+
+// ---- request / response types -----------------------------------------------
+
+type physicalHostRequest struct {
+	Name  string `json:"name"`
+	IP    string `json:"ip"`
+	Type  string `json:"type"`
+	Notes string `json:"notes"`
+}
+
+type physicalHostResponse struct {
+	models.PhysicalHost
+	VirtualHostIDs []string `json:"virtual_hosts"`
+}
+
+type virtualHostRequest struct {
+	Name           string `json:"name"`
+	IP             string `json:"ip"`
+	Type           string `json:"type"`
+	PhysicalHostID string `json:"physical_host_id"`
+}
+
+type virtualHostResponse struct {
+	models.VirtualHost
+	DockerEngineIDs []string `json:"docker_engines"`
+}
+
+type dockerEngineRequest struct {
+	Name          string `json:"name"`
+	SocketType    string `json:"socket_type"`
+	SocketPath    string `json:"socket_path"`
+	VirtualHostID string `json:"virtual_host_id"`
+}
+
+// topology chain response types
+
+type topologyApp struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type topologyEngine struct {
+	ID            string        `json:"id"`
+	Name          string        `json:"name"`
+	DockerEngines []topologyApp `json:"apps"`
+}
+
+type topologyVirtualHost struct {
+	ID            string           `json:"id"`
+	Name          string           `json:"name"`
+	DockerEngines []topologyEngine `json:"docker_engines"`
+}
+
+type topologyPhysicalHost struct {
+	ID           string                `json:"id"`
+	Name         string                `json:"name"`
+	Type         string                `json:"type"`
+	VirtualHosts []topologyVirtualHost `json:"virtual_hosts"`
+}
+
+// ---- validation helpers -----------------------------------------------------
+
+var validPhysicalTypes = map[string]bool{"bare_metal": true, "proxmox_node": true}
+var validVirtualTypes = map[string]bool{"vm": true, "lxc": true, "wsl": true}
+var validSocketTypes = map[string]bool{"local": true, "remote_proxy": true}
+
+// ---- physical host handlers -------------------------------------------------
+
+// ListPhysical returns all physical hosts with nested virtual host IDs.
+// GET /api/v1/hosts/physical
+func (h *TopologyHandler) ListPhysical(w http.ResponseWriter, r *http.Request) {
+	hosts, err := h.physicalHosts.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	vhosts, err := h.virtualHosts.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Group virtual host IDs by physical_host_id.
+	vByPhysical := make(map[string][]string)
+	for _, v := range vhosts {
+		if v.PhysicalHostID != "" {
+			vByPhysical[v.PhysicalHostID] = append(vByPhysical[v.PhysicalHostID], v.ID)
+		}
+	}
+
+	result := make([]physicalHostResponse, 0, len(hosts))
+	for _, ph := range hosts {
+		ids := vByPhysical[ph.ID]
+		if ids == nil {
+			ids = []string{}
+		}
+		result = append(result, physicalHostResponse{PhysicalHost: ph, VirtualHostIDs: ids})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": result, "total": len(result)})
+}
+
+// CreatePhysical creates a physical host.
+// POST /api/v1/hosts/physical
+func (h *TopologyHandler) CreatePhysical(w http.ResponseWriter, r *http.Request) {
+	var req physicalHostRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if req.IP == "" {
+		writeError(w, http.StatusBadRequest, "ip is required")
+		return
+	}
+	if !validPhysicalTypes[req.Type] {
+		writeError(w, http.StatusBadRequest, "type must be bare_metal or proxmox_node")
+		return
+	}
+
+	host := &models.PhysicalHost{
+		ID:        uuid.New().String(),
+		Name:      req.Name,
+		IP:        req.IP,
+		Type:      req.Type,
+		Notes:     req.Notes,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := h.physicalHosts.Create(r.Context(), host); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, host)
+}
+
+// GetPhysical returns a single physical host.
+// GET /api/v1/hosts/physical/{id}
+func (h *TopologyHandler) GetPhysical(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	host, err := h.physicalHosts.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "physical host not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, host)
+}
+
+// UpdatePhysical replaces mutable fields on a physical host.
+// PUT /api/v1/hosts/physical/{id}
+func (h *TopologyHandler) UpdatePhysical(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	existing, err := h.physicalHosts.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "physical host not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var req physicalHostRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Type != "" && !validPhysicalTypes[req.Type] {
+		writeError(w, http.StatusBadRequest, "type must be bare_metal or proxmox_node")
+		return
+	}
+
+	if req.Name != "" {
+		existing.Name = req.Name
+	}
+	if req.IP != "" {
+		existing.IP = req.IP
+	}
+	if req.Type != "" {
+		existing.Type = req.Type
+	}
+	existing.Notes = req.Notes
+
+	if err := h.physicalHosts.Update(r.Context(), existing); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, existing)
+}
+
+// DeletePhysical removes a physical host (virtual hosts are SET NULL, not cascaded).
+// DELETE /api/v1/hosts/physical/{id}
+func (h *TopologyHandler) DeletePhysical(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := h.physicalHosts.Delete(r.Context(), id); errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "physical host not found")
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ---- virtual host handlers --------------------------------------------------
+
+// ListVirtual returns all virtual hosts with nested docker engine IDs.
+// GET /api/v1/hosts/virtual
+func (h *TopologyHandler) ListVirtual(w http.ResponseWriter, r *http.Request) {
+	hosts, err := h.virtualHosts.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	engines, err := h.dockerEngines.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Group docker engine IDs by virtual_host_id.
+	deByVirtual := make(map[string][]string)
+	for _, e := range engines {
+		if e.VirtualHostID != "" {
+			deByVirtual[e.VirtualHostID] = append(deByVirtual[e.VirtualHostID], e.ID)
+		}
+	}
+
+	result := make([]virtualHostResponse, 0, len(hosts))
+	for _, vh := range hosts {
+		ids := deByVirtual[vh.ID]
+		if ids == nil {
+			ids = []string{}
+		}
+		result = append(result, virtualHostResponse{VirtualHost: vh, DockerEngineIDs: ids})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": result, "total": len(result)})
+}
+
+// CreateVirtual creates a virtual host.
+// POST /api/v1/hosts/virtual
+func (h *TopologyHandler) CreateVirtual(w http.ResponseWriter, r *http.Request) {
+	var req virtualHostRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if req.IP == "" {
+		writeError(w, http.StatusBadRequest, "ip is required")
+		return
+	}
+	if !validVirtualTypes[req.Type] {
+		writeError(w, http.StatusBadRequest, "type must be vm, lxc, or wsl")
+		return
+	}
+
+	// Validate FK if provided.
+	if req.PhysicalHostID != "" {
+		if _, err := h.physicalHosts.Get(r.Context(), req.PhysicalHostID); errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusUnprocessableEntity, "physical_host_id not found")
+			return
+		} else if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+
+	host := &models.VirtualHost{
+		ID:             uuid.New().String(),
+		PhysicalHostID: req.PhysicalHostID,
+		Name:           req.Name,
+		IP:             req.IP,
+		Type:           req.Type,
+		CreatedAt:      time.Now().UTC(),
+	}
+	if err := h.virtualHosts.Create(r.Context(), host); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, host)
+}
+
+// GetVirtual returns a single virtual host.
+// GET /api/v1/hosts/virtual/{id}
+func (h *TopologyHandler) GetVirtual(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	host, err := h.virtualHosts.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "virtual host not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, host)
+}
+
+// UpdateVirtual replaces mutable fields on a virtual host.
+// PUT /api/v1/hosts/virtual/{id}
+func (h *TopologyHandler) UpdateVirtual(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	existing, err := h.virtualHosts.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "virtual host not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var req virtualHostRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Type != "" && !validVirtualTypes[req.Type] {
+		writeError(w, http.StatusBadRequest, "type must be vm, lxc, or wsl")
+		return
+	}
+	if req.PhysicalHostID != "" {
+		if _, err := h.physicalHosts.Get(r.Context(), req.PhysicalHostID); errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusUnprocessableEntity, "physical_host_id not found")
+			return
+		} else if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+
+	if req.Name != "" {
+		existing.Name = req.Name
+	}
+	if req.IP != "" {
+		existing.IP = req.IP
+	}
+	if req.Type != "" {
+		existing.Type = req.Type
+	}
+	existing.PhysicalHostID = req.PhysicalHostID
+
+	if err := h.virtualHosts.Update(r.Context(), existing); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, existing)
+}
+
+// DeleteVirtual removes a virtual host.
+// DELETE /api/v1/hosts/virtual/{id}
+func (h *TopologyHandler) DeleteVirtual(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := h.virtualHosts.Delete(r.Context(), id); errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "virtual host not found")
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ---- docker engine handlers -------------------------------------------------
+
+// ListDockerEngines returns all docker engines.
+// GET /api/v1/docker-engines
+func (h *TopologyHandler) ListDockerEngines(w http.ResponseWriter, r *http.Request) {
+	engines, err := h.dockerEngines.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if engines == nil {
+		engines = []models.DockerEngine{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"data": engines, "total": len(engines)})
+}
+
+// CreateDockerEngine creates a docker engine.
+// POST /api/v1/docker-engines
+func (h *TopologyHandler) CreateDockerEngine(w http.ResponseWriter, r *http.Request) {
+	var req dockerEngineRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if !validSocketTypes[req.SocketType] {
+		writeError(w, http.StatusBadRequest, "socket_type must be local or remote_proxy")
+		return
+	}
+	if req.SocketPath == "" {
+		writeError(w, http.StatusBadRequest, "socket_path is required")
+		return
+	}
+
+	// Validate FK if provided.
+	if req.VirtualHostID != "" {
+		if _, err := h.virtualHosts.Get(r.Context(), req.VirtualHostID); errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusUnprocessableEntity, "virtual_host_id not found")
+			return
+		} else if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+
+	engine := &models.DockerEngine{
+		ID:            uuid.New().String(),
+		VirtualHostID: req.VirtualHostID,
+		Name:          req.Name,
+		SocketType:    req.SocketType,
+		SocketPath:    req.SocketPath,
+		CreatedAt:     time.Now().UTC(),
+	}
+	if err := h.dockerEngines.Create(r.Context(), engine); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, engine)
+}
+
+// GetDockerEngine returns a single docker engine.
+// GET /api/v1/docker-engines/{id}
+func (h *TopologyHandler) GetDockerEngine(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	engine, err := h.dockerEngines.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "docker engine not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, engine)
+}
+
+// UpdateDockerEngine replaces mutable fields on a docker engine.
+// PUT /api/v1/docker-engines/{id}
+func (h *TopologyHandler) UpdateDockerEngine(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	existing, err := h.dockerEngines.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "docker engine not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var req dockerEngineRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.SocketType != "" && !validSocketTypes[req.SocketType] {
+		writeError(w, http.StatusBadRequest, "socket_type must be local or remote_proxy")
+		return
+	}
+	if req.VirtualHostID != "" {
+		if _, err := h.virtualHosts.Get(r.Context(), req.VirtualHostID); errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusUnprocessableEntity, "virtual_host_id not found")
+			return
+		} else if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+
+	if req.Name != "" {
+		existing.Name = req.Name
+	}
+	if req.SocketType != "" {
+		existing.SocketType = req.SocketType
+	}
+	if req.SocketPath != "" {
+		existing.SocketPath = req.SocketPath
+	}
+	existing.VirtualHostID = req.VirtualHostID
+
+	if err := h.dockerEngines.Update(r.Context(), existing); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, existing)
+}
+
+// DeleteDockerEngine removes a docker engine.
+// DELETE /api/v1/docker-engines/{id}
+func (h *TopologyHandler) DeleteDockerEngine(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := h.dockerEngines.Delete(r.Context(), id); errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "docker engine not found")
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ---- full topology chain ----------------------------------------------------
+
+// GetTopology returns the full physical → virtual → docker → app chain.
+// GET /api/v1/topology
+func (h *TopologyHandler) GetTopology(w http.ResponseWriter, r *http.Request) {
+	physHosts, err := h.physicalHosts.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	virtHosts, err := h.virtualHosts.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	engines, err := h.dockerEngines.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	allApps, err := h.apps.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Index apps by docker_engine_id.
+	appsByEngine := make(map[string][]topologyApp)
+	for _, a := range allApps {
+		if a.DockerEngineID != "" {
+			appsByEngine[a.DockerEngineID] = append(appsByEngine[a.DockerEngineID], topologyApp{ID: a.ID, Name: a.Name})
+		}
+	}
+
+	// Index engines by virtual_host_id.
+	enginesByVirtual := make(map[string][]topologyEngine)
+	for _, e := range engines {
+		apps := appsByEngine[e.ID]
+		if apps == nil {
+			apps = []topologyApp{}
+		}
+		enginesByVirtual[e.VirtualHostID] = append(enginesByVirtual[e.VirtualHostID], topologyEngine{
+			ID:            e.ID,
+			Name:          e.Name,
+			DockerEngines: apps,
+		})
+	}
+
+	// Index virtual hosts by physical_host_id.
+	virtByPhysical := make(map[string][]topologyVirtualHost)
+	for _, v := range virtHosts {
+		des := enginesByVirtual[v.ID]
+		if des == nil {
+			des = []topologyEngine{}
+		}
+		virtByPhysical[v.PhysicalHostID] = append(virtByPhysical[v.PhysicalHostID], topologyVirtualHost{
+			ID:            v.ID,
+			Name:          v.Name,
+			DockerEngines: des,
+		})
+	}
+
+	result := make([]topologyPhysicalHost, 0, len(physHosts))
+	for _, p := range physHosts {
+		vhs := virtByPhysical[p.ID]
+		if vhs == nil {
+			vhs = []topologyVirtualHost{}
+		}
+		result = append(result, topologyPhysicalHost{
+			ID:           p.ID,
+			Name:         p.Name,
+			Type:         p.Type,
+			VirtualHosts: vhs,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}

--- a/internal/api/topology_test.go
+++ b/internal/api/topology_test.go
@@ -1,0 +1,522 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/digitalcheffe/nora/internal/api"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+)
+
+// newTopologyRouter wires a TopologyHandler onto a chi router using a real in-memory DB.
+func newTopologyRouter(t *testing.T) http.Handler {
+	t.Helper()
+	db := newTestDB(t)
+	ph := repo.NewPhysicalHostRepo(db)
+	vh := repo.NewVirtualHostRepo(db)
+	de := repo.NewDockerEngineRepo(db)
+	apps := repo.NewAppRepo(db)
+	h := api.NewTopologyHandler(ph, vh, de, apps)
+	r := chi.NewRouter()
+	h.Routes(r)
+	return r
+}
+
+// helpers
+
+func createPhysicalHost(t *testing.T, router http.Handler, name, ip, hostType string) models.PhysicalHost {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{"name": name, "ip": ip, "type": hostType})
+	req := httptest.NewRequest(http.MethodPost, "/hosts/physical", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("createPhysicalHost: expected 201 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var h models.PhysicalHost
+	if err := json.NewDecoder(rr.Body).Decode(&h); err != nil {
+		t.Fatalf("createPhysicalHost decode: %v", err)
+	}
+	return h
+}
+
+func createVirtualHost(t *testing.T, router http.Handler, name, ip, hostType, physicalHostID string) models.VirtualHost {
+	t.Helper()
+	payload := map[string]any{"name": name, "ip": ip, "type": hostType}
+	if physicalHostID != "" {
+		payload["physical_host_id"] = physicalHostID
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/hosts/virtual", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("createVirtualHost: expected 201 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var h models.VirtualHost
+	if err := json.NewDecoder(rr.Body).Decode(&h); err != nil {
+		t.Fatalf("createVirtualHost decode: %v", err)
+	}
+	return h
+}
+
+func createDockerEngine(t *testing.T, router http.Handler, name, socketType, socketPath, virtualHostID string) models.DockerEngine {
+	t.Helper()
+	payload := map[string]any{"name": name, "socket_type": socketType, "socket_path": socketPath}
+	if virtualHostID != "" {
+		payload["virtual_host_id"] = virtualHostID
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/docker-engines", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("createDockerEngine: expected 201 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var e models.DockerEngine
+	if err := json.NewDecoder(rr.Body).Decode(&e); err != nil {
+		t.Fatalf("createDockerEngine decode: %v", err)
+	}
+	return e
+}
+
+// ---- PhysicalHost CRUD -------------------------------------------------------
+
+func TestListPhysicalHosts_Empty(t *testing.T) {
+	router := newTopologyRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/hosts/physical", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	var resp struct {
+		Data  []any `json:"data"`
+		Total int   `json:"total"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.Total != 0 {
+		t.Errorf("expected total=0 got %d", resp.Total)
+	}
+}
+
+func TestCreatePhysicalHost_HappyPath(t *testing.T) {
+	router := newTopologyRouter(t)
+	h := createPhysicalHost(t, router, "proxmox-node1", "192.168.1.10", "proxmox_node")
+	if h.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if h.Name != "proxmox-node1" {
+		t.Errorf("expected name=proxmox-node1 got %q", h.Name)
+	}
+}
+
+func TestCreatePhysicalHost_InvalidType(t *testing.T) {
+	router := newTopologyRouter(t)
+	body, _ := json.Marshal(map[string]any{"name": "test", "ip": "1.2.3.4", "type": "unknown"})
+	req := httptest.NewRequest(http.MethodPost, "/hosts/physical", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+func TestCreatePhysicalHost_MissingName(t *testing.T) {
+	router := newTopologyRouter(t)
+	body := bytes.NewBufferString(`{"ip":"1.2.3.4","type":"bare_metal"}`)
+	req := httptest.NewRequest(http.MethodPost, "/hosts/physical", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+func TestGetPhysicalHost_HappyPath(t *testing.T) {
+	router := newTopologyRouter(t)
+	created := createPhysicalHost(t, router, "host1", "10.0.0.1", "bare_metal")
+	req := httptest.NewRequest(http.MethodGet, "/hosts/physical/"+created.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+}
+
+func TestGetPhysicalHost_NotFound(t *testing.T) {
+	router := newTopologyRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/hosts/physical/does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+func TestUpdatePhysicalHost_HappyPath(t *testing.T) {
+	router := newTopologyRouter(t)
+	created := createPhysicalHost(t, router, "host1", "10.0.0.1", "bare_metal")
+	body, _ := json.Marshal(map[string]any{"name": "host1-renamed"})
+	req := httptest.NewRequest(http.MethodPut, "/hosts/physical/"+created.ID, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var h models.PhysicalHost
+	json.NewDecoder(rr.Body).Decode(&h)
+	if h.Name != "host1-renamed" {
+		t.Errorf("expected updated name got %q", h.Name)
+	}
+}
+
+func TestUpdatePhysicalHost_NotFound(t *testing.T) {
+	router := newTopologyRouter(t)
+	body, _ := json.Marshal(map[string]any{"name": "x"})
+	req := httptest.NewRequest(http.MethodPut, "/hosts/physical/does-not-exist", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+func TestDeletePhysicalHost_HappyPath(t *testing.T) {
+	router := newTopologyRouter(t)
+	created := createPhysicalHost(t, router, "host1", "10.0.0.1", "bare_metal")
+	req := httptest.NewRequest(http.MethodDelete, "/hosts/physical/"+created.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 got %d", rr.Code)
+	}
+}
+
+func TestDeletePhysicalHost_NotFound(t *testing.T) {
+	router := newTopologyRouter(t)
+	req := httptest.NewRequest(http.MethodDelete, "/hosts/physical/does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+// Deleting a physical host must SET NULL on virtual hosts (not cascade-delete).
+func TestDeletePhysicalHost_DoesNotCascadeToVirtualHosts(t *testing.T) {
+	router := newTopologyRouter(t)
+	ph := createPhysicalHost(t, router, "phys", "10.0.0.1", "bare_metal")
+	vh := createVirtualHost(t, router, "vm01", "10.0.0.2", "vm", ph.ID)
+
+	// Delete the physical host.
+	req := httptest.NewRequest(http.MethodDelete, "/hosts/physical/"+ph.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 got %d", rr.Code)
+	}
+
+	// Virtual host must still exist.
+	req2 := httptest.NewRequest(http.MethodGet, "/hosts/virtual/"+vh.ID, nil)
+	rr2 := httptest.NewRecorder()
+	router.ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("virtual host should still exist after physical host deleted, got %d", rr2.Code)
+	}
+}
+
+// ---- VirtualHost CRUD -------------------------------------------------------
+
+func TestCreateVirtualHost_HappyPath(t *testing.T) {
+	router := newTopologyRouter(t)
+	vh := createVirtualHost(t, router, "rocky-vm01", "192.168.1.50", "vm", "")
+	if vh.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+}
+
+func TestCreateVirtualHost_InvalidType(t *testing.T) {
+	router := newTopologyRouter(t)
+	body, _ := json.Marshal(map[string]any{"name": "test", "ip": "1.2.3.4", "type": "kvm"})
+	req := httptest.NewRequest(http.MethodPost, "/hosts/virtual", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+func TestCreateVirtualHost_InvalidParentID(t *testing.T) {
+	router := newTopologyRouter(t)
+	body, _ := json.Marshal(map[string]any{
+		"name": "vm01", "ip": "1.2.3.4", "type": "vm",
+		"physical_host_id": "does-not-exist",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/hosts/virtual", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422 got %d", rr.Code)
+	}
+}
+
+func TestListVirtualHosts_IncludesDockerEngineIDs(t *testing.T) {
+	router := newTopologyRouter(t)
+	vh := createVirtualHost(t, router, "vm01", "10.0.0.1", "vm", "")
+	createDockerEngine(t, router, "docker-01", "local", "/var/run/docker.sock", vh.ID)
+
+	req := httptest.NewRequest(http.MethodGet, "/hosts/virtual", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	var resp struct {
+		Data []struct {
+			ID            string   `json:"id"`
+			DockerEngines []string `json:"docker_engines"`
+		} `json:"data"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 virtual host got %d", len(resp.Data))
+	}
+	if len(resp.Data[0].DockerEngines) != 1 {
+		t.Errorf("expected 1 docker engine ID got %d", len(resp.Data[0].DockerEngines))
+	}
+}
+
+func TestGetVirtualHost_NotFound(t *testing.T) {
+	router := newTopologyRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/hosts/virtual/does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+func TestDeleteVirtualHost_HappyPath(t *testing.T) {
+	router := newTopologyRouter(t)
+	vh := createVirtualHost(t, router, "vm01", "10.0.0.1", "vm", "")
+	req := httptest.NewRequest(http.MethodDelete, "/hosts/virtual/"+vh.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 got %d", rr.Code)
+	}
+}
+
+func TestDeleteVirtualHost_NotFound(t *testing.T) {
+	router := newTopologyRouter(t)
+	req := httptest.NewRequest(http.MethodDelete, "/hosts/virtual/does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+// ---- DockerEngine CRUD ------------------------------------------------------
+
+func TestCreateDockerEngine_HappyPath(t *testing.T) {
+	router := newTopologyRouter(t)
+	e := createDockerEngine(t, router, "docker-01", "local", "/var/run/docker.sock", "")
+	if e.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if e.SocketType != "local" {
+		t.Errorf("expected socket_type=local got %q", e.SocketType)
+	}
+}
+
+func TestCreateDockerEngine_InvalidSocketType(t *testing.T) {
+	router := newTopologyRouter(t)
+	body, _ := json.Marshal(map[string]any{
+		"name": "docker-01", "socket_type": "tcp", "socket_path": "/var/run/docker.sock",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/docker-engines", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+func TestCreateDockerEngine_InvalidParentID(t *testing.T) {
+	router := newTopologyRouter(t)
+	body, _ := json.Marshal(map[string]any{
+		"name": "docker-01", "socket_type": "local", "socket_path": "/var/run/docker.sock",
+		"virtual_host_id": "does-not-exist",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/docker-engines", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422 got %d", rr.Code)
+	}
+}
+
+func TestGetDockerEngine_NotFound(t *testing.T) {
+	router := newTopologyRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/docker-engines/does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+func TestUpdateDockerEngine_HappyPath(t *testing.T) {
+	router := newTopologyRouter(t)
+	e := createDockerEngine(t, router, "docker-01", "local", "/var/run/docker.sock", "")
+	body, _ := json.Marshal(map[string]any{"name": "docker-renamed"})
+	req := httptest.NewRequest(http.MethodPut, "/docker-engines/"+e.ID, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var updated models.DockerEngine
+	json.NewDecoder(rr.Body).Decode(&updated)
+	if updated.Name != "docker-renamed" {
+		t.Errorf("expected updated name got %q", updated.Name)
+	}
+}
+
+func TestUpdateDockerEngine_NotFound(t *testing.T) {
+	router := newTopologyRouter(t)
+	body, _ := json.Marshal(map[string]any{"name": "x"})
+	req := httptest.NewRequest(http.MethodPut, "/docker-engines/does-not-exist", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+func TestDeleteDockerEngine_HappyPath(t *testing.T) {
+	router := newTopologyRouter(t)
+	e := createDockerEngine(t, router, "docker-01", "local", "/var/run/docker.sock", "")
+	req := httptest.NewRequest(http.MethodDelete, "/docker-engines/"+e.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 got %d", rr.Code)
+	}
+}
+
+func TestDeleteDockerEngine_NotFound(t *testing.T) {
+	router := newTopologyRouter(t)
+	req := httptest.NewRequest(http.MethodDelete, "/docker-engines/does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+// ---- GET /topology ----------------------------------------------------------
+
+func TestGetTopology_EmptyChain(t *testing.T) {
+	router := newTopologyRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/topology", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	var result []any
+	json.NewDecoder(rr.Body).Decode(&result)
+	if len(result) != 0 {
+		t.Errorf("expected empty array got %d items", len(result))
+	}
+}
+
+func TestGetTopology_FullChain(t *testing.T) {
+	router := newTopologyRouter(t)
+
+	ph := createPhysicalHost(t, router, "proxmox-node1", "192.168.1.10", "proxmox_node")
+	vh := createVirtualHost(t, router, "rocky-vm01", "192.168.1.50", "vm", ph.ID)
+	createDockerEngine(t, router, "docker-01", "local", "/var/run/docker.sock", vh.ID)
+
+	req := httptest.NewRequest(http.MethodGet, "/topology", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+
+	var chain []struct {
+		ID           string `json:"id"`
+		Name         string `json:"name"`
+		VirtualHosts []struct {
+			ID            string `json:"id"`
+			DockerEngines []struct {
+				ID   string `json:"id"`
+				Apps []any  `json:"apps"`
+			} `json:"docker_engines"`
+		} `json:"virtual_hosts"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&chain); err != nil {
+		t.Fatalf("decode topology: %v", err)
+	}
+	if len(chain) != 1 {
+		t.Fatalf("expected 1 physical host got %d", len(chain))
+	}
+	if chain[0].ID != ph.ID {
+		t.Errorf("expected physical host id=%s got %s", ph.ID, chain[0].ID)
+	}
+	if len(chain[0].VirtualHosts) != 1 {
+		t.Fatalf("expected 1 virtual host got %d", len(chain[0].VirtualHosts))
+	}
+	if len(chain[0].VirtualHosts[0].DockerEngines) != 1 {
+		t.Fatalf("expected 1 docker engine got %d", len(chain[0].VirtualHosts[0].DockerEngines))
+	}
+	if len(chain[0].VirtualHosts[0].DockerEngines[0].Apps) != 0 {
+		t.Errorf("expected 0 apps got %d", len(chain[0].VirtualHosts[0].DockerEngines[0].Apps))
+	}
+}
+
+func TestListPhysicalHosts_IncludesVirtualHostIDs(t *testing.T) {
+	router := newTopologyRouter(t)
+	ph := createPhysicalHost(t, router, "phys", "10.0.0.1", "bare_metal")
+	createVirtualHost(t, router, "vm01", "10.0.0.2", "vm", ph.ID)
+
+	req := httptest.NewRequest(http.MethodGet, "/hosts/physical", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	var resp struct {
+		Data []struct {
+			ID           string   `json:"id"`
+			VirtualHosts []string `json:"virtual_hosts"`
+		} `json:"data"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 physical host got %d", len(resp.Data))
+	}
+	if len(resp.Data[0].VirtualHosts) != 1 {
+		t.Errorf("expected 1 virtual host ID got %d", len(resp.Data[0].VirtualHosts))
+	}
+}

--- a/internal/docker/resources_test.go
+++ b/internal/docker/resources_test.go
@@ -49,7 +49,7 @@ func (r *mockResourceReadingRepo) Create(_ context.Context, reading *models.Reso
 // --- helpers --------------------------------------------------------------
 
 func newTestResourcePoller(appRepo repo.AppRepo, eventRepo repo.EventRepo, resRepo repo.ResourceReadingRepo, cli resourcePollerAPI) *ResourcePoller {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo, nil, nil, nil)
 	return newResourcePollerWithClient(store, cli)
 }
 

--- a/internal/docker/watcher_test.go
+++ b/internal/docker/watcher_test.go
@@ -78,7 +78,7 @@ func (r *mockEventRepo) LatestPerApp(_ context.Context, _ []string) (map[string]
 // --- helpers -------------------------------------------------------------
 
 func newTestWatcher(appRepo repo.AppRepo, eventRepo repo.EventRepo, dc dockerAPI) *Watcher {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil, nil, nil, nil)
 	return &Watcher{store: store, client: dc}
 }
 

--- a/internal/ingest/pipeline_test.go
+++ b/internal/ingest/pipeline_test.go
@@ -24,7 +24,7 @@ func newTestStore(t *testing.T) *repo.Store {
 	t.Cleanup(func() { db.Close() })
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil)
+	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil)
 }
 
 func seedApp(t *testing.T, store *repo.Store, token string, rateLimit int) models.App {

--- a/internal/models/topology.go
+++ b/internal/models/topology.go
@@ -1,0 +1,33 @@
+package models
+
+import "time"
+
+// PhysicalHost represents a physical machine (bare metal or Proxmox node).
+type PhysicalHost struct {
+	ID        string    `db:"id"         json:"id"`
+	Name      string    `db:"name"       json:"name"`
+	IP        string    `db:"ip"         json:"ip"`
+	Type      string    `db:"type"       json:"type"`
+	Notes     string    `db:"notes"      json:"notes"`
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
+}
+
+// VirtualHost represents a VM, LXC container, or WSL instance.
+type VirtualHost struct {
+	ID             string    `db:"id"               json:"id"`
+	PhysicalHostID string    `db:"physical_host_id" json:"physical_host_id,omitempty"`
+	Name           string    `db:"name"             json:"name"`
+	IP             string    `db:"ip"               json:"ip"`
+	Type           string    `db:"type"             json:"type"`
+	CreatedAt      time.Time `db:"created_at"       json:"created_at"`
+}
+
+// DockerEngine represents a Docker daemon accessible to NORA.
+type DockerEngine struct {
+	ID            string    `db:"id"              json:"id"`
+	VirtualHostID string    `db:"virtual_host_id" json:"virtual_host_id,omitempty"`
+	Name          string    `db:"name"            json:"name"`
+	SocketType    string    `db:"socket_type"     json:"socket_type"`
+	SocketPath    string    `db:"socket_path"     json:"socket_path"`
+	CreatedAt     time.Time `db:"created_at"      json:"created_at"`
+}

--- a/internal/repo/store.go
+++ b/internal/repo/store.go
@@ -2,14 +2,26 @@ package repo
 
 // Store bundles all repository interfaces into a single dependency.
 type Store struct {
-	Apps      AppRepo
-	Events    EventRepo
-	Checks    CheckRepo
-	Rollups   RollupRepo
-	Resources ResourceReadingRepo
+	Apps          AppRepo
+	Events        EventRepo
+	Checks        CheckRepo
+	Rollups       RollupRepo
+	Resources     ResourceReadingRepo
+	PhysicalHosts PhysicalHostRepo
+	VirtualHosts  VirtualHostRepo
+	DockerEngines DockerEngineRepo
 }
 
 // NewStore creates a Store backed by the given repositories.
-func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRepo, resources ResourceReadingRepo) *Store {
-	return &Store{Apps: apps, Events: events, Checks: checks, Rollups: rollups, Resources: resources}
+func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRepo, resources ResourceReadingRepo, physicalHosts PhysicalHostRepo, virtualHosts VirtualHostRepo, dockerEngines DockerEngineRepo) *Store {
+	return &Store{
+		Apps:          apps,
+		Events:        events,
+		Checks:        checks,
+		Rollups:       rollups,
+		Resources:     resources,
+		PhysicalHosts: physicalHosts,
+		VirtualHosts:  virtualHosts,
+		DockerEngines: dockerEngines,
+	}
 }

--- a/internal/repo/topology.go
+++ b/internal/repo/topology.go
@@ -1,0 +1,242 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/jmoiron/sqlx"
+)
+
+// ---- PhysicalHostRepo -------------------------------------------------------
+
+// PhysicalHostRepo defines CRUD for physical_hosts.
+type PhysicalHostRepo interface {
+	List(ctx context.Context) ([]models.PhysicalHost, error)
+	Create(ctx context.Context, h *models.PhysicalHost) error
+	Get(ctx context.Context, id string) (*models.PhysicalHost, error)
+	Update(ctx context.Context, h *models.PhysicalHost) error
+	Delete(ctx context.Context, id string) error
+}
+
+type sqlitePhysicalHostRepo struct{ db *sqlx.DB }
+
+// NewPhysicalHostRepo returns a PhysicalHostRepo backed by SQLite.
+func NewPhysicalHostRepo(db *sqlx.DB) PhysicalHostRepo {
+	return &sqlitePhysicalHostRepo{db: db}
+}
+
+func (r *sqlitePhysicalHostRepo) List(ctx context.Context) ([]models.PhysicalHost, error) {
+	var hosts []models.PhysicalHost
+	err := r.db.SelectContext(ctx, &hosts,
+		`SELECT id, name, ip, type, COALESCE(notes,'') AS notes, created_at
+		 FROM physical_hosts ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("list physical_hosts: %w", err)
+	}
+	return hosts, nil
+}
+
+func (r *sqlitePhysicalHostRepo) Create(ctx context.Context, h *models.PhysicalHost) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO physical_hosts (id, name, ip, type, notes) VALUES (?, ?, ?, ?, NULLIF(?, ''))`,
+		h.ID, h.Name, h.IP, h.Type, h.Notes)
+	if err != nil {
+		return fmt.Errorf("create physical_host: %w", err)
+	}
+	return nil
+}
+
+func (r *sqlitePhysicalHostRepo) Get(ctx context.Context, id string) (*models.PhysicalHost, error) {
+	var h models.PhysicalHost
+	err := r.db.GetContext(ctx, &h,
+		`SELECT id, name, ip, type, COALESCE(notes,'') AS notes, created_at
+		 FROM physical_hosts WHERE id = ?`, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get physical_host: %w", err)
+	}
+	return &h, nil
+}
+
+func (r *sqlitePhysicalHostRepo) Update(ctx context.Context, h *models.PhysicalHost) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE physical_hosts SET name=?, ip=?, type=?, notes=NULLIF(?, '') WHERE id=?`,
+		h.Name, h.IP, h.Type, h.Notes, h.ID)
+	if err != nil {
+		return fmt.Errorf("update physical_host: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sqlitePhysicalHostRepo) Delete(ctx context.Context, id string) error {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM physical_hosts WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete physical_host: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ---- VirtualHostRepo --------------------------------------------------------
+
+// VirtualHostRepo defines CRUD for virtual_hosts.
+type VirtualHostRepo interface {
+	List(ctx context.Context) ([]models.VirtualHost, error)
+	Create(ctx context.Context, h *models.VirtualHost) error
+	Get(ctx context.Context, id string) (*models.VirtualHost, error)
+	Update(ctx context.Context, h *models.VirtualHost) error
+	Delete(ctx context.Context, id string) error
+}
+
+type sqliteVirtualHostRepo struct{ db *sqlx.DB }
+
+// NewVirtualHostRepo returns a VirtualHostRepo backed by SQLite.
+func NewVirtualHostRepo(db *sqlx.DB) VirtualHostRepo {
+	return &sqliteVirtualHostRepo{db: db}
+}
+
+func (r *sqliteVirtualHostRepo) List(ctx context.Context) ([]models.VirtualHost, error) {
+	var hosts []models.VirtualHost
+	err := r.db.SelectContext(ctx, &hosts,
+		`SELECT id, COALESCE(physical_host_id,'') AS physical_host_id, name, ip, type, created_at
+		 FROM virtual_hosts ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("list virtual_hosts: %w", err)
+	}
+	return hosts, nil
+}
+
+func (r *sqliteVirtualHostRepo) Create(ctx context.Context, h *models.VirtualHost) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO virtual_hosts (id, physical_host_id, name, ip, type) VALUES (?, NULLIF(?, ''), ?, ?, ?)`,
+		h.ID, h.PhysicalHostID, h.Name, h.IP, h.Type)
+	if err != nil {
+		return fmt.Errorf("create virtual_host: %w", err)
+	}
+	return nil
+}
+
+func (r *sqliteVirtualHostRepo) Get(ctx context.Context, id string) (*models.VirtualHost, error) {
+	var h models.VirtualHost
+	err := r.db.GetContext(ctx, &h,
+		`SELECT id, COALESCE(physical_host_id,'') AS physical_host_id, name, ip, type, created_at
+		 FROM virtual_hosts WHERE id = ?`, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get virtual_host: %w", err)
+	}
+	return &h, nil
+}
+
+func (r *sqliteVirtualHostRepo) Update(ctx context.Context, h *models.VirtualHost) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE virtual_hosts SET physical_host_id=NULLIF(?, ''), name=?, ip=?, type=? WHERE id=?`,
+		h.PhysicalHostID, h.Name, h.IP, h.Type, h.ID)
+	if err != nil {
+		return fmt.Errorf("update virtual_host: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sqliteVirtualHostRepo) Delete(ctx context.Context, id string) error {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM virtual_hosts WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete virtual_host: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ---- DockerEngineRepo -------------------------------------------------------
+
+// DockerEngineRepo defines CRUD for docker_engines.
+type DockerEngineRepo interface {
+	List(ctx context.Context) ([]models.DockerEngine, error)
+	Create(ctx context.Context, e *models.DockerEngine) error
+	Get(ctx context.Context, id string) (*models.DockerEngine, error)
+	Update(ctx context.Context, e *models.DockerEngine) error
+	Delete(ctx context.Context, id string) error
+}
+
+type sqliteDockerEngineRepo struct{ db *sqlx.DB }
+
+// NewDockerEngineRepo returns a DockerEngineRepo backed by SQLite.
+func NewDockerEngineRepo(db *sqlx.DB) DockerEngineRepo {
+	return &sqliteDockerEngineRepo{db: db}
+}
+
+func (r *sqliteDockerEngineRepo) List(ctx context.Context) ([]models.DockerEngine, error) {
+	var engines []models.DockerEngine
+	err := r.db.SelectContext(ctx, &engines,
+		`SELECT id, COALESCE(virtual_host_id,'') AS virtual_host_id, name, socket_type, socket_path, created_at
+		 FROM docker_engines ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("list docker_engines: %w", err)
+	}
+	return engines, nil
+}
+
+func (r *sqliteDockerEngineRepo) Create(ctx context.Context, e *models.DockerEngine) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO docker_engines (id, virtual_host_id, name, socket_type, socket_path) VALUES (?, NULLIF(?, ''), ?, ?, ?)`,
+		e.ID, e.VirtualHostID, e.Name, e.SocketType, e.SocketPath)
+	if err != nil {
+		return fmt.Errorf("create docker_engine: %w", err)
+	}
+	return nil
+}
+
+func (r *sqliteDockerEngineRepo) Get(ctx context.Context, id string) (*models.DockerEngine, error) {
+	var e models.DockerEngine
+	err := r.db.GetContext(ctx, &e,
+		`SELECT id, COALESCE(virtual_host_id,'') AS virtual_host_id, name, socket_type, socket_path, created_at
+		 FROM docker_engines WHERE id = ?`, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get docker_engine: %w", err)
+	}
+	return &e, nil
+}
+
+func (r *sqliteDockerEngineRepo) Update(ctx context.Context, e *models.DockerEngine) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE docker_engines SET virtual_host_id=NULLIF(?, ''), name=?, socket_type=?, socket_path=? WHERE id=?`,
+		e.VirtualHostID, e.Name, e.SocketType, e.SocketPath, e.ID)
+	if err != nil {
+		return fmt.Errorf("update docker_engine: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sqliteDockerEngineRepo) Delete(ctx context.Context, id string) error {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM docker_engines WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete docker_engine: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}


### PR DESCRIPTION
## What
Adds the full topology CRUD API for the physical → virtual → docker → app chain.

## Why
Closes #18 — T-18 Topology CRUD API.

## How
- **`internal/models/topology.go`** — `PhysicalHost`, `VirtualHost`, `DockerEngine` structs
- **`internal/repo/topology.go`** — `PhysicalHostRepo`, `VirtualHostRepo`, `DockerEngineRepo` interfaces + SQLite implementations (COALESCE/NULLIF for nullable FK columns)
- **`internal/repo/store.go`** — added three new topology repos to `Store`
- **`internal/api/topology.go`** — all 15 CRUD endpoints plus `GET /topology` full chain aggregation. FK validation returns 422 for unknown parent IDs. Type validation on all enum fields.
- **`cmd/nora/main.go`** — wired topology handler into the v1 API route group

Deleting a physical host SET NULLs virtual hosts — not cascade-deleted — matching the schema's `ON DELETE SET NULL` constraint.

`GET /topology` assembles the full chain in Go by listing all four entity types and grouping them by parent IDs.

## Test coverage
- Happy-path and error-path tests for all three entity types (CRUD)
- FK validation returns 422 for invalid parent IDs (physical→virtual, virtual→docker engine)
- `TestDeletePhysicalHost_DoesNotCascadeToVirtualHosts` — verifies SET NULL behaviour
- `TestGetTopology_FullChain` — verifies the nested chain is correctly assembled
- All existing tests updated for the expanded `repo.NewStore` signature

## Closes
Closes #18