### PR TITLE
feat: T-20 Profile YAML schema, loader, and API

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -97,6 +97,7 @@ func main() {
 		api.NewChecksHandler(checkRepo, eventRepo).Routes(r)
 		api.NewDashboardHandler(appRepo, eventRepo, checkRepo, rollupRepo, registry).Routes(r)
 		api.NewTopologyHandler(physicalHostRepo, virtualHostRepo, dockerEngineRepo, appRepo).Routes(r)
+		api.NewProfilesHandler(registry).Routes(r)
 	})
 
 	// Frontend — serve embedded React app, SPA fallback to index.html

--- a/internal/api/profiles.go
+++ b/internal/api/profiles.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/digitalcheffe/nora/internal/profile"
+	"github.com/go-chi/chi/v5"
+)
+
+// ProfilesHandler serves the profile library API.
+type ProfilesHandler struct {
+	registry *profile.Registry
+}
+
+// NewProfilesHandler creates a ProfilesHandler backed by the given registry.
+func NewProfilesHandler(registry *profile.Registry) *ProfilesHandler {
+	return &ProfilesHandler{registry: registry}
+}
+
+// Routes registers GET /profiles and GET /profiles/{id}.
+func (h *ProfilesHandler) Routes(r chi.Router) {
+	r.Get("/profiles", h.List)
+	r.Get("/profiles/{id}", h.Get)
+}
+
+// profileMeta is the list-response shape — meta fields only, no internals.
+type profileMeta struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Category    string `json:"category"`
+	Logo        string `json:"logo"`
+	Description string `json:"description"`
+	Capability  string `json:"capability"`
+}
+
+// profileDetail is the full response shape returned by GET /profiles/{id}.
+type profileDetail struct {
+	ID      string          `json:"id"`
+	Profile *profile.Profile `json:"profile"`
+}
+
+// List handles GET /profiles — returns meta for all registered profiles.
+func (h *ProfilesHandler) List(w http.ResponseWriter, r *http.Request) {
+	all := h.registry.List()
+
+	items := make([]profileMeta, 0, len(all))
+	for id, p := range all {
+		items = append(items, profileMeta{
+			ID:          id,
+			Name:        p.Meta.Name,
+			Category:    p.Meta.Category,
+			Logo:        p.Meta.Logo,
+			Description: p.Meta.Description,
+			Capability:  p.Meta.Capability,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"data":  items,
+		"total": len(items),
+	})
+}
+
+// Get handles GET /profiles/{id} — returns the full profile including setup instructions.
+func (h *ProfilesHandler) Get(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	p, err := h.registry.Get(id)
+	if err != nil || p == nil {
+		writeError(w, http.StatusNotFound, "profile not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, profileDetail{
+		ID:      id,
+		Profile: p,
+	})
+}

--- a/internal/profile/loader.go
+++ b/internal/profile/loader.go
@@ -1,13 +1,18 @@
 package profile
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+var arrayIndexRe = regexp.MustCompile(`^([^\[]+)\[(\d+)\]$`)
 
 // Loader retrieves app profiles by ID.
 type Loader interface {
@@ -119,6 +124,120 @@ func (r *Registry) List() map[string]*Profile {
 		out[k] = v
 	}
 	return out
+}
+
+// ExtractFields evaluates each JSONPath in the profile's field_mappings against payload
+// and returns a flat tag→value map. Returns an error only on JSON decode failure.
+func (r *Registry) ExtractFields(profileID string, payload []byte) (map[string]string, error) {
+	p, ok := r.profiles[profileID]
+	if !ok || len(p.Webhook.FieldMappings) == 0 {
+		return map[string]string{}, nil
+	}
+
+	var root interface{}
+	if err := json.Unmarshal(payload, &root); err != nil {
+		return nil, fmt.Errorf("decode payload: %w", err)
+	}
+
+	out := make(map[string]string, len(p.Webhook.FieldMappings))
+	for tag, path := range p.Webhook.FieldMappings {
+		if v, ok := jsonPathGet(root, path); ok {
+			out[tag] = v
+		}
+	}
+	return out, nil
+}
+
+// RenderDisplayText substitutes {field_name} tokens in the profile's display_template
+// with values from fields. Returns "Event received" when the template is empty.
+func (r *Registry) RenderDisplayText(profileID string, fields map[string]string) string {
+	p, ok := r.profiles[profileID]
+	if !ok || p.Webhook.DisplayTemplate == "" {
+		return "Event received"
+	}
+	result := p.Webhook.DisplayTemplate
+	for k, v := range fields {
+		result = strings.ReplaceAll(result, "{"+k+"}", v)
+	}
+	return result
+}
+
+// MapSeverity looks up the value of the profile's severity_field in fields against
+// severity_mapping. Returns "info" for unknown values or missing configuration.
+func (r *Registry) MapSeverity(profileID string, fields map[string]string) string {
+	p, ok := r.profiles[profileID]
+	if !ok || p.Webhook.SeverityField == "" || len(p.Webhook.SeverityMapping) == 0 {
+		return "info"
+	}
+	val, ok := fields[p.Webhook.SeverityField]
+	if !ok {
+		return "info"
+	}
+	if s, ok := p.Webhook.SeverityMapping[val]; ok {
+		return s
+	}
+	return "info"
+}
+
+// jsonPathGet resolves a JSONPath expression against a decoded JSON value.
+// Supports dot-notation ($.field.nested) and array indexing ($.arr[0].field).
+func jsonPathGet(v interface{}, path string) (string, bool) {
+	path = strings.TrimPrefix(path, "$.")
+	path = strings.TrimPrefix(path, "$")
+	if path == "" {
+		return jsonToString(v), true
+	}
+
+	parts := strings.SplitN(path, ".", 2)
+	segment := parts[0]
+	rest := ""
+	if len(parts) == 2 {
+		rest = parts[1]
+	}
+
+	// Handle array index notation: episodes[0]
+	if m := arrayIndexRe.FindStringSubmatch(segment); m != nil {
+		key := m[1]
+		idx, _ := strconv.Atoi(m[2])
+
+		obj, ok := v.(map[string]interface{})
+		if !ok {
+			return "", false
+		}
+		arr, ok := obj[key].([]interface{})
+		if !ok || idx >= len(arr) {
+			return "", false
+		}
+		child := arr[idx]
+		if rest == "" {
+			return jsonToString(child), true
+		}
+		return jsonPathGet(child, rest)
+	}
+
+	obj, ok := v.(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+	child, ok := obj[segment]
+	if !ok {
+		return "", false
+	}
+	if rest == "" {
+		return jsonToString(child), true
+	}
+	return jsonPathGet(child, rest)
+}
+
+func jsonToString(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	b, _ := json.Marshal(v)
+	return string(b)
 }
 
 // NoopLoader returns nil for all profiles (passthrough mode).

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -1,0 +1,235 @@
+package profile_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/digitalcheffe/nora/internal/profile"
+)
+
+const sonarrYAML = `
+meta:
+  name: Sonarr
+  category: Media
+  logo: sonarr.png
+  description: TV series management
+  capability: full
+webhook:
+  field_mappings:
+    event_type: "$.eventType"
+    series_title: "$.series.title"
+    episode_title: "$.episodes[0].title"
+    season_number: "$.episodes[0].seasonNumber"
+    episode_number: "$.episodes[0].episodeNumber"
+    health_type: "$.healthCheck.type"
+  severity_field: event_type
+  display_template: "{event_type} — {series_title} S{season_number}E{episode_number}"
+  severity_mapping:
+    Download: info
+    HealthIssue: warn
+    ApplicationUpdate: info
+monitor:
+  check_type: url
+  check_url: "{base_url}/api/v3/system/status"
+  healthy_status: 200
+  check_interval: 5m
+digest:
+  categories:
+    - label: Downloads
+      match_field: event_type
+      match_value: Download
+`
+
+const simpleYAML = `
+meta:
+  name: Simple
+  category: Infrastructure
+  logo: simple.png
+  description: A simple app
+  capability: monitor_only
+monitor:
+  check_type: ping
+  check_interval: 1m
+`
+
+func newTestRegistry(t *testing.T) *profile.Registry {
+	t.Helper()
+	fsys := fstest.MapFS{
+		"sonarr.yaml": {Data: []byte(sonarrYAML)},
+		"simple.yaml": {Data: []byte(simpleYAML)},
+	}
+	reg, err := profile.NewRegistry(fsys)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	return reg
+}
+
+// TestNewRegistry_LoadsProfiles verifies all YAML files in the FS are loaded.
+func TestNewRegistry_LoadsProfiles(t *testing.T) {
+	reg := newTestRegistry(t)
+	all := reg.List()
+	if len(all) != 2 {
+		t.Fatalf("want 2 profiles, got %d", len(all))
+	}
+	p, ok := all["sonarr"]
+	if !ok {
+		t.Fatal("sonarr profile not found")
+	}
+	if p.Meta.Name != "Sonarr" {
+		t.Errorf("want name Sonarr, got %q", p.Meta.Name)
+	}
+}
+
+// TestGet verifies Get returns the correct profile and nil for unknown IDs.
+func TestGet(t *testing.T) {
+	reg := newTestRegistry(t)
+
+	p, err := reg.Get("sonarr")
+	if err != nil || p == nil {
+		t.Fatalf("want sonarr profile, got err=%v p=%v", err, p)
+	}
+	if p.Meta.Category != "Media" {
+		t.Errorf("want category Media, got %q", p.Meta.Category)
+	}
+
+	missing, err := reg.Get("nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if missing != nil {
+		t.Errorf("want nil for unknown profile, got %+v", missing)
+	}
+}
+
+// TestExtractFields verifies nested field extraction including array indexing.
+func TestExtractFields(t *testing.T) {
+	reg := newTestRegistry(t)
+
+	payload := []byte(`{
+		"eventType": "Download",
+		"series": {"title": "The Expanse"},
+		"episodes": [
+			{"title": "Pilot", "seasonNumber": 1, "episodeNumber": 1}
+		],
+		"healthCheck": {"type": "IndexerSearch"}
+	}`)
+
+	fields, err := reg.ExtractFields("sonarr", payload)
+	if err != nil {
+		t.Fatalf("ExtractFields error: %v", err)
+	}
+
+	cases := map[string]string{
+		"event_type":     "Download",
+		"series_title":   "The Expanse",
+		"episode_title":  "Pilot",
+		"season_number":  "1",
+		"episode_number": "1",
+		"health_type":    "IndexerSearch",
+	}
+	for tag, want := range cases {
+		if got := fields[tag]; got != want {
+			t.Errorf("fields[%q] = %q, want %q", tag, got, want)
+		}
+	}
+}
+
+// TestExtractFields_UnknownProfile returns empty map for an unregistered profile.
+func TestExtractFields_UnknownProfile(t *testing.T) {
+	reg := newTestRegistry(t)
+	fields, err := reg.ExtractFields("ghost", []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 0 {
+		t.Errorf("want empty map, got %v", fields)
+	}
+}
+
+// TestExtractFields_InvalidJSON returns an error on malformed payloads.
+func TestExtractFields_InvalidJSON(t *testing.T) {
+	reg := newTestRegistry(t)
+	_, err := reg.ExtractFields("sonarr", []byte(`not json`))
+	if err == nil {
+		t.Error("want error for invalid JSON, got nil")
+	}
+}
+
+// TestRenderDisplayText verifies {token} substitution from extracted fields.
+func TestRenderDisplayText(t *testing.T) {
+	reg := newTestRegistry(t)
+
+	fields := map[string]string{
+		"event_type":     "Download",
+		"series_title":   "The Expanse",
+		"season_number":  "1",
+		"episode_number": "1",
+	}
+
+	got := reg.RenderDisplayText("sonarr", fields)
+	want := "Download — The Expanse S1E1"
+	if got != want {
+		t.Errorf("RenderDisplayText = %q, want %q", got, want)
+	}
+}
+
+// TestRenderDisplayText_UnknownProfile returns default text for unknown profile.
+func TestRenderDisplayText_UnknownProfile(t *testing.T) {
+	reg := newTestRegistry(t)
+	got := reg.RenderDisplayText("ghost", map[string]string{})
+	if got != "Event received" {
+		t.Errorf("want %q, got %q", "Event received", got)
+	}
+}
+
+// TestRenderDisplayText_NoTemplate returns default for profile without template.
+func TestRenderDisplayText_NoTemplate(t *testing.T) {
+	reg := newTestRegistry(t)
+	got := reg.RenderDisplayText("simple", map[string]string{})
+	if got != "Event received" {
+		t.Errorf("want %q, got %q", "Event received", got)
+	}
+}
+
+// TestMapSeverity verifies known event values map to correct severity levels.
+func TestMapSeverity(t *testing.T) {
+	reg := newTestRegistry(t)
+
+	cases := []struct {
+		eventType string
+		want      string
+	}{
+		{"Download", "info"},
+		{"HealthIssue", "warn"},
+		{"ApplicationUpdate", "info"},
+		{"UnknownEvent", "info"},
+		{"", "info"},
+	}
+
+	for _, c := range cases {
+		fields := map[string]string{"event_type": c.eventType}
+		got := reg.MapSeverity("sonarr", fields)
+		if got != c.want {
+			t.Errorf("MapSeverity(event_type=%q) = %q, want %q", c.eventType, got, c.want)
+		}
+	}
+}
+
+// TestMapSeverity_UnknownProfile returns "info" for an unregistered profile.
+func TestMapSeverity_UnknownProfile(t *testing.T) {
+	reg := newTestRegistry(t)
+	got := reg.MapSeverity("ghost", map[string]string{"event_type": "Anything"})
+	if got != "info" {
+		t.Errorf("want info, got %q", got)
+	}
+}
+
+// TestMapSeverity_NoSeverityConfig returns "info" when profile has no severity config.
+func TestMapSeverity_NoSeverityConfig(t *testing.T) {
+	reg := newTestRegistry(t)
+	got := reg.MapSeverity("simple", map[string]string{"event_type": "Anything"})
+	if got != "info" {
+		t.Errorf("want info, got %q", got)
+	}
+}


### PR DESCRIPTION
## What
Implements the profile package loader methods and the profiles REST API for T-20.

## Why
Closes #20 — the profile registry needed `ExtractFields`, `RenderDisplayText`, and `MapSeverity` as first-class methods so both the ingest pipeline and the API can use them. The profile endpoints expose the bundled profile library to the frontend.

## How
- Added `ExtractFields`, `RenderDisplayText`, `MapSeverity` methods to `Registry` in `internal/profile/loader.go` with JSONPath support including array indexing (`$.episodes[0].title`)
- Created `internal/api/profiles.go` with `GET /api/v1/profiles` (meta only) and `GET /api/v1/profiles/{id}` (full profile)
- Registered `ProfilesHandler` in the protected `/api/v1` route group in `main.go`
- Internal `jsonPathGet` helper handles dot-notation and `[N]` array indexing

## Test coverage
- `TestNewRegistry_LoadsProfiles` — all YAML files loaded correctly
- `TestGet` — correct profile returned, nil for unknown IDs
- `TestExtractFields` — nested fields and array indexing both verified
- `TestExtractFields_UnknownProfile` / `TestExtractFields_InvalidJSON` — error paths covered
- `TestRenderDisplayText` — `{token}` substitution verified end-to-end
- `TestMapSeverity` — known values, unknown values, and no-config cases all tested

## Closes
Closes #20