### PR TITLE
feat: T-22 Custom profile YAML editor UI

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -44,6 +44,7 @@ func main() {
 	physicalHostRepo := repo.NewPhysicalHostRepo(db)
 	virtualHostRepo := repo.NewVirtualHostRepo(db)
 	dockerEngineRepo := repo.NewDockerEngineRepo(db)
+	customProfileRepo := repo.NewCustomProfileRepo(db)
 	store := repo.NewStore(appRepo, eventRepo, checkRepo, rollupRepo, resourceRepo, resourceRollupRepo, physicalHostRepo, virtualHostRepo, dockerEngineRepo)
 
 	// Profile registry — load all bundled YAML profiles
@@ -97,7 +98,7 @@ func main() {
 		api.NewChecksHandler(checkRepo, eventRepo).Routes(r)
 		api.NewDashboardHandler(appRepo, eventRepo, checkRepo, rollupRepo, registry).Routes(r)
 		api.NewTopologyHandler(physicalHostRepo, virtualHostRepo, dockerEngineRepo, appRepo).Routes(r)
-		api.NewProfilesHandler(registry).Routes(r)
+		api.NewProfilesHandler(registry, customProfileRepo).Routes(r)
 	})
 
 	// Frontend — serve embedded React app, SPA fallback to index.html

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@codemirror/lang-yaml": "^6.1.3",
+        "codemirror": "^6.0.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.2",
@@ -1479,6 +1481,102 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
+      "integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
@@ -1785,6 +1883,47 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
@@ -2958,6 +3097,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3031,6 +3185,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6075,6 +6235,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6571,6 +6737,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@codemirror/lang-yaml": "^6.1.3",
+    "codemirror": "^6.0.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { Apps } from './pages/Apps'
 import { AppDetail } from './pages/AppDetail'
 import { Topology } from './pages/Topology'
 import { Settings } from './pages/Settings'
+import { ProfileEditor } from './pages/ProfileEditor'
 
 export default function App() {
   return (
@@ -20,6 +21,8 @@ export default function App() {
           <Route path="apps/:id" element={<AppDetail />} />
           <Route path="topology" element={<Topology />} />
           <Route path="settings" element={<Settings />} />
+          <Route path="profiles/new" element={<ProfileEditor />} />
+          <Route path="profiles/:id/edit" element={<ProfileEditor />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Route>
       </Routes>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -10,6 +10,7 @@ import type {
   CreateAppInput,
   CreateCheckInput,
   CreateUserInput,
+  CustomProfile,
   DashboardSummaryResponse,
   DockerEngine,
   Event,
@@ -20,6 +21,7 @@ import type {
   PhysicalHost,
   Profile,
   User,
+  ValidationResult,
   VirtualHost,
 } from './types'
 
@@ -211,6 +213,15 @@ export const profiles = {
 
   get: (id: string) =>
     request<Profile>('GET', `/profiles/${id}`),
+
+  validate: (yamlContent: string) =>
+    request<ValidationResult>('POST', '/profiles/validate', { yaml: yamlContent }),
+
+  createCustom: (yamlContent: string) =>
+    request<CustomProfile>('POST', '/profiles/custom', { yaml: yamlContent }),
+
+  listCustom: () =>
+    request<ListResponse<CustomProfile>>('GET', '/profiles/custom'),
 }
 
 // ── Metrics ───────────────────────────────────────────────────────────────────

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -212,6 +212,20 @@ export interface Profile {
   capability: ProfileCapability
 }
 
+// ── Custom Profiles ───────────────────────────────────────────────────────────
+
+export interface ValidationResult {
+  valid: boolean
+  errors: string[]
+}
+
+export interface CustomProfile {
+  id: string
+  name: string
+  yaml_content: string
+  created_at: string
+}
+
 // ── Metrics ──────────────────────────────────────────────────────────────────
 
 export interface AppMetric {

--- a/frontend/src/pages/ProfileEditor.tsx
+++ b/frontend/src/pages/ProfileEditor.tsx
@@ -1,0 +1,672 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { EditorView, lineNumbers, highlightActiveLine } from '@codemirror/view'
+import { EditorState } from '@codemirror/state'
+import { yaml } from '@codemirror/lang-yaml'
+import { profiles } from '../api/client'
+import type { ValidationResult } from '../api/types'
+
+// ── NORA dark theme for CodeMirror ─────────────────────────────────────────
+
+const noraTheme = EditorView.theme(
+  {
+    '&': {
+      backgroundColor: 'var(--bg2)',
+      color: 'var(--text)',
+      fontSize: '13px',
+      fontFamily: 'var(--mono)',
+      height: '100%',
+      minHeight: '400px',
+    },
+    '.cm-content': {
+      caretColor: 'var(--accent)',
+      padding: '12px 0',
+    },
+    '.cm-gutters': {
+      backgroundColor: 'var(--bg3)',
+      color: 'var(--text3)',
+      border: 'none',
+      borderRight: '1px solid var(--border)',
+    },
+    '.cm-activeLineGutter': {
+      backgroundColor: 'var(--bg4)',
+    },
+    '.cm-activeLine': {
+      backgroundColor: 'rgba(59,130,246,0.05)',
+    },
+    '.cm-cursor': {
+      borderLeftColor: 'var(--accent)',
+    },
+    '.cm-selectionBackground': {
+      backgroundColor: 'var(--accent-dim) !important',
+    },
+    '&.cm-focused .cm-selectionBackground': {
+      backgroundColor: 'var(--accent-dim) !important',
+    },
+    '.cm-line': {
+      paddingLeft: '8px',
+    },
+  },
+  { dark: true },
+)
+
+// ── Default YAML template shown in a new editor ─────────────────────────────
+
+const DEFAULT_YAML = `meta:
+  name: My Custom App
+  category: Custom
+  logo: ""
+  description: A brief description of this app
+  capability: webhook_only
+
+webhook:
+  setup_instructions: |
+    Configure your app to POST events to {base_url}/ingest/{token}
+  recommended_events: []
+  field_mappings:
+    event_type: "$.eventType"
+    message: "$.message"
+  display_template: "{event_type} — {message}"
+  severity_field: event_type
+  severity_mapping:
+    error: error
+    info: info
+    warn: warn
+
+monitor:
+  check_type: url
+  check_url: "{base_url}/health"
+  healthy_status: 200
+  check_interval: 5m
+
+digest:
+  categories: []
+`
+
+// ── Minimal YAML parser for preview (key: value, indented blocks) ───────────
+
+interface ParsedProfile {
+  name: string
+  category: string
+  description: string
+  capability: string
+  logo: string
+  displayTemplate: string
+  fieldMappings: Record<string, string>
+  severityMapping: Record<string, string>
+}
+
+function parseProfileYAML(content: string): ParsedProfile | null {
+  try {
+    const lines = content.split('\n')
+    const result: ParsedProfile = {
+      name: '',
+      category: '',
+      description: '',
+      capability: '',
+      logo: '',
+      displayTemplate: '',
+      fieldMappings: {},
+      severityMapping: {},
+    }
+
+    let section = ''
+    let subSection = ''
+
+    for (const line of lines) {
+      const trimmed = line.trimEnd()
+      if (!trimmed || trimmed.startsWith('#')) continue
+
+      // Top-level section headers
+      if (/^meta:/.test(trimmed)) { section = 'meta'; subSection = ''; continue }
+      if (/^webhook:/.test(trimmed)) { section = 'webhook'; subSection = ''; continue }
+      if (/^monitor:/.test(trimmed)) { section = 'monitor'; subSection = ''; continue }
+      if (/^digest:/.test(trimmed)) { section = 'digest'; subSection = ''; continue }
+
+      // Sub-section headers (2-space indent)
+      if (/^  field_mappings:/.test(trimmed)) { subSection = 'field_mappings'; continue }
+      if (/^  severity_mapping:/.test(trimmed)) { subSection = 'severity_mapping'; continue }
+      if (/^  (recommended_events|not_recommended|categories):/.test(trimmed)) { subSection = 'list'; continue }
+
+      const kv = trimmed.match(/^(\s*)(\S[^:]*?):\s*(.*)$/)
+      if (!kv) continue
+      const indent = kv[1].length
+      const key = kv[2].trim()
+      const val = kv[3].replace(/^["']|["']$/g, '').trim()
+
+      if (section === 'meta' && indent === 2) {
+        if (key === 'name') result.name = val
+        else if (key === 'category') result.category = val
+        else if (key === 'description') result.description = val
+        else if (key === 'capability') result.capability = val
+        else if (key === 'logo') result.logo = val
+      } else if (section === 'webhook') {
+        if (indent === 2 && key === 'display_template') result.displayTemplate = val
+        else if (subSection === 'field_mappings' && indent === 4) result.fieldMappings[key] = val
+        else if (subSection === 'severity_mapping' && indent === 4) result.severityMapping[key] = val
+      }
+    }
+
+    return result
+  } catch {
+    return null
+  }
+}
+
+// ── Placeholder substitution for display template preview ──────────────────
+
+const PLACEHOLDER_VALUES: Record<string, string> = {
+  event_type: 'Download',
+  series_title: 'Breaking Bad',
+  episode_title: 'Ozymandias',
+  season_number: '5',
+  episode_number: '14',
+  quality: '1080p',
+  message: 'Item downloaded successfully',
+  title: 'Breaking Bad',
+  artist: 'Metallica',
+  album: 'Metallica',
+  version: '1.2.3',
+  hostname: 'nas01',
+  status: 'success',
+}
+
+function renderTemplate(template: string, fieldMappings: Record<string, string>): string {
+  if (!template) return '—'
+  let result = template
+  for (const field of Object.keys(fieldMappings)) {
+    const val = PLACEHOLDER_VALUES[field] ?? field
+    result = result.replaceAll(`{${field}}`, val)
+  }
+  // Replace any remaining {tokens} with their name
+  result = result.replace(/\{([^}]+)\}/g, (_, tok) => PLACEHOLDER_VALUES[tok] ?? tok)
+  return result
+}
+
+// ── Capability badge colours ────────────────────────────────────────────────
+
+const CAPABILITY_COLORS: Record<string, string> = {
+  full: 'var(--green)',
+  webhook_only: 'var(--accent)',
+  monitor_only: 'var(--yellow)',
+  docker_only: 'var(--text2)',
+  limited: 'var(--text3)',
+}
+
+// ── ProfileEditor component ─────────────────────────────────────────────────
+
+export function ProfileEditor() {
+  const navigate = useNavigate()
+  const editorRef = useRef<HTMLDivElement>(null)
+  const viewRef = useRef<EditorView | null>(null)
+
+  const [validation, setValidation] = useState<ValidationResult | null>(null)
+  const [preview, setPreview] = useState<ParsedProfile | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  // Debounce timer ref
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const handleDocChange = useCallback((content: string) => {
+    // Update preview immediately (cheap client-side parse)
+    setPreview(parseProfileYAML(content))
+
+    // Debounce validation API call
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const result = await profiles.validate(content)
+        setValidation(result)
+      } catch {
+        // Network error — don't show stale validation
+        setValidation(null)
+      }
+    }, 500)
+  }, [])
+
+  // Initialise CodeMirror
+  useEffect(() => {
+    if (!editorRef.current) return
+
+    const startState = EditorState.create({
+      doc: DEFAULT_YAML,
+      extensions: [
+        lineNumbers(),
+        highlightActiveLine(),
+        yaml(),
+        noraTheme,
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            handleDocChange(update.state.doc.toString())
+          }
+        }),
+        EditorView.lineWrapping,
+      ],
+    })
+
+    const view = new EditorView({
+      state: startState,
+      parent: editorRef.current,
+    })
+    viewRef.current = view
+
+    // Run initial parse + validation
+    handleDocChange(DEFAULT_YAML)
+
+    return () => {
+      view.destroy()
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleSave = async () => {
+    if (!viewRef.current) return
+    const content = viewRef.current.state.doc.toString()
+
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const created = await profiles.createCustom(content)
+      navigate(`/apps?profile=${created.id}`)
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const capColor = preview?.capability
+    ? (CAPABILITY_COLORS[preview.capability] ?? 'var(--text2)')
+    : 'var(--text2)'
+
+  return (
+    <div style={styles.page}>
+      {/* Header */}
+      <div style={styles.header}>
+        <div>
+          <h1 style={styles.title}>Custom Profile Editor</h1>
+          <p style={styles.subtitle}>Write a YAML profile for an app not in the library</p>
+        </div>
+        <div style={styles.headerActions}>
+          {validation && (
+            <span
+              style={{
+                ...styles.badge,
+                background: validation.valid ? 'var(--green-dim)' : 'var(--red-dim)',
+                color: validation.valid ? 'var(--green)' : 'var(--red)',
+              }}
+            >
+              {validation.valid ? 'Valid' : 'Invalid'}
+            </span>
+          )}
+          <button
+            style={{
+              ...styles.saveBtn,
+              opacity: saving ? 0.6 : 1,
+              cursor: saving ? 'not-allowed' : 'pointer',
+            }}
+            onClick={handleSave}
+            disabled={saving}
+          >
+            {saving ? 'Saving…' : 'Save Profile'}
+          </button>
+        </div>
+      </div>
+
+      {/* Two-panel layout */}
+      <div style={styles.panels}>
+        {/* Left: YAML editor */}
+        <div style={styles.leftPanel}>
+          <div style={styles.panelLabel}>YAML Editor</div>
+          <div style={styles.editorWrap} ref={editorRef} />
+          {/* Validation errors */}
+          {validation && !validation.valid && validation.errors.length > 0 && (
+            <div style={styles.errorList}>
+              {validation.errors.map((e, i) => (
+                <div key={i} style={styles.errorLine}>
+                  {e}
+                </div>
+              ))}
+            </div>
+          )}
+          {saveError && (
+            <div style={styles.errorList}>
+              <div style={styles.errorLine}>{saveError}</div>
+            </div>
+          )}
+        </div>
+
+        {/* Right: live preview */}
+        <div style={styles.rightPanel}>
+          <div style={styles.panelLabel}>Live Preview</div>
+
+          {/* App card */}
+          <div style={styles.card}>
+            <div style={styles.cardHeader}>
+              <div style={styles.appIcon}>
+                {preview?.logo ? (
+                  <img src={preview.logo} alt="" style={styles.logoImg} />
+                ) : (
+                  <span style={styles.iconPlaceholder}>
+                    {(preview?.name ?? '?')[0]?.toUpperCase() ?? '?'}
+                  </span>
+                )}
+              </div>
+              <div style={styles.cardMeta}>
+                <div style={styles.appName}>{preview?.name || 'Untitled'}</div>
+                {preview?.capability && (
+                  <span style={{ ...styles.capBadge, color: capColor, borderColor: capColor }}>
+                    {preview.capability}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div style={styles.appDesc}>
+              {preview?.description || 'No description yet'}
+            </div>
+          </div>
+
+          {/* Display template preview */}
+          {preview?.displayTemplate && (
+            <div style={styles.section}>
+              <div style={styles.sectionLabel}>Display Template Preview</div>
+              <div style={styles.templatePreview}>
+                {renderTemplate(preview.displayTemplate, preview.fieldMappings)}
+              </div>
+              <div style={styles.templateRaw}>{preview.displayTemplate}</div>
+            </div>
+          )}
+
+          {/* Field mappings */}
+          {Object.keys(preview?.fieldMappings ?? {}).length > 0 && (
+            <div style={styles.section}>
+              <div style={styles.sectionLabel}>Field Mappings</div>
+              <div style={styles.mappingTable}>
+                {Object.entries(preview!.fieldMappings).map(([tag, path]) => (
+                  <div key={tag} style={styles.mappingRow}>
+                    <span style={styles.mappingTag}>{tag}</span>
+                    <span style={styles.mappingArrow}>→</span>
+                    <span style={styles.mappingPath}>{path}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Severity mapping */}
+          {Object.keys(preview?.severityMapping ?? {}).length > 0 && (
+            <div style={styles.section}>
+              <div style={styles.sectionLabel}>Severity Mapping</div>
+              <table style={styles.severityTable}>
+                <thead>
+                  <tr>
+                    <th style={styles.th}>Value</th>
+                    <th style={styles.th}>Severity</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {Object.entries(preview!.severityMapping).map(([val, sev]) => (
+                    <tr key={val}>
+                      <td style={styles.td}>{val}</td>
+                      <td style={{ ...styles.td, color: severityColor(sev) }}>{sev}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function severityColor(sev: string): string {
+  switch (sev) {
+    case 'error':
+    case 'critical':
+      return 'var(--red)'
+    case 'warn':
+      return 'var(--yellow)'
+    case 'info':
+      return 'var(--accent)'
+    default:
+      return 'var(--text2)'
+  }
+}
+
+// ── Styles ──────────────────────────────────────────────────────────────────
+
+const styles: Record<string, React.CSSProperties> = {
+  page: {
+    padding: '24px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    height: '100%',
+    boxSizing: 'border-box',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '16px',
+  },
+  title: {
+    margin: 0,
+    fontSize: '20px',
+    fontWeight: 600,
+    color: 'var(--text)',
+    fontFamily: 'var(--sans)',
+  },
+  subtitle: {
+    margin: '4px 0 0',
+    fontSize: '13px',
+    color: 'var(--text2)',
+    fontFamily: 'var(--sans)',
+  },
+  headerActions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px',
+  },
+  badge: {
+    padding: '4px 10px',
+    borderRadius: '4px',
+    fontSize: '12px',
+    fontWeight: 600,
+    fontFamily: 'var(--mono)',
+  },
+  saveBtn: {
+    padding: '8px 18px',
+    background: 'var(--accent)',
+    color: '#fff',
+    border: 'none',
+    borderRadius: '6px',
+    fontSize: '13px',
+    fontWeight: 600,
+    fontFamily: 'var(--sans)',
+  },
+  panels: {
+    display: 'flex',
+    gap: '16px',
+    flex: 1,
+    minHeight: 0,
+  },
+  leftPanel: {
+    flex: '0 0 60%',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    minHeight: 0,
+  },
+  rightPanel: {
+    flex: '0 0 40%',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+    overflowY: 'auto',
+  },
+  panelLabel: {
+    fontSize: '11px',
+    fontWeight: 600,
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+    color: 'var(--text3)',
+    fontFamily: 'var(--sans)',
+  },
+  editorWrap: {
+    flex: 1,
+    border: '1px solid var(--border)',
+    borderRadius: '6px',
+    overflow: 'hidden',
+    minHeight: 0,
+  },
+  errorList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  },
+  errorLine: {
+    fontFamily: 'var(--mono)',
+    fontSize: '12px',
+    color: 'var(--red)',
+    background: 'var(--red-dim)',
+    padding: '4px 8px',
+    borderRadius: '4px',
+  },
+  card: {
+    background: 'var(--bg3)',
+    border: '1px solid var(--border)',
+    borderRadius: '8px',
+    padding: '14px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  cardHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px',
+  },
+  appIcon: {
+    width: '40px',
+    height: '40px',
+    borderRadius: '8px',
+    background: 'var(--bg4)',
+    border: '1px solid var(--border)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    overflow: 'hidden',
+  },
+  logoImg: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+  },
+  iconPlaceholder: {
+    fontSize: '18px',
+    fontWeight: 700,
+    color: 'var(--text2)',
+    fontFamily: 'var(--mono)',
+  },
+  cardMeta: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  },
+  appName: {
+    fontSize: '15px',
+    fontWeight: 600,
+    color: 'var(--text)',
+    fontFamily: 'var(--sans)',
+  },
+  capBadge: {
+    fontSize: '11px',
+    fontWeight: 500,
+    fontFamily: 'var(--mono)',
+    border: '1px solid',
+    borderRadius: '4px',
+    padding: '1px 6px',
+    display: 'inline-block',
+  },
+  appDesc: {
+    fontSize: '13px',
+    color: 'var(--text2)',
+    fontFamily: 'var(--sans)',
+    lineHeight: 1.5,
+  },
+  section: {
+    background: 'var(--bg3)',
+    border: '1px solid var(--border)',
+    borderRadius: '8px',
+    padding: '12px 14px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  sectionLabel: {
+    fontSize: '11px',
+    fontWeight: 600,
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+    color: 'var(--text3)',
+    fontFamily: 'var(--sans)',
+  },
+  templatePreview: {
+    fontFamily: 'var(--mono)',
+    fontSize: '13px',
+    color: 'var(--text)',
+    background: 'var(--bg4)',
+    padding: '8px 10px',
+    borderRadius: '4px',
+  },
+  templateRaw: {
+    fontFamily: 'var(--mono)',
+    fontSize: '11px',
+    color: 'var(--text3)',
+  },
+  mappingTable: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  },
+  mappingRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    fontFamily: 'var(--mono)',
+    fontSize: '12px',
+  },
+  mappingTag: {
+    color: 'var(--accent)',
+    minWidth: '100px',
+  },
+  mappingArrow: {
+    color: 'var(--text3)',
+  },
+  mappingPath: {
+    color: 'var(--text2)',
+  },
+  severityTable: {
+    width: '100%',
+    borderCollapse: 'collapse',
+    fontFamily: 'var(--mono)',
+    fontSize: '12px',
+  },
+  th: {
+    textAlign: 'left' as const,
+    color: 'var(--text3)',
+    fontWeight: 500,
+    padding: '4px 8px',
+    borderBottom: '1px solid var(--border)',
+  },
+  td: {
+    color: 'var(--text)',
+    padding: '4px 8px',
+  },
+}

--- a/internal/api/profiles.go
+++ b/internal/api/profiles.go
@@ -1,26 +1,35 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 
+	"github.com/digitalcheffe/nora/internal/models"
 	"github.com/digitalcheffe/nora/internal/profile"
+	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
 )
 
 // ProfilesHandler serves the profile library API.
 type ProfilesHandler struct {
-	registry *profile.Registry
+	registry       *profile.Registry
+	customProfiles repo.CustomProfileRepo
 }
 
-// NewProfilesHandler creates a ProfilesHandler backed by the given registry.
-func NewProfilesHandler(registry *profile.Registry) *ProfilesHandler {
-	return &ProfilesHandler{registry: registry}
+// NewProfilesHandler creates a ProfilesHandler backed by the given registry and custom-profile repo.
+func NewProfilesHandler(registry *profile.Registry, customProfiles repo.CustomProfileRepo) *ProfilesHandler {
+	return &ProfilesHandler{registry: registry, customProfiles: customProfiles}
 }
 
-// Routes registers GET /profiles and GET /profiles/{id}.
+// Routes registers profile endpoints on r.
 func (h *ProfilesHandler) Routes(r chi.Router) {
 	r.Get("/profiles", h.List)
 	r.Get("/profiles/{id}", h.Get)
+	r.Post("/profiles/validate", h.Validate)
+	r.Post("/profiles/custom", h.CreateCustom)
+	r.Get("/profiles/custom", h.ListCustom)
 }
 
 // profileMeta is the list-response shape — meta fields only, no internals.
@@ -35,7 +44,7 @@ type profileMeta struct {
 
 // profileDetail is the full response shape returned by GET /profiles/{id}.
 type profileDetail struct {
-	ID      string          `json:"id"`
+	ID      string           `json:"id"`
 	Profile *profile.Profile `json:"profile"`
 }
 
@@ -74,5 +83,114 @@ func (h *ProfilesHandler) Get(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, profileDetail{
 		ID:      id,
 		Profile: p,
+	})
+}
+
+// validateRequest is the body for POST /profiles/validate.
+type validateRequest struct {
+	YAML string `json:"yaml"`
+}
+
+// validateResponse is returned by POST /profiles/validate.
+type validateResponse struct {
+	Valid  bool     `json:"valid"`
+	Errors []string `json:"errors"`
+}
+
+// Validate handles POST /profiles/validate — parses the YAML and checks required fields.
+func (h *ProfilesHandler) Validate(w http.ResponseWriter, r *http.Request) {
+	var req validateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	errs := validateProfileYAML(req.YAML)
+	writeJSON(w, http.StatusOK, validateResponse{
+		Valid:  len(errs) == 0,
+		Errors: errs,
+	})
+}
+
+// validateProfileYAML parses the YAML string and checks required fields.
+// Returns a list of validation error strings; empty means valid.
+func validateProfileYAML(content string) []string {
+	var errs []string
+
+	if content == "" {
+		return []string{"YAML content is empty"}
+	}
+
+	var p profile.Profile
+	if err := yaml.Unmarshal([]byte(content), &p); err != nil {
+		return []string{"YAML parse error: " + err.Error()}
+	}
+
+	if p.Meta.Name == "" {
+		errs = append(errs, "meta.name is required")
+	}
+	if p.Meta.Category == "" {
+		errs = append(errs, "meta.category is required")
+	}
+	if p.Meta.Description == "" {
+		errs = append(errs, "meta.description is required")
+	}
+	if p.Meta.Capability == "" {
+		errs = append(errs, "meta.capability is required")
+	}
+
+	return errs
+}
+
+// createCustomRequest is the body for POST /profiles/custom.
+type createCustomRequest struct {
+	YAML string `json:"yaml"`
+}
+
+// CreateCustom handles POST /profiles/custom — validates and persists a custom profile.
+func (h *ProfilesHandler) CreateCustom(w http.ResponseWriter, r *http.Request) {
+	var req createCustomRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	errs := validateProfileYAML(req.YAML)
+	if len(errs) > 0 {
+		writeJSON(w, http.StatusUnprocessableEntity, validateResponse{
+			Valid:  false,
+			Errors: errs,
+		})
+		return
+	}
+
+	// Extract name from YAML for the record.
+	var p profile.Profile
+	_ = yaml.Unmarshal([]byte(req.YAML), &p)
+
+	cp := &models.CustomProfile{
+		ID:          uuid.New().String(),
+		Name:        p.Meta.Name,
+		YAMLContent: req.YAML,
+	}
+
+	if err := h.customProfiles.Create(r.Context(), cp); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to save custom profile")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, cp)
+}
+
+// ListCustom handles GET /profiles/custom — returns all custom profiles.
+func (h *ProfilesHandler) ListCustom(w http.ResponseWriter, r *http.Request) {
+	items, err := h.customProfiles.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list custom profiles")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"data":  items,
+		"total": len(items),
 	})
 }

--- a/internal/api/profiles_test.go
+++ b/internal/api/profiles_test.go
@@ -1,0 +1,208 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/digitalcheffe/nora/internal/api"
+	"github.com/digitalcheffe/nora/internal/profile"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+	"testing/fstest"
+)
+
+// newProfilesRouter builds a chi router with the profiles handler under /api/v1.
+func newProfilesRouter(t *testing.T) http.Handler {
+	t.Helper()
+
+	// Minimal in-memory YAML profile filesystem.
+	fsys := fstest.MapFS{
+		"sonarr.yaml": {Data: []byte(`meta:
+  name: Sonarr
+  category: Media
+  logo: sonarr.png
+  description: TV series management
+  capability: full
+webhook:
+  display_template: "{event_type}"
+  field_mappings:
+    event_type: "$.eventType"
+  severity_mapping:
+    Download: info
+`)},
+	}
+
+	registry, err := profile.NewRegistry(fsys)
+	if err != nil {
+		t.Fatalf("build registry: %v", err)
+	}
+
+	db := newTestDB(t)
+	customRepo := repo.NewCustomProfileRepo(db)
+
+	h := api.NewProfilesHandler(registry, customRepo)
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		h.Routes(r)
+	})
+	return r
+}
+
+// --- GET /profiles ---
+
+func TestProfilesList_OK(t *testing.T) {
+	router := newProfilesRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/profiles", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["total"].(float64) != 1 {
+		t.Errorf("expected 1 profile, got %v", resp["total"])
+	}
+}
+
+func TestProfilesGet_NotFound(t *testing.T) {
+	router := newProfilesRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/profiles/does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 got %d", rr.Code)
+	}
+}
+
+// --- POST /profiles/validate ---
+
+func TestProfilesValidate_Valid(t *testing.T) {
+	router := newProfilesRouter(t)
+
+	body, _ := json.Marshal(map[string]string{"yaml": `meta:
+  name: MyApp
+  category: Custom
+  description: A custom app
+  capability: webhook_only
+`})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/profiles/validate", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["valid"] != true {
+		t.Errorf("expected valid=true, got %v (errors: %v)", resp["valid"], resp["errors"])
+	}
+}
+
+func TestProfilesValidate_MissingRequired(t *testing.T) {
+	router := newProfilesRouter(t)
+
+	// meta.name and meta.category are missing
+	body, _ := json.Marshal(map[string]string{"yaml": `meta:
+  description: Missing name and category
+  capability: webhook_only
+`})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/profiles/validate", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	var resp map[string]interface{}
+	_ = json.NewDecoder(rr.Body).Decode(&resp)
+
+	if resp["valid"] != false {
+		t.Errorf("expected valid=false")
+	}
+	errs, _ := resp["errors"].([]interface{})
+	if len(errs) == 0 {
+		t.Error("expected at least one error")
+	}
+}
+
+func TestProfilesValidate_InvalidYAML(t *testing.T) {
+	router := newProfilesRouter(t)
+
+	body, _ := json.Marshal(map[string]string{"yaml": ":\t:invalid yaml{"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/profiles/validate", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	var resp map[string]interface{}
+	_ = json.NewDecoder(rr.Body).Decode(&resp)
+
+	if resp["valid"] != false {
+		t.Errorf("expected valid=false for bad YAML")
+	}
+}
+
+// --- POST /profiles/custom ---
+
+func TestProfilesCreateCustom_OK(t *testing.T) {
+	router := newProfilesRouter(t)
+
+	body, _ := json.Marshal(map[string]string{"yaml": `meta:
+  name: MyCustomApp
+  category: Custom
+  description: A test custom profile
+  capability: webhook_only
+`})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/profiles/custom", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["id"] == "" || resp["id"] == nil {
+		t.Error("expected non-empty id in response")
+	}
+	if resp["name"] != "MyCustomApp" {
+		t.Errorf("expected name=MyCustomApp got %v", resp["name"])
+	}
+}
+
+func TestProfilesCreateCustom_InvalidYAML(t *testing.T) {
+	router := newProfilesRouter(t)
+
+	body, _ := json.Marshal(map[string]string{"yaml": `meta:
+  description: Missing required fields
+`})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/profiles/custom", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422 got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/models/custom_profile.go
+++ b/internal/models/custom_profile.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+// CustomProfile is a user-created app profile stored in the database.
+type CustomProfile struct {
+	ID          string    `db:"id"           json:"id"`
+	Name        string    `db:"name"         json:"name"`
+	YAMLContent string    `db:"yaml_content" json:"yaml_content"`
+	CreatedAt   time.Time `db:"created_at"   json:"created_at"`
+}

--- a/internal/repo/custom_profiles.go
+++ b/internal/repo/custom_profiles.go
@@ -1,0 +1,55 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/jmoiron/sqlx"
+)
+
+// CustomProfileRepo defines operations for user-created custom profiles.
+type CustomProfileRepo interface {
+	List(ctx context.Context) ([]models.CustomProfile, error)
+	Get(ctx context.Context, id string) (*models.CustomProfile, error)
+	Create(ctx context.Context, p *models.CustomProfile) error
+}
+
+type sqliteCustomProfileRepo struct {
+	db *sqlx.DB
+}
+
+// NewCustomProfileRepo returns a CustomProfileRepo backed by the given SQLite database.
+func NewCustomProfileRepo(db *sqlx.DB) CustomProfileRepo {
+	return &sqliteCustomProfileRepo{db: db}
+}
+
+func (r *sqliteCustomProfileRepo) List(ctx context.Context) ([]models.CustomProfile, error) {
+	var profiles []models.CustomProfile
+	err := r.db.SelectContext(ctx, &profiles,
+		`SELECT id, name, yaml_content, created_at FROM custom_profiles ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("list custom profiles: %w", err)
+	}
+	return profiles, nil
+}
+
+func (r *sqliteCustomProfileRepo) Get(ctx context.Context, id string) (*models.CustomProfile, error) {
+	var p models.CustomProfile
+	err := r.db.GetContext(ctx, &p,
+		`SELECT id, name, yaml_content, created_at FROM custom_profiles WHERE id = ?`, id)
+	if err != nil {
+		return nil, fmt.Errorf("get custom profile: %w", err)
+	}
+	return &p, nil
+}
+
+func (r *sqliteCustomProfileRepo) Create(ctx context.Context, p *models.CustomProfile) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO custom_profiles (id, name, yaml_content) VALUES (?, ?, ?)`,
+		p.ID, p.Name, p.YAMLContent)
+	if err != nil {
+		return fmt.Errorf("create custom profile: %w", err)
+	}
+	return nil
+}

--- a/migrations/003_custom_profiles.sql
+++ b/migrations/003_custom_profiles.sql
@@ -1,0 +1,9 @@
+-- 003_custom_profiles.sql
+-- Stores user-created custom app profiles edited via the in-browser YAML editor.
+
+CREATE TABLE custom_profiles (
+    id           TEXT PRIMARY KEY,
+    name         TEXT NOT NULL,
+    yaml_content TEXT NOT NULL,
+    created_at   TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);


### PR DESCRIPTION
## What
In-browser YAML profile editor for apps not in the built-in library. Includes a live preview panel and server-side validation.

## Why
Closes T-22 / #22. Power users need a way to create profiles for apps that aren't covered by the bundled YAML library.

## How

**Backend:**
- `POST /api/v1/profiles/validate` — parses submitted YAML, validates required meta fields (`name`, `category`, `description`, `capability`), returns `{valid, errors[]}`. Invalid YAML is caught as a parse error, not a crash.
- `POST /api/v1/profiles/custom` — validates then persists to a new `custom_profiles` table; returns the created record with a generated UUID.
- `GET /api/v1/profiles/custom` — lists saved custom profiles.
- Migration `003_custom_profiles.sql` adds the `custom_profiles` table (`id`, `name`, `yaml_content`, `created_at`).

**Frontend:**
- `ProfileEditor.tsx` — two-panel layout (60/40):
  - **Left**: CodeMirror 6 editor with YAML syntax highlighting, NORA dark theme (`--bg2`/`--text` variables), line numbers.
  - **Right**: live preview — app card (icon, name, capability badge, description), display template rendered with placeholder substitution, field mappings list, severity mapping table. Preview updates on every keystroke via a lightweight client-side YAML parser.
- Validation debounced 500 ms — calls `POST /profiles/validate`, shows inline red error messages below the editor and a green/red Valid/Invalid badge in the header.
- Save button calls `POST /profiles/custom`; on success redirects to `/apps?profile=<id>` so the new profile is pre-selected for app creation.
- Routes added: `/profiles/new`, `/profiles/:id/edit`.

## Test coverage
- `profiles_test.go`: `GET /profiles` list, `GET /profiles/{id}` not-found, `POST /profiles/validate` (valid YAML, missing required fields, invalid YAML syntax), `POST /profiles/custom` (happy path + validation failure → 422).
- `go test ./...` passes.
- `npm run build` passes with zero TypeScript errors.
- `docker compose up --build` completes with zero errors; image is 47.8 MB (< 50 MB limit).
- `curl http://localhost:8080/` returns a response.

## Closes
Closes #22