### PR TITLE
feat: T-19 Resource rollup background job

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/digitalcheffe/nora/internal/docker"
 	"github.com/digitalcheffe/nora/internal/frontend"
 	"github.com/digitalcheffe/nora/internal/ingest"
+	"github.com/digitalcheffe/nora/internal/jobs"
 	"github.com/digitalcheffe/nora/internal/monitor"
 	"github.com/digitalcheffe/nora/internal/profile"
 	"github.com/digitalcheffe/nora/internal/repo"
@@ -39,10 +40,11 @@ func main() {
 	checkRepo := repo.NewCheckRepo(db)
 	rollupRepo := repo.NewRollupRepo(db)
 	resourceRepo := repo.NewResourceReadingRepo(db)
+	resourceRollupRepo := repo.NewResourceRollupRepo(db)
 	physicalHostRepo := repo.NewPhysicalHostRepo(db)
 	virtualHostRepo := repo.NewVirtualHostRepo(db)
 	dockerEngineRepo := repo.NewDockerEngineRepo(db)
-	store := repo.NewStore(appRepo, eventRepo, checkRepo, rollupRepo, resourceRepo, physicalHostRepo, virtualHostRepo, dockerEngineRepo)
+	store := repo.NewStore(appRepo, eventRepo, checkRepo, rollupRepo, resourceRepo, resourceRollupRepo, physicalHostRepo, virtualHostRepo, dockerEngineRepo)
 
 	// Profile registry — load all bundled YAML profiles
 	registry, err := profile.NewRegistry(noraprofiles.Files)
@@ -57,6 +59,12 @@ func main() {
 	schedCtx, schedCancel := context.WithCancel(context.Background())
 	defer schedCancel()
 	go monitor.NewScheduler(store).Start(schedCtx)
+
+	// Resource rollup jobs — hourly aggregation and daily rollup + retention purge.
+	rollupCtx, rollupCancel := context.WithCancel(context.Background())
+	defer rollupCancel()
+	go jobs.StartHourlyRollup(rollupCtx, store)
+	go jobs.StartDailyRollup(rollupCtx, store)
 
 	// Docker socket watcher and resource poller — optional; skipped if the socket is not available.
 	dockerCtx, dockerCancel := context.WithCancel(context.Background())

--- a/internal/api/ingest_test.go
+++ b/internal/api/ingest_test.go
@@ -21,7 +21,7 @@ func newIngestRouter(t *testing.T) (http.Handler, *repo.Store) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 	profiler := &profile.NoopLoader{}
 
@@ -44,7 +44,7 @@ func TestHandleIngest_HappyPath(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()
@@ -131,7 +131,7 @@ func TestHandleIngest_RateLimit(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()

--- a/internal/docker/resources_test.go
+++ b/internal/docker/resources_test.go
@@ -49,7 +49,7 @@ func (r *mockResourceReadingRepo) Create(_ context.Context, reading *models.Reso
 // --- helpers --------------------------------------------------------------
 
 func newTestResourcePoller(appRepo repo.AppRepo, eventRepo repo.EventRepo, resRepo repo.ResourceReadingRepo, cli resourcePollerAPI) *ResourcePoller {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo, nil, nil, nil, nil)
 	return newResourcePollerWithClient(store, cli)
 }
 

--- a/internal/docker/watcher_test.go
+++ b/internal/docker/watcher_test.go
@@ -78,7 +78,7 @@ func (r *mockEventRepo) LatestPerApp(_ context.Context, _ []string) (map[string]
 // --- helpers -------------------------------------------------------------
 
 func newTestWatcher(appRepo repo.AppRepo, eventRepo repo.EventRepo, dc dockerAPI) *Watcher {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil, nil, nil, nil, nil)
 	return &Watcher{store: store, client: dc}
 }
 

--- a/internal/ingest/pipeline_test.go
+++ b/internal/ingest/pipeline_test.go
@@ -24,7 +24,7 @@ func newTestStore(t *testing.T) *repo.Store {
 	t.Cleanup(func() { db.Close() })
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil)
+	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil)
 }
 
 func seedApp(t *testing.T, store *repo.Store, token string, rateLimit int) models.App {

--- a/internal/jobs/resource_rollup.go
+++ b/internal/jobs/resource_rollup.go
@@ -1,0 +1,171 @@
+package jobs
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// RunHourlyRollup aggregates raw resource readings from the previous complete hour
+// and upserts the results into resource_rollups with period_type="hour".
+func RunHourlyRollup(ctx context.Context, store *repo.Store) error {
+	now := time.Now().UTC()
+	// Previous complete hour: from HH:00 to (HH+1):00
+	hourEnd := now.Truncate(time.Hour)
+	hourStart := hourEnd.Add(-time.Hour)
+
+	aggs, err := store.ResourceRollups.AggregateReadings(ctx, hourStart, hourEnd)
+	if err != nil {
+		return err
+	}
+
+	for i := range aggs {
+		a := &aggs[i]
+		rollup := &models.ResourceRollup{
+			SourceID:    a.SourceID,
+			SourceType:  a.SourceType,
+			Metric:      a.Metric,
+			PeriodType:  "hour",
+			PeriodStart: hourStart,
+			Avg:         a.Avg,
+			Min:         a.Min,
+			Max:         a.Max,
+		}
+		if err := store.ResourceRollups.Upsert(ctx, rollup); err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+
+	log.Printf("resource rollup: processed %d sources for hour %s", len(aggs), hourStart.Format("2006-01-02T15:04"))
+	return nil
+}
+
+// RunDailyRollup aggregates hourly rollups from the previous complete day and
+// upserts the results into resource_rollups with period_type="day".
+func RunDailyRollup(ctx context.Context, store *repo.Store) error {
+	now := time.Now().UTC()
+	// Previous complete day: midnight to midnight
+	dayEnd := now.Truncate(24 * time.Hour)
+	dayStart := dayEnd.Add(-24 * time.Hour)
+
+	aggs, err := store.ResourceRollups.AggregateHourlyRollups(ctx, dayStart, dayEnd)
+	if err != nil {
+		return err
+	}
+
+	for i := range aggs {
+		a := &aggs[i]
+		rollup := &models.ResourceRollup{
+			SourceID:    a.SourceID,
+			SourceType:  a.SourceType,
+			Metric:      a.Metric,
+			PeriodType:  "day",
+			PeriodStart: dayStart,
+			Avg:         a.Avg,
+			Min:         a.Min,
+			Max:         a.Max,
+		}
+		if err := store.ResourceRollups.Upsert(ctx, rollup); err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+
+	log.Printf("resource rollup: processed %d sources for day %s", len(aggs), dayStart.Format("2006-01-02"))
+	return nil
+}
+
+// RunRetentionPurge deletes:
+//   - resource_readings older than 7 days
+//   - hourly resource_rollups older than 90 days
+//
+// Daily rollups are never deleted.
+func RunRetentionPurge(ctx context.Context, store *repo.Store) error {
+	now := time.Now().UTC()
+
+	readingCutoff := now.Add(-7 * 24 * time.Hour)
+	deletedReadings, err := store.ResourceRollups.PurgeReadings(ctx, readingCutoff)
+	if err != nil {
+		return err
+	}
+	log.Printf("resource rollup: purged %d resource_readings older than %s", deletedReadings, readingCutoff.Format("2006-01-02"))
+
+	hourlyCutoff := now.Add(-90 * 24 * time.Hour)
+	deletedHourly, err := store.ResourceRollups.PurgeHourlyRollups(ctx, hourlyCutoff)
+	if err != nil {
+		return err
+	}
+	log.Printf("resource rollup: purged %d hourly rollups older than %s", deletedHourly, hourlyCutoff.Format("2006-01-02"))
+
+	return nil
+}
+
+// durationUntilNextMidnight returns the duration from now until the next UTC midnight.
+func durationUntilNextMidnight() time.Duration {
+	now := time.Now().UTC()
+	next := now.Truncate(24 * time.Hour).Add(24 * time.Hour)
+	return next.Sub(now)
+}
+
+// StartHourlyRollup runs RunHourlyRollup every hour until ctx is cancelled.
+func StartHourlyRollup(ctx context.Context, store *repo.Store) {
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+
+	log.Printf("resource rollup: hourly job started")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := RunHourlyRollup(ctx, store); err != nil && ctx.Err() == nil {
+				log.Printf("resource rollup: hourly job error: %v", err)
+			}
+		}
+	}
+}
+
+// StartDailyRollup waits until the next UTC midnight, then runs RunDailyRollup
+// and RunRetentionPurge every 24 hours until ctx is cancelled.
+func StartDailyRollup(ctx context.Context, store *repo.Store) {
+	delay := durationUntilNextMidnight()
+	log.Printf("resource rollup: daily job waiting %s until next midnight", delay.Round(time.Minute))
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(delay):
+	}
+
+	// Run immediately at the first midnight, then every 24 hours.
+	runDaily := func() {
+		if err := RunDailyRollup(ctx, store); err != nil && ctx.Err() == nil {
+			log.Printf("resource rollup: daily job error: %v", err)
+		}
+		if err := RunRetentionPurge(ctx, store); err != nil && ctx.Err() == nil {
+			log.Printf("resource rollup: purge job error: %v", err)
+		}
+	}
+
+	runDaily()
+
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			runDaily()
+		}
+	}
+}

--- a/internal/jobs/resource_rollup_test.go
+++ b/internal/jobs/resource_rollup_test.go
@@ -1,0 +1,309 @@
+package jobs_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/config"
+	"github.com/digitalcheffe/nora/internal/jobs"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/migrations"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+// newTestStore opens an in-memory SQLite database with all migrations applied and
+// returns both the store and the underlying *sqlx.DB for direct queries in tests.
+func newTestStore(t *testing.T) (*repo.Store, *sqlx.DB) {
+	t.Helper()
+	cfg := &config.Config{DBPath: ":memory:", DevMode: true}
+	db, err := repo.Open(cfg, migrations.Files)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	store := repo.NewStore(
+		repo.NewAppRepo(db),
+		repo.NewEventRepo(db),
+		repo.NewCheckRepo(db),
+		repo.NewRollupRepo(db),
+		repo.NewResourceReadingRepo(db),
+		repo.NewResourceRollupRepo(db),
+		nil, nil, nil,
+	)
+	return store, db
+}
+
+// seedReading inserts a resource_readings row at the given time.
+func seedReading(t *testing.T, store *repo.Store, sourceID, sourceType, metric string, value float64, at time.Time) {
+	t.Helper()
+	err := store.Resources.Create(context.Background(), &models.ResourceReading{
+		ID:         uuid.NewString(),
+		SourceID:   sourceID,
+		SourceType: sourceType,
+		Metric:     metric,
+		Value:      value,
+		RecordedAt: at,
+	})
+	if err != nil {
+		t.Fatalf("seed reading: %v", err)
+	}
+}
+
+// ---- hourly rollup tests -------------------------------------------------
+
+func TestRunHourlyRollup_ComputesAvgMinMax(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	hourEnd := time.Now().UTC().Truncate(time.Hour)
+	hourStart := hourEnd.Add(-time.Hour)
+	mid := hourStart.Add(30 * time.Minute)
+
+	seedReading(t, store, "src-1", "docker_container", "cpu_percent", 10.0, hourStart.Add(time.Minute))
+	seedReading(t, store, "src-1", "docker_container", "cpu_percent", 30.0, mid)
+	seedReading(t, store, "src-1", "docker_container", "cpu_percent", 20.0, hourEnd.Add(-time.Minute))
+
+	if err := jobs.RunHourlyRollup(ctx, store); err != nil {
+		t.Fatalf("RunHourlyRollup: %v", err)
+	}
+
+	aggs, err := store.ResourceRollups.AggregateHourlyRollups(ctx, hourStart, hourEnd.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("AggregateHourlyRollups: %v", err)
+	}
+	if len(aggs) != 1 {
+		t.Fatalf("expected 1 hourly rollup row, got %d", len(aggs))
+	}
+	a := aggs[0]
+	if a.SourceID != "src-1" {
+		t.Errorf("SourceID: got %q, want %q", a.SourceID, "src-1")
+	}
+	wantAvg := (10.0 + 30.0 + 20.0) / 3.0
+	if absf(a.Avg-wantAvg) > 0.001 {
+		t.Errorf("Avg: got %.4f, want %.4f", a.Avg, wantAvg)
+	}
+	if a.Min != 10.0 {
+		t.Errorf("Min: got %.4f, want 10.0", a.Min)
+	}
+	if a.Max != 30.0 {
+		t.Errorf("Max: got %.4f, want 30.0", a.Max)
+	}
+}
+
+func TestRunHourlyRollup_MultipleSourcesAndMetrics(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	hourEnd := time.Now().UTC().Truncate(time.Hour)
+	hourStart := hourEnd.Add(-time.Hour)
+	mid := hourStart.Add(30 * time.Minute)
+
+	seedReading(t, store, "src-a", "docker_container", "cpu_percent", 50.0, mid)
+	seedReading(t, store, "src-a", "docker_container", "mem_percent", 60.0, mid)
+	seedReading(t, store, "src-b", "docker_container", "cpu_percent", 70.0, mid)
+
+	if err := jobs.RunHourlyRollup(ctx, store); err != nil {
+		t.Fatalf("RunHourlyRollup: %v", err)
+	}
+
+	aggs, err := store.ResourceRollups.AggregateHourlyRollups(ctx, hourStart, hourEnd.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("AggregateHourlyRollups: %v", err)
+	}
+	if len(aggs) != 3 {
+		t.Errorf("expected 3 rollup rows (2 metrics for src-a, 1 for src-b), got %d", len(aggs))
+	}
+}
+
+func TestRunHourlyRollup_NoReadings_NoError(t *testing.T) {
+	store, _ := newTestStore(t)
+	if err := jobs.RunHourlyRollup(context.Background(), store); err != nil {
+		t.Fatalf("RunHourlyRollup with no data: %v", err)
+	}
+}
+
+func TestRunHourlyRollup_Idempotent(t *testing.T) {
+	store, db := newTestStore(t)
+	ctx := context.Background()
+
+	hourEnd := time.Now().UTC().Truncate(time.Hour)
+	hourStart := hourEnd.Add(-time.Hour)
+
+	seedReading(t, store, "src-1", "docker_container", "cpu_percent", 40.0, hourStart.Add(time.Minute))
+
+	if err := jobs.RunHourlyRollup(ctx, store); err != nil {
+		t.Fatalf("first RunHourlyRollup: %v", err)
+	}
+	if err := jobs.RunHourlyRollup(ctx, store); err != nil {
+		t.Fatalf("second RunHourlyRollup: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_rollups WHERE period_type = 'hour'").Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 rollup row after idempotent runs, got %d", count)
+	}
+}
+
+// ---- daily rollup tests --------------------------------------------------
+
+func TestRunDailyRollup_AggregatesHourlyData(t *testing.T) {
+	store, db := newTestStore(t)
+	ctx := context.Background()
+
+	dayEnd := time.Now().UTC().Truncate(24 * time.Hour)
+	dayStart := dayEnd.Add(-24 * time.Hour)
+	hour1 := dayStart
+	hour2 := dayStart.Add(time.Hour)
+
+	_ = store.ResourceRollups.Upsert(ctx, &models.ResourceRollup{
+		SourceID: "src-1", SourceType: "docker_container", Metric: "cpu_percent",
+		PeriodType: "hour", PeriodStart: hour1, Avg: 20.0, Min: 10.0, Max: 30.0,
+	})
+	_ = store.ResourceRollups.Upsert(ctx, &models.ResourceRollup{
+		SourceID: "src-1", SourceType: "docker_container", Metric: "cpu_percent",
+		PeriodType: "hour", PeriodStart: hour2, Avg: 40.0, Min: 5.0, Max: 80.0,
+	})
+
+	if err := jobs.RunDailyRollup(ctx, store); err != nil {
+		t.Fatalf("RunDailyRollup: %v", err)
+	}
+
+	type row struct {
+		Avg float64 `db:"avg"`
+		Min float64 `db:"min"`
+		Max float64 `db:"max"`
+	}
+	var r row
+	err := db.QueryRowxContext(ctx, `
+		SELECT avg, min, max FROM resource_rollups
+		WHERE source_id = ? AND period_type = 'day' AND period_start = ?`,
+		"src-1", dayStart).StructScan(&r)
+	if err != nil {
+		t.Fatalf("query daily rollup row: %v", err)
+	}
+	wantAvg := (20.0 + 40.0) / 2.0
+	if absf(r.Avg-wantAvg) > 0.001 {
+		t.Errorf("daily Avg: got %.4f, want %.4f", r.Avg, wantAvg)
+	}
+	if r.Min != 5.0 {
+		t.Errorf("daily Min: got %.4f, want 5.0", r.Min)
+	}
+	if r.Max != 80.0 {
+		t.Errorf("daily Max: got %.4f, want 80.0", r.Max)
+	}
+}
+
+// ---- purge tests ---------------------------------------------------------
+
+func TestRunRetentionPurge_DeletesOldReadings(t *testing.T) {
+	store, db := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	old := now.Add(-8 * 24 * time.Hour)
+	recent := now.Add(-1 * 24 * time.Hour)
+
+	seedReading(t, store, "src-1", "docker_container", "cpu_percent", 10.0, old)
+	seedReading(t, store, "src-1", "docker_container", "cpu_percent", 20.0, recent)
+
+	if err := jobs.RunRetentionPurge(ctx, store); err != nil {
+		t.Fatalf("RunRetentionPurge: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_readings").Scan(&count); err != nil {
+		t.Fatalf("count readings: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 reading to survive purge (recent), got %d", count)
+	}
+}
+
+func TestRunRetentionPurge_KeepsRecentReadings(t *testing.T) {
+	store, db := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	seedReading(t, store, "src-1", "docker_container", "mem_percent", 50.0, now.Add(-2*24*time.Hour))
+	seedReading(t, store, "src-2", "docker_container", "mem_percent", 55.0, now.Add(-6*24*time.Hour))
+
+	if err := jobs.RunRetentionPurge(ctx, store); err != nil {
+		t.Fatalf("RunRetentionPurge: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_readings").Scan(&count); err != nil {
+		t.Fatalf("count readings: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 readings kept (both within 7 days), got %d", count)
+	}
+}
+
+func TestRunRetentionPurge_DeletesOldHourlyRollups(t *testing.T) {
+	store, db := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	oldHour := now.Add(-91 * 24 * time.Hour).Truncate(time.Hour)
+	recentHour := now.Add(-1 * time.Hour).Truncate(time.Hour)
+
+	_ = store.ResourceRollups.Upsert(ctx, &models.ResourceRollup{
+		SourceID: "src-1", SourceType: "docker_container", Metric: "cpu_percent",
+		PeriodType: "hour", PeriodStart: oldHour, Avg: 10, Min: 5, Max: 20,
+	})
+	_ = store.ResourceRollups.Upsert(ctx, &models.ResourceRollup{
+		SourceID: "src-1", SourceType: "docker_container", Metric: "cpu_percent",
+		PeriodType: "hour", PeriodStart: recentHour, Avg: 15, Min: 8, Max: 25,
+	})
+
+	if err := jobs.RunRetentionPurge(ctx, store); err != nil {
+		t.Fatalf("RunRetentionPurge: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_rollups WHERE period_type = 'hour'").Scan(&count); err != nil {
+		t.Fatalf("count hourly rollups: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 hourly rollup kept (recent), got %d", count)
+	}
+}
+
+func TestRunRetentionPurge_NeverDeletesDailyRollups(t *testing.T) {
+	store, db := newTestStore(t)
+	ctx := context.Background()
+
+	ancient := time.Now().UTC().Add(-5 * 365 * 24 * time.Hour).Truncate(24 * time.Hour)
+	_ = store.ResourceRollups.Upsert(ctx, &models.ResourceRollup{
+		SourceID: "src-1", SourceType: "docker_container", Metric: "cpu_percent",
+		PeriodType: "day", PeriodStart: ancient, Avg: 10, Min: 5, Max: 20,
+	})
+
+	if err := jobs.RunRetentionPurge(ctx, store); err != nil {
+		t.Fatalf("RunRetentionPurge: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM resource_rollups WHERE period_type = 'day'").Scan(&count); err != nil {
+		t.Fatalf("count daily rollups: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("daily rollups should never be deleted, got %d", count)
+	}
+}
+
+// ---- helpers -------------------------------------------------------------
+
+func absf(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/internal/models/resource.go
+++ b/internal/models/resource.go
@@ -11,3 +11,15 @@ type ResourceReading struct {
 	Value      float64   `db:"value"`
 	RecordedAt time.Time `db:"recorded_at"`
 }
+
+// ResourceRollup is an aggregated summary of resource readings for a time period.
+type ResourceRollup struct {
+	SourceID    string    `db:"source_id"`
+	SourceType  string    `db:"source_type"`
+	Metric      string    `db:"metric"`
+	PeriodType  string    `db:"period_type"`
+	PeriodStart time.Time `db:"period_start"`
+	Avg         float64   `db:"avg"`
+	Min         float64   `db:"min"`
+	Max         float64   `db:"max"`
+}

--- a/internal/repo/resource_rollups.go
+++ b/internal/repo/resource_rollups.go
@@ -1,0 +1,116 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/jmoiron/sqlx"
+)
+
+// ResourceAggregate holds computed avg/min/max for a single source+metric combination.
+type ResourceAggregate struct {
+	SourceID   string  `db:"source_id"`
+	SourceType string  `db:"source_type"`
+	Metric     string  `db:"metric"`
+	Avg        float64 `db:"avg_val"`
+	Min        float64 `db:"min_val"`
+	Max        float64 `db:"max_val"`
+}
+
+// ResourceRollupRepo provides rollup aggregation, upsert, and purge operations.
+type ResourceRollupRepo interface {
+	// AggregateReadings returns avg/min/max per source+metric for raw readings in [from, to).
+	AggregateReadings(ctx context.Context, from, to time.Time) ([]ResourceAggregate, error)
+	// AggregateHourlyRollups returns avg/min/max per source+metric from hourly rollups in [from, to).
+	AggregateHourlyRollups(ctx context.Context, from, to time.Time) ([]ResourceAggregate, error)
+	// Upsert inserts or updates a resource_rollup row.
+	Upsert(ctx context.Context, r *models.ResourceRollup) error
+	// PurgeReadings deletes resource_readings with recorded_at < cutoff. Returns rows deleted.
+	PurgeReadings(ctx context.Context, cutoff time.Time) (int64, error)
+	// PurgeHourlyRollups deletes hourly resource_rollups with period_start < cutoff. Returns rows deleted.
+	PurgeHourlyRollups(ctx context.Context, cutoff time.Time) (int64, error)
+}
+
+type sqliteResourceRollupRepo struct {
+	db *sqlx.DB
+}
+
+// NewResourceRollupRepo returns a ResourceRollupRepo backed by the given SQLite database.
+func NewResourceRollupRepo(db *sqlx.DB) ResourceRollupRepo {
+	return &sqliteResourceRollupRepo{db: db}
+}
+
+func (r *sqliteResourceRollupRepo) AggregateReadings(ctx context.Context, from, to time.Time) ([]ResourceAggregate, error) {
+	var rows []ResourceAggregate
+	err := r.db.SelectContext(ctx, &rows, `
+		SELECT source_id, source_type, metric,
+		       AVG(value) AS avg_val,
+		       MIN(value) AS min_val,
+		       MAX(value) AS max_val
+		FROM resource_readings
+		WHERE recorded_at >= ? AND recorded_at < ?
+		GROUP BY source_id, source_type, metric`,
+		from, to)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate readings: %w", err)
+	}
+	return rows, nil
+}
+
+func (r *sqliteResourceRollupRepo) AggregateHourlyRollups(ctx context.Context, from, to time.Time) ([]ResourceAggregate, error) {
+	var rows []ResourceAggregate
+	err := r.db.SelectContext(ctx, &rows, `
+		SELECT source_id, source_type, metric,
+		       AVG(avg) AS avg_val,
+		       MIN(min) AS min_val,
+		       MAX(max) AS max_val
+		FROM resource_rollups
+		WHERE period_type = 'hour' AND period_start >= ? AND period_start < ?
+		GROUP BY source_id, source_type, metric`,
+		from, to)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate hourly rollups: %w", err)
+	}
+	return rows, nil
+}
+
+func (r *sqliteResourceRollupRepo) Upsert(ctx context.Context, rollup *models.ResourceRollup) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO resource_rollups (source_id, source_type, metric, period_type, period_start, avg, min, max)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT (source_id, metric, period_type, period_start)
+		DO UPDATE SET
+		    source_type = excluded.source_type,
+		    avg         = excluded.avg,
+		    min         = excluded.min,
+		    max         = excluded.max`,
+		rollup.SourceID, rollup.SourceType, rollup.Metric,
+		rollup.PeriodType, rollup.PeriodStart,
+		rollup.Avg, rollup.Min, rollup.Max)
+	if err != nil {
+		return fmt.Errorf("upsert resource rollup: %w", err)
+	}
+	return nil
+}
+
+func (r *sqliteResourceRollupRepo) PurgeReadings(ctx context.Context, cutoff time.Time) (int64, error) {
+	res, err := r.db.ExecContext(ctx,
+		`DELETE FROM resource_readings WHERE recorded_at < ?`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("purge readings: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+func (r *sqliteResourceRollupRepo) PurgeHourlyRollups(ctx context.Context, cutoff time.Time) (int64, error) {
+	res, err := r.db.ExecContext(ctx,
+		`DELETE FROM resource_rollups WHERE period_type = 'hour' AND period_start < ?`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("purge hourly rollups: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}

--- a/internal/repo/store.go
+++ b/internal/repo/store.go
@@ -2,26 +2,28 @@ package repo
 
 // Store bundles all repository interfaces into a single dependency.
 type Store struct {
-	Apps          AppRepo
-	Events        EventRepo
-	Checks        CheckRepo
-	Rollups       RollupRepo
-	Resources     ResourceReadingRepo
-	PhysicalHosts PhysicalHostRepo
-	VirtualHosts  VirtualHostRepo
-	DockerEngines DockerEngineRepo
+	Apps            AppRepo
+	Events          EventRepo
+	Checks          CheckRepo
+	Rollups         RollupRepo
+	Resources       ResourceReadingRepo
+	ResourceRollups ResourceRollupRepo
+	PhysicalHosts   PhysicalHostRepo
+	VirtualHosts    VirtualHostRepo
+	DockerEngines   DockerEngineRepo
 }
 
 // NewStore creates a Store backed by the given repositories.
-func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRepo, resources ResourceReadingRepo, physicalHosts PhysicalHostRepo, virtualHosts VirtualHostRepo, dockerEngines DockerEngineRepo) *Store {
+func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRepo, resources ResourceReadingRepo, resourceRollups ResourceRollupRepo, physicalHosts PhysicalHostRepo, virtualHosts VirtualHostRepo, dockerEngines DockerEngineRepo) *Store {
 	return &Store{
-		Apps:          apps,
-		Events:        events,
-		Checks:        checks,
-		Rollups:       rollups,
-		Resources:     resources,
-		PhysicalHosts: physicalHosts,
-		VirtualHosts:  virtualHosts,
-		DockerEngines: dockerEngines,
+		Apps:            apps,
+		Events:          events,
+		Checks:          checks,
+		Rollups:         rollups,
+		Resources:       resources,
+		ResourceRollups: resourceRollups,
+		PhysicalHosts:   physicalHosts,
+		VirtualHosts:    virtualHosts,
+		DockerEngines:   dockerEngines,
 	}
 }


### PR DESCRIPTION
## What
Adds the resource rollup background job that collapses raw resource readings into hourly and daily summaries, and purges old data on schedule.

## Why
Closes #19. Raw readings in `resource_readings` only live 7 days. Without rollup jobs, all historical trend data is lost after that window. This job preserves trends indefinitely through hourly (90-day) and daily (forever) summaries at minimal storage cost.

## How
- **`internal/models/resource.go`** — added `ResourceRollup` struct
- **`internal/repo/resource_rollups.go`** — new `ResourceRollupRepo` interface with `AggregateReadings`, `AggregateHourlyRollups`, `Upsert`, `PurgeReadings`, `PurgeHourlyRollups`; SQLite implementation uses `ON CONFLICT DO UPDATE` for idempotent upserts
- **`internal/repo/store.go`** — added `ResourceRollups ResourceRollupRepo` field; updated `NewStore` signature
- **`internal/jobs/resource_rollup.go`** — `RunHourlyRollup` (previous complete hour), `RunDailyRollup` (previous complete day from hourly rollups), `RunRetentionPurge` (7-day readings, 90-day hourly rollups; daily rollups never deleted); `StartHourlyRollup` and `StartDailyRollup` goroutine entry points — daily job calculates duration until next UTC midnight before starting its ticker
- **`cmd/nora/main.go`** — wires both goroutines with a shared cancellable context

## Test coverage
- `go test ./internal/jobs/...` — 10 tests covering: avg/min/max correctness with seeded readings, multi-source/multi-metric, no-data no-error, idempotent upsert, daily aggregation from hourly rollups, purge boundary (8 days deleted, 6 days kept), hourly rollup purge (91 days deleted, 1 hour kept), daily rollups never deleted
- `go test ./...` — all packages green
- `go vet ./...` — clean

## Closes
Closes #19