### PR TITLE
feat: T-21 Write v1 app profiles (15 apps)

### DIFF
--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -233,3 +233,218 @@ func TestMapSeverity_NoSeverityConfig(t *testing.T) {
 		t.Errorf("want info, got %q", got)
 	}
 }
+
+// ---- n8n ----
+
+const n8nYAML = `
+meta:
+  name: n8n
+  category: Automation
+  logo: n8n.png
+  description: Workflow automation platform
+  capability: full
+webhook:
+  field_mappings:
+    event_type: "$.eventName"
+    workflow_name: "$.workflowData.name"
+    error_message: "$.error.message"
+  severity_field: event_type
+  display_template: "{event_type} — {workflow_name}"
+  severity_mapping:
+    "workflow.finished": info
+    "workflow.error": error
+    "node.error": warn
+monitor:
+  check_type: url
+  check_url: "{base_url}/healthz"
+  healthy_status: 200
+  check_interval: 5m
+digest:
+  categories:
+    - label: Workflows
+      match_field: event_type
+      match_value: "workflow.finished"
+      match_severity: ""
+    - label: Errors
+      match_field: ""
+      match_value: ""
+      match_severity: error
+`
+
+func newN8nRegistry(t *testing.T) *profile.Registry {
+	t.Helper()
+	fsys := fstest.MapFS{
+		"n8n.yaml": {Data: []byte(n8nYAML)},
+	}
+	reg, err := profile.NewRegistry(fsys)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	return reg
+}
+
+// TestN8n_ExtractFields verifies n8n field extraction from a workflow error payload.
+func TestN8n_ExtractFields(t *testing.T) {
+	reg := newN8nRegistry(t)
+
+	payload := []byte(`{
+		"eventName": "workflow.error",
+		"workflowData": {"name": "Daily Sync", "id": "42"},
+		"executionId": "99",
+		"error": {"message": "Connection refused"}
+	}`)
+
+	fields, err := reg.ExtractFields("n8n", payload)
+	if err != nil {
+		t.Fatalf("ExtractFields error: %v", err)
+	}
+
+	cases := map[string]string{
+		"event_type":    "workflow.error",
+		"workflow_name": "Daily Sync",
+		"error_message": "Connection refused",
+	}
+	for tag, want := range cases {
+		if got := fields[tag]; got != want {
+			t.Errorf("fields[%q] = %q, want %q", tag, got, want)
+		}
+	}
+}
+
+// TestN8n_SeverityMapping verifies n8n event names map to correct severity levels.
+func TestN8n_SeverityMapping(t *testing.T) {
+	reg := newN8nRegistry(t)
+
+	cases := []struct {
+		event string
+		want  string
+	}{
+		{"workflow.finished", "info"},
+		{"workflow.error", "error"},
+		{"node.error", "warn"},
+		{"unknown.event", "info"},
+	}
+
+	for _, c := range cases {
+		fields := map[string]string{"event_type": c.event}
+		got := reg.MapSeverity("n8n", fields)
+		if got != c.want {
+			t.Errorf("MapSeverity(event=%q) = %q, want %q", c.event, got, c.want)
+		}
+	}
+}
+
+// ---- Duplicati ----
+
+const duplicatiYAML = `
+meta:
+  name: Duplicati
+  category: Storage
+  logo: duplicati.png
+  description: Open-source backup software
+  capability: webhook_only
+webhook:
+  field_mappings:
+    event_type: "$.Data.ParsedResult"
+    backup_name: "$.Data.OperationName"
+    duration: "$.Data.Duration"
+    error_message: "$.Data.Message"
+  severity_field: event_type
+  display_template: "Backup {event_type} — {backup_name}"
+  severity_mapping:
+    Success: info
+    Warning: warn
+    Error: error
+    Fatal: critical
+digest:
+  categories:
+    - label: Backups
+      match_field: event_type
+      match_value: Success
+      match_severity: ""
+    - label: Backup Errors
+      match_field: ""
+      match_value: ""
+      match_severity: error
+`
+
+func newDuplicatiRegistry(t *testing.T) *profile.Registry {
+	t.Helper()
+	fsys := fstest.MapFS{
+		"duplicati.yaml": {Data: []byte(duplicatiYAML)},
+	}
+	reg, err := profile.NewRegistry(fsys)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	return reg
+}
+
+// TestDuplicati_ExtractFields verifies Duplicati field extraction from a backup payload.
+func TestDuplicati_ExtractFields(t *testing.T) {
+	reg := newDuplicatiRegistry(t)
+
+	payload := []byte(`{
+		"Data": {
+			"ParsedResult": "Success",
+			"OperationName": "Home NAS",
+			"Duration": "00:03:21",
+			"Message": ""
+		}
+	}`)
+
+	fields, err := reg.ExtractFields("duplicati", payload)
+	if err != nil {
+		t.Fatalf("ExtractFields error: %v", err)
+	}
+
+	cases := map[string]string{
+		"event_type":  "Success",
+		"backup_name": "Home NAS",
+		"duration":    "00:03:21",
+	}
+	for tag, want := range cases {
+		if got := fields[tag]; got != want {
+			t.Errorf("fields[%q] = %q, want %q", tag, got, want)
+		}
+	}
+}
+
+// TestDuplicati_SeverityMapping verifies Success/Failure map to correct severity levels.
+func TestDuplicati_SeverityMapping(t *testing.T) {
+	reg := newDuplicatiRegistry(t)
+
+	cases := []struct {
+		result string
+		want   string
+	}{
+		{"Success", "info"},
+		{"Warning", "warn"},
+		{"Error", "error"},
+		{"Fatal", "critical"},
+		{"Unknown", "info"},
+	}
+
+	for _, c := range cases {
+		fields := map[string]string{"event_type": c.result}
+		got := reg.MapSeverity("duplicati", fields)
+		if got != c.want {
+			t.Errorf("MapSeverity(result=%q) = %q, want %q", c.result, got, c.want)
+		}
+	}
+}
+
+// TestDuplicati_RenderDisplayText verifies display template renders correctly.
+func TestDuplicati_RenderDisplayText(t *testing.T) {
+	reg := newDuplicatiRegistry(t)
+
+	fields := map[string]string{
+		"event_type":  "Success",
+		"backup_name": "Home NAS",
+	}
+	got := reg.RenderDisplayText("duplicati", fields)
+	want := "Backup Success — Home NAS"
+	if got != want {
+		t.Errorf("RenderDisplayText = %q, want %q", got, want)
+	}
+}

--- a/profiles/diun.yaml
+++ b/profiles/diun.yaml
@@ -1,0 +1,31 @@
+meta:
+  name: Diun
+  category: Infrastructure
+  logo: diun.png
+  description: Docker image update notifier
+  capability: webhook_only
+
+webhook:
+  setup_instructions: |
+    In Diun configure a webhook notifier pointing to {base_url}/ingest/{token}.
+    Diun sends a POST on new or updated images.
+  recommended_events:
+    - new
+    - update
+  not_recommended: []
+  field_mappings:
+    entry_image: "$.entry.image"
+    entry_status: "$.entry.status"
+    hostname: "$.hostname"
+  severity_field: entry_status
+  display_template: "Image {entry_status} — {entry_image}"
+  severity_mapping:
+    new: info
+    update: info
+
+digest:
+  categories:
+    - label: Updates
+      match_field: ""
+      match_value: ""
+      match_severity: info

--- a/profiles/lidarr.yaml
+++ b/profiles/lidarr.yaml
@@ -1,0 +1,55 @@
+meta:
+  name: Lidarr
+  category: Media
+  logo: lidarr.png
+  description: Music management and download automation
+  capability: full
+
+webhook:
+  setup_instructions: |
+    In Lidarr go to Settings → Connect → Add → Webhook.
+    Set the URL to {base_url}/ingest/{token} and select the event types below.
+  recommended_events:
+    - On Release Import
+    - On Upgrade
+    - On Health Issue
+    - On Application Update
+  not_recommended:
+    - On Grab
+  field_mappings:
+    event_type: "$.eventType"
+    artist_name: "$.artist.name"
+    album_title: "$.albums[0].title"
+    quality: "$.trackFiles[0].quality.quality.name"
+    health_type: "$.healthCheck.type"
+    health_message: "$.healthCheck.message"
+  severity_field: event_type
+  display_template: "{event_type} — {artist_name} — {album_title}"
+  severity_mapping:
+    AlbumDownload: info
+    Upgrade: info
+    HealthIssue: warn
+    HealthRestored: info
+    ApplicationUpdate: info
+
+monitor:
+  check_type: url
+  check_url: "{base_url}/api/v1/system/status"
+  auth_header: "X-Api-Key: {api_key}"
+  healthy_status: 200
+  check_interval: 5m
+
+digest:
+  categories:
+    - label: Downloads
+      match_field: event_type
+      match_value: AlbumDownload
+      match_severity: ""
+    - label: Upgrades
+      match_field: event_type
+      match_value: Upgrade
+      match_severity: ""
+    - label: Health Issues
+      match_field: event_type
+      match_value: HealthIssue
+      match_severity: ""

--- a/profiles/matrix.yaml
+++ b/profiles/matrix.yaml
@@ -1,0 +1,12 @@
+meta:
+  name: Matrix (Synapse)
+  category: Communication
+  logo: matrix.png
+  description: Synapse Matrix homeserver
+  capability: monitor_only
+
+monitor:
+  check_type: url
+  check_url: "{base_url}/_matrix/client/versions"
+  healthy_status: 200
+  check_interval: 5m

--- a/profiles/opnsense.yaml
+++ b/profiles/opnsense.yaml
@@ -1,0 +1,10 @@
+meta:
+  name: OPNsense
+  category: Infrastructure
+  logo: opnsense.png
+  description: Open source firewall and router platform
+  capability: monitor_only
+
+monitor:
+  check_type: ping
+  check_interval: 1m

--- a/profiles/overseerr.yaml
+++ b/profiles/overseerr.yaml
@@ -1,0 +1,55 @@
+meta:
+  name: Overseerr
+  category: Media
+  logo: overseerr.png
+  description: Media request management for Plex
+  capability: full
+
+webhook:
+  setup_instructions: |
+    In Overseerr go to Settings → Notifications → Webhook.
+    Set the Webhook URL to {base_url}/ingest/{token} and enable the notification types below.
+  recommended_events:
+    - Media Requested
+    - Media Approved
+    - Media Available
+    - Media Failed
+    - Issue Reported
+  not_recommended: []
+  field_mappings:
+    notification_type: "$.notification_type"
+    subject: "$.subject"
+    message: "$.message"
+    media_type: "$.media.media_type"
+    requested_by: "$.request.requestedBy.displayName"
+  severity_field: notification_type
+  display_template: "{notification_type} — {subject}"
+  severity_mapping:
+    MEDIA_REQUESTED: info
+    MEDIA_APPROVED: info
+    MEDIA_AVAILABLE: info
+    MEDIA_FAILED: error
+    ISSUE_REPORTED: warn
+    ISSUE_RESOLVED: info
+
+monitor:
+  check_type: url
+  check_url: "{base_url}/api/v1/status"
+  auth_header: "X-Api-Key: {api_key}"
+  healthy_status: 200
+  check_interval: 5m
+
+digest:
+  categories:
+    - label: Requests
+      match_field: notification_type
+      match_value: MEDIA_REQUESTED
+      match_severity: ""
+    - label: Available
+      match_field: notification_type
+      match_value: MEDIA_AVAILABLE
+      match_severity: ""
+    - label: Issues
+      match_field: ""
+      match_value: ""
+      match_severity: error

--- a/profiles/prowlarr.yaml
+++ b/profiles/prowlarr.yaml
@@ -1,0 +1,47 @@
+meta:
+  name: Prowlarr
+  category: Media
+  logo: prowlarr.png
+  description: Indexer manager and proxy for Usenet and torrents
+  capability: full
+
+webhook:
+  setup_instructions: |
+    In Prowlarr go to Settings → Connect → Add → Webhook.
+    Set the URL to {base_url}/ingest/{token} and select the event types below.
+  recommended_events:
+    - On Health Issue
+    - On Application Update
+    - On Grab
+  not_recommended: []
+  field_mappings:
+    event_type: "$.eventType"
+    indexer_name: "$.grabInfo.indexerName"
+    release_title: "$.grabInfo.title"
+    health_type: "$.healthCheck.type"
+    health_message: "$.healthCheck.message"
+  severity_field: event_type
+  display_template: "{event_type} — {indexer_name}"
+  severity_mapping:
+    Grab: info
+    HealthIssue: warn
+    HealthRestored: info
+    ApplicationUpdate: info
+
+monitor:
+  check_type: url
+  check_url: "{base_url}/api/v1/system/status"
+  auth_header: "X-Api-Key: {api_key}"
+  healthy_status: 200
+  check_interval: 5m
+
+digest:
+  categories:
+    - label: Grabs
+      match_field: event_type
+      match_value: Grab
+      match_severity: ""
+    - label: Health Issues
+      match_field: event_type
+      match_value: HealthIssue
+      match_severity: ""

--- a/profiles/proxmox.yaml
+++ b/profiles/proxmox.yaml
@@ -1,0 +1,12 @@
+meta:
+  name: Proxmox
+  category: Infrastructure
+  logo: proxmox.png
+  description: Enterprise-class open-source virtualisation platform
+  capability: monitor_only
+
+monitor:
+  check_type: url
+  check_url: "{base_url}:8006"
+  healthy_status: 200
+  check_interval: 5m

--- a/profiles/tautulli.yaml
+++ b/profiles/tautulli.yaml
@@ -1,0 +1,40 @@
+meta:
+  name: Tautulli
+  category: Media
+  logo: tautulli.png
+  description: Plex media server monitoring and statistics
+  capability: full
+
+webhook:
+  setup_instructions: |
+    In Tautulli go to Settings → Notification Agents → Add → Webhook.
+    Set the Webhook URL to {base_url}/ingest/{token} and configure triggers below.
+  recommended_events:
+    - Playback Start
+    - Playback Stop
+    - Playback Pause
+    - Playback Resume
+  not_recommended: []
+  field_mappings:
+    action: "$.action"
+    user: "$.user"
+    title: "$.title"
+    media_type: "$.media_type"
+    player: "$.player"
+    quality: "$.quality"
+  severity_field: ""
+  display_template: "{action} — {title} ({user})"
+  severity_mapping: {}
+
+monitor:
+  check_type: url
+  check_url: "{base_url}/api/v2?apikey={api_key}&cmd=status"
+  healthy_status: 200
+  check_interval: 5m
+
+digest:
+  categories:
+    - label: Plays
+      match_field: action
+      match_value: play
+      match_severity: ""

--- a/profiles/traefik.yaml
+++ b/profiles/traefik.yaml
@@ -1,0 +1,12 @@
+meta:
+  name: Traefik
+  category: Infrastructure
+  logo: traefik.png
+  description: Cloud-native reverse proxy and load balancer
+  capability: monitor_only
+
+monitor:
+  check_type: url
+  check_url: "{base_url}/ping"
+  healthy_status: 200
+  check_interval: 1m

--- a/profiles/uptime-kuma.yaml
+++ b/profiles/uptime-kuma.yaml
@@ -1,0 +1,32 @@
+meta:
+  name: Uptime Kuma
+  category: Monitoring
+  logo: uptime-kuma.png
+  description: Self-hosted uptime monitoring tool
+  capability: webhook_only
+
+webhook:
+  setup_instructions: |
+    In Uptime Kuma go to Settings → Notifications → Add → Webhook.
+    Set the URL to {base_url}/ingest/{token}.
+  recommended_events:
+    - Monitor down
+    - Monitor up
+  not_recommended: []
+  field_mappings:
+    monitor_name: "$.monitor.name"
+    monitor_url: "$.monitor.url"
+    status: "$.heartbeat.status"
+    msg: "$.heartbeat.msg"
+  severity_field: status
+  display_template: "{monitor_name} — {msg}"
+  severity_mapping:
+    "0": error
+    "1": info
+
+digest:
+  categories:
+    - label: Incidents
+      match_field: ""
+      match_value: ""
+      match_severity: error

--- a/profiles/watchtower.yaml
+++ b/profiles/watchtower.yaml
@@ -1,0 +1,27 @@
+meta:
+  name: Watchtower
+  category: Infrastructure
+  logo: watchtower.png
+  description: Automatic Docker container base image updates
+  capability: webhook_only
+
+webhook:
+  setup_instructions: |
+    Configure Watchtower with the HTTP API notifications flag pointing to
+    {base_url}/ingest/{token}. Watchtower posts on each update cycle.
+  recommended_events:
+    - Container updated
+  not_recommended: []
+  field_mappings:
+    updated: "$.updated"
+    hostname: "$.hostname"
+  severity_field: ""
+  display_template: "Containers updated — {hostname}"
+  severity_mapping: {}
+
+digest:
+  categories:
+    - label: Updates
+      match_field: ""
+      match_value: ""
+      match_severity: info


### PR DESCRIPTION
## What
Adds YAML profiles for 11 additional homelab apps, completing the full set of 15 bundled profiles for T-21.

New profiles: lidarr, prowlarr, diun, watchtower, uptime-kuma, tautulli, traefik, matrix (Synapse), overseerr, opnsense, proxmox.

Previously shipped in T-20: sonarr, radarr, n8n, duplicati.

## Why
Closes T-21. Profiles drive field extraction, severity mapping, display templates, monitor checks, and digest categories for the out-of-box experience.

## How
- `full` capability: lidarr, prowlarr, tautulli, overseerr — webhook + monitor
- `webhook_only` capability: diun, watchtower, uptime-kuma — no monitor endpoint
- `monitor_only` capability: traefik, matrix, opnsense, proxmox — no webhook
- Uptime Kuma uses numeric status field (`"0"` = error, `"1"` = info) matching its heartbeat payload
- OPNsense uses `check_type: ping` since it's a router/firewall with no HTTP health endpoint
- Proxmox monitor targets `:8006` (the web UI port) as there is no dedicated health endpoint

## Test coverage
- Extended `profile_test.go` with 5 new test functions covering n8n and duplicati:
  - `TestN8n_ExtractFields` — verifies nested workflow payload extraction
  - `TestN8n_SeverityMapping` — verifies workflow.error→error, node.error→warn, workflow.finished→info
  - `TestDuplicati_ExtractFields` — verifies nested `$.Data.*` path extraction
  - `TestDuplicati_SeverityMapping` — verifies Success/Warning/Error/Fatal mapping
  - `TestDuplicati_RenderDisplayText` — verifies template rendering
- `go test ./internal/profile/...` — 16/16 pass
- `go test ./...` — all packages pass
- `go vet ./...` — clean
- `go build ./cmd/nora/` — binary builds with all 15 profiles embedded

## Closes
Closes #21