### PR TITLE
feat: T-23 Monitor checks screen + SSL panel

### DIFF
--- a/frontend/src/pages/Checks.css
+++ b/frontend/src/pages/Checks.css
@@ -1,3 +1,4 @@
+/* ── EMPTY STATE ── */
 .checks-empty {
   padding: 40px;
   text-align: center;
@@ -9,21 +10,52 @@
   border-radius: 8px;
 }
 
-/* Monitor widget — extracted from dashboard mockup */
-.monitor-widget {
-  background: var(--bg2);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 14px;
-  cursor: pointer;
-  transition: all 0.15s;
+/* ── SECTION HEADER (shared pattern) ── */
+.section-header {
   display: flex;
   align-items: center;
-  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 10px;
 }
 
-.monitor-widget:hover { border-color: var(--border2); }
+.section-title {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
 
+.section-title::before {
+  content: '';
+  width: 2px;
+  height: 12px;
+  background: var(--accent);
+  border-radius: 1px;
+  display: block;
+}
+
+.section-action {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0.7;
+  transition: opacity 0.15s;
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+.section-action:hover { opacity: 1; }
+
+/* ── MONITOR WIDGET (shared styles) ── */
 .monitor-status-block {
   width: 36px;
   height: 36px;
@@ -38,21 +70,249 @@
   letter-spacing: 0.05em;
 }
 
-.monitor-status-block.up   { background: var(--green-dim);  color: var(--green);  border: 1px solid #166534; }
-.monitor-status-block.warn { background: var(--yellow-dim); color: var(--yellow); border: 1px solid #854d0e; }
-.monitor-status-block.down { background: var(--red-dim);    color: var(--red);    border: 1px solid #991b1b; }
+.monitor-status-block.up      { background: var(--green-dim);  color: var(--green);  border: 1px solid #166534; }
+.monitor-status-block.warn    { background: var(--yellow-dim); color: var(--yellow); border: 1px solid #854d0e; }
+.monitor-status-block.down    { background: var(--red-dim);    color: var(--red);    border: 1px solid #991b1b; }
+.monitor-status-block.unknown { background: var(--bg4);        color: var(--text3);  border: 1px solid var(--border); }
 
-.monitor-info { flex: 1; min-width: 0; }
-.monitor-name   { font-size: 13px; font-weight: 500; color: var(--text); }
-.monitor-target {
+.monitor-info    { flex: 1; min-width: 0; }
+.monitor-name    { font-size: 13px; font-weight: 500; color: var(--text); }
+.monitor-target  { font-family: var(--mono); font-size: 10px; color: var(--text3); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+.monitor-meta    { text-align: right; flex-shrink: 0; }
+.monitor-uptime  { font-family: var(--mono); font-size: 12px; font-weight: 600; color: var(--green); }
+.monitor-uptime.warn { color: var(--yellow); }
+.monitor-uptime.down { color: var(--red); }
+.monitor-last    { font-family: var(--mono); font-size: 10px; color: var(--text3); }
+
+/* ── CHECKS LIST ── */
+.checks-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* ── CHECK ROW ── */
+.check-row {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.check-row:hover { border-color: var(--border2); }
+
+.check-row-wrapper.expanded .check-row {
+  border-radius: 8px 8px 0 0;
+}
+
+/* ── EXPAND PANEL ── */
+.check-expand {
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-top: none;
+  border-radius: 0 0 8px 8px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.check-expand-details {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  white-space: pre-wrap;
+  word-break: break-all;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  line-height: 1.6;
+}
+
+/* ── RUN BUTTON ── */
+.check-run-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  color: var(--text2);
+  font-size: 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: all 0.15s;
+}
+
+.check-run-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.check-run-btn:disabled { cursor: default; opacity: 0.6; }
+.check-run-btn.running  { border-color: var(--accent-dim); }
+
+/* ── SPINNER ── */
+.check-spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--accent-dim);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── ADD / EDIT FORM ── */
+.add-form {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.form-title {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.type-selector {
+  display: flex;
+  gap: 6px;
+}
+
+.type-btn {
+  padding: 6px 14px;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text2);
+  font-family: var(--mono);
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.type-btn:hover  { border-color: var(--border2); color: var(--text); }
+.type-btn.active { background: var(--accent-dim); border-color: var(--accent); color: var(--accent); }
+
+.form-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.form-label {
   font-family: var(--mono);
   font-size: 10px;
   color: var(--text3);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
-.monitor-meta { text-align: right; flex-shrink: 0; }
-.monitor-uptime { font-family: var(--mono); font-size: 12px; font-weight: 600; color: var(--green); }
-.monitor-last   { font-family: var(--mono); font-size: 10px; color: var(--text3); }
+.form-input {
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 7px 10px;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.form-input:focus { border-color: var(--accent); }
+
+.form-error {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--red);
+}
+
+.form-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.form-btn {
+  padding: 7px 16px;
+  border-radius: 6px;
+  font-family: var(--mono);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: 1px solid transparent;
+}
+
+.form-btn.primary              { background: var(--accent);   color: white;         border-color: var(--accent); }
+.form-btn.primary:hover:not(:disabled) { opacity: 0.85; }
+.form-btn.primary:disabled     { opacity: 0.5; cursor: default; }
+
+.form-btn.secondary            { background: var(--bg3);      color: var(--text2);  border-color: var(--border); }
+.form-btn.secondary:hover      { border-color: var(--border2); color: var(--text); }
+
+.form-btn.danger               { background: var(--red-dim);  color: var(--red);    border-color: #991b1b; }
+.form-btn.danger:hover:not(:disabled) { opacity: 0.85; }
+.form-btn.danger:disabled      { opacity: 0.5; cursor: default; }
+
+/* ── SSL PANEL ── */
+.ssl-panel {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.ssl-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  transition: background 0.1s;
+}
+
+.ssl-row:last-child { border-bottom: none; }
+.ssl-row:hover      { background: var(--bg3); }
+
+.ssl-days {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  width: 50px;
+  flex-shrink: 0;
+}
+
+.ssl-days.good { color: var(--green); }
+.ssl-days.warn { color: var(--yellow); }
+.ssl-days.crit { color: var(--red); }
+
+.ssl-domain { font-size: 12px; color: var(--text); flex: 1; font-family: var(--mono); }
+.ssl-date   { font-family: var(--mono); font-size: 10px; color: var(--text3); }

--- a/frontend/src/pages/Checks.tsx
+++ b/frontend/src/pages/Checks.tsx
@@ -1,18 +1,486 @@
+import { useState, useEffect } from 'react'
+import type { ReactNode } from 'react'
 import { Topbar } from '../components/Topbar'
+import { SSLRow } from '../components/SSLRow'
+import { checks as checksApi } from '../api/client'
+import type { MonitorCheck, CreateCheckInput, CheckType, SSLCert } from '../api/types'
 import './Checks.css'
 
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type FormFields = {
+  type: CheckType
+  name: string
+  target: string
+  interval_secs: string
+  expected_status: string
+  ssl_warn_days: string
+  ssl_crit_days: string
+}
+
+const defaultForm: FormFields = {
+  type: 'ping',
+  name: '',
+  target: '',
+  interval_secs: '60',
+  expected_status: '200',
+  ssl_warn_days: '30',
+  ssl_crit_days: '7',
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function statusLabel(check: MonitorCheck): string {
+  if (check.type === 'ssl') return 'SSL'
+  if (check.last_status === 'up') return 'UP'
+  if (check.last_status === 'down') return 'DOWN'
+  if (check.last_status === 'warn') return 'WARN'
+  return '?'
+}
+
+function statusClass(status: string | null, type: string): string {
+  if (type === 'ssl' && status === 'warn') return 'monitor-status-block warn'
+  if (status === 'up') return 'monitor-status-block up'
+  if (status === 'warn') return 'monitor-status-block warn'
+  if (status === 'down') return 'monitor-status-block down'
+  return 'monitor-status-block unknown'
+}
+
+function formatTimeAgo(iso?: string | null): string {
+  if (!iso) return '—'
+  const diffMs = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diffMs / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return `${Math.floor(hrs / 24)}d ago`
+}
+
+function extractSSLCerts(checkList: MonitorCheck[]): SSLCert[] {
+  return checkList
+    .filter(c => c.type === 'ssl' && c.last_result)
+    .flatMap(c => {
+      try {
+        const result = JSON.parse(c.last_result!) as { days_remaining?: number; expires_at?: string }
+        if (result.days_remaining == null) return []
+        const domain = c.target.replace(/^https?:\/\//, '').split('/')[0]
+        const expiresAt = result.expires_at
+          ? new Date(result.expires_at).toISOString().split('T')[0]
+          : ''
+        return [{
+          domain,
+          days_remaining: result.days_remaining,
+          expires_at: expiresAt,
+          status: c.last_status ?? 'unknown',
+        } as SSLCert]
+      } catch {
+        return []
+      }
+    })
+    .sort((a, b) => a.days_remaining - b.days_remaining)
+}
+
+function formatResult(lastResult: string | null): string {
+  if (!lastResult) return 'No result yet'
+  try {
+    return JSON.stringify(JSON.parse(lastResult), null, 2)
+  } catch {
+    return lastResult
+  }
+}
+
+function validateForm(form: FormFields): string | null {
+  if (!form.name.trim()) return 'Name is required'
+  if (!form.target.trim()) return 'Target is required'
+  if (form.type === 'url' || form.type === 'ssl') {
+    if (!form.target.startsWith('http://') && !form.target.startsWith('https://')) {
+      return 'Target must begin with http:// or https://'
+    }
+  }
+  const interval = parseInt(form.interval_secs, 10)
+  if (isNaN(interval) || interval < 30) return 'Interval must be at least 30 seconds'
+  return null
+}
+
+function checkToForm(check: MonitorCheck): FormFields {
+  return {
+    type: check.type as CheckType,
+    name: check.name,
+    target: check.target,
+    interval_secs: String(check.interval_secs),
+    expected_status: String(check.expected_status ?? 200),
+    ssl_warn_days: String(check.ssl_warn_days ?? 30),
+    ssl_crit_days: String(check.ssl_crit_days ?? 7),
+  }
+}
+
+function formToInput(form: FormFields): CreateCheckInput {
+  const input: CreateCheckInput = {
+    name: form.name.trim(),
+    type: form.type,
+    target: form.target.trim(),
+    interval_secs: parseInt(form.interval_secs, 10),
+  }
+  if (form.type === 'url') input.expected_status = parseInt(form.expected_status, 10)
+  if (form.type === 'ssl') {
+    input.ssl_warn_days = parseInt(form.ssl_warn_days, 10)
+    input.ssl_crit_days = parseInt(form.ssl_crit_days, 10)
+  }
+  return input
+}
+
+// ── CheckForm component ───────────────────────────────────────────────────────
+
+interface CheckFormProps {
+  form: FormFields
+  onChange: (field: keyof FormFields, value: string) => void
+  onSubmit: () => void
+  onCancel: () => void
+  error: string | null
+  submitting: boolean
+  title: string
+  submitLabel: string
+  extraAction?: ReactNode
+}
+
+const CHECK_TYPES: CheckType[] = ['ping', 'url', 'ssl']
+
+function CheckForm({
+  form,
+  onChange,
+  onSubmit,
+  onCancel,
+  error,
+  submitting,
+  title,
+  submitLabel,
+  extraAction,
+}: CheckFormProps) {
+  return (
+    <div className="add-form">
+      <div className="form-title">{title}</div>
+      <div className="type-selector">
+        {CHECK_TYPES.map(t => (
+          <button
+            key={t}
+            className={`type-btn${form.type === t ? ' active' : ''}`}
+            onClick={() => onChange('type', t)}
+          >
+            {t.charAt(0).toUpperCase() + t.slice(1)}
+          </button>
+        ))}
+      </div>
+      <div className="form-fields">
+        <div className="form-field">
+          <div className="form-label">Name</div>
+          <input
+            className="form-input"
+            value={form.name}
+            onChange={e => onChange('name', e.target.value)}
+            placeholder="e.g. Proxmox Web UI"
+          />
+        </div>
+        <div className="form-field">
+          <div className="form-label">{form.type === 'ping' ? 'Host / IP' : 'URL'}</div>
+          <input
+            className="form-input"
+            value={form.target}
+            onChange={e => onChange('target', e.target.value)}
+            placeholder={form.type === 'ping' ? 'e.g. 192.168.1.1' : 'https://example.com'}
+          />
+        </div>
+        <div className="form-field">
+          <div className="form-label">Interval (seconds)</div>
+          <input
+            className="form-input"
+            type="number"
+            min="30"
+            value={form.interval_secs}
+            onChange={e => onChange('interval_secs', e.target.value)}
+          />
+        </div>
+        {form.type === 'url' && (
+          <div className="form-field">
+            <div className="form-label">Expected Status</div>
+            <input
+              className="form-input"
+              type="number"
+              value={form.expected_status}
+              onChange={e => onChange('expected_status', e.target.value)}
+              placeholder="200"
+            />
+          </div>
+        )}
+        {form.type === 'ssl' && (
+          <>
+            <div className="form-field">
+              <div className="form-label">Warn Threshold (days)</div>
+              <input
+                className="form-input"
+                type="number"
+                min="1"
+                value={form.ssl_warn_days}
+                onChange={e => onChange('ssl_warn_days', e.target.value)}
+                placeholder="30"
+              />
+            </div>
+            <div className="form-field">
+              <div className="form-label">Critical Threshold (days)</div>
+              <input
+                className="form-input"
+                type="number"
+                min="1"
+                value={form.ssl_crit_days}
+                onChange={e => onChange('ssl_crit_days', e.target.value)}
+                placeholder="7"
+              />
+            </div>
+          </>
+        )}
+      </div>
+      {error && <div className="form-error">{error}</div>}
+      <div className="form-actions">
+        <button className="form-btn primary" onClick={onSubmit} disabled={submitting}>
+          {submitting ? 'Saving…' : submitLabel}
+        </button>
+        <button className="form-btn secondary" onClick={onCancel}>
+          Cancel
+        </button>
+        {extraAction}
+      </div>
+    </div>
+  )
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
 export function Checks() {
+  const [checkList, setCheckList] = useState<MonitorCheck[]>([])
+  const [loading, setLoading] = useState(true)
+
+  // Add form
+  const [showAddForm, setShowAddForm] = useState(false)
+  const [addForm, setAddForm] = useState<FormFields>(defaultForm)
+  const [addError, setAddError] = useState<string | null>(null)
+  const [addSubmitting, setAddSubmitting] = useState(false)
+
+  // Expand + edit
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [editForm, setEditForm] = useState<FormFields>(defaultForm)
+  const [editError, setEditError] = useState<string | null>(null)
+  const [editSubmitting, setEditSubmitting] = useState(false)
+
+  // Run
+  const [runningIds, setRunningIds] = useState<Set<string>>(new Set())
+
+  // Delete
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    checksApi.list()
+      .then(res => setCheckList(res.data))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
+  const sslCerts = extractSSLCerts(checkList)
+
+  // ── Add form ──
+
+  function handleAddChange(field: keyof FormFields, value: string) {
+    setAddForm(prev => ({ ...prev, [field]: value }))
+    setAddError(null)
+  }
+
+  async function handleAddSubmit() {
+    const err = validateForm(addForm)
+    if (err) { setAddError(err); return }
+    setAddSubmitting(true)
+    try {
+      const created = await checksApi.create(formToInput(addForm))
+      setCheckList(prev => [created, ...prev])
+      setShowAddForm(false)
+      setAddForm(defaultForm)
+    } catch (e: unknown) {
+      setAddError(e instanceof Error ? e.message : 'Failed to create check')
+    } finally {
+      setAddSubmitting(false)
+    }
+  }
+
+  // ── Expand / edit ──
+
+  function handleToggleExpand(check: MonitorCheck) {
+    if (expandedId === check.id) {
+      setExpandedId(null)
+    } else {
+      setExpandedId(check.id)
+      setEditForm(checkToForm(check))
+      setEditError(null)
+    }
+  }
+
+  function handleEditChange(field: keyof FormFields, value: string) {
+    setEditForm(prev => ({ ...prev, [field]: value }))
+    setEditError(null)
+  }
+
+  async function handleEditSubmit(id: string) {
+    const err = validateForm(editForm)
+    if (err) { setEditError(err); return }
+    setEditSubmitting(true)
+    try {
+      const updated = await checksApi.update(id, formToInput(editForm))
+      setCheckList(prev => prev.map(c => c.id === id ? updated : c))
+      setExpandedId(null)
+    } catch (e: unknown) {
+      setEditError(e instanceof Error ? e.message : 'Failed to save check')
+    } finally {
+      setEditSubmitting(false)
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setDeletingIds(prev => new Set(prev).add(id))
+    try {
+      await checksApi.delete(id)
+      setCheckList(prev => prev.filter(c => c.id !== id))
+      setExpandedId(null)
+    } catch {
+      // keep in list if delete fails
+    } finally {
+      setDeletingIds(prev => {
+        const next = new Set(prev)
+        next.delete(id)
+        return next
+      })
+    }
+  }
+
+  // ── Run ──
+
+  async function handleRun(id: string) {
+    setRunningIds(prev => new Set(prev).add(id))
+    try {
+      await checksApi.run(id)
+      const updated = await checksApi.get(id)
+      setCheckList(prev => prev.map(c => c.id === id ? updated : c))
+    } catch {
+      // noop — status update visible on next poll
+    } finally {
+      setRunningIds(prev => {
+        const next = new Set(prev)
+        next.delete(id)
+        return next
+      })
+    }
+  }
+
   return (
     <>
-      <Topbar title="Monitor Checks" onAdd={() => {}} />
+      <Topbar title="Monitor Checks" onAdd={() => setShowAddForm(prev => !prev)} />
       <div className="content">
+
+        {showAddForm && (
+          <CheckForm
+            form={addForm}
+            onChange={handleAddChange}
+            onSubmit={handleAddSubmit}
+            onCancel={() => { setShowAddForm(false); setAddForm(defaultForm); setAddError(null) }}
+            error={addError}
+            submitting={addSubmitting}
+            title="New Check"
+            submitLabel="Add Check"
+          />
+        )}
+
         <div className="section-header">
           <span className="section-title">Active Checks</span>
-          <button className="section-action" onClick={() => {}}>+ Add check</button>
+          <button className="section-action" onClick={() => setShowAddForm(prev => !prev)}>
+            + Add check
+          </button>
         </div>
-        <div className="checks-empty">
-          <span>No monitor checks configured yet.</span>
-        </div>
+
+        {loading ? (
+          <div className="checks-empty"><span>Loading…</span></div>
+        ) : checkList.length === 0 ? (
+          <div className="checks-empty"><span>No monitor checks configured yet.</span></div>
+        ) : (
+          <div className="checks-list">
+            {checkList.map(check => (
+              <div
+                key={check.id}
+                className={`check-row-wrapper${expandedId === check.id ? ' expanded' : ''}`}
+              >
+                <div className="check-row" onClick={() => handleToggleExpand(check)}>
+                  <div className={statusClass(check.last_status, check.type)}>
+                    {statusLabel(check)}
+                  </div>
+                  <div className="monitor-info">
+                    <div className="monitor-name">{check.name}</div>
+                    <div className="monitor-target">
+                      {check.target} · {check.type} · every {check.interval_secs}s
+                    </div>
+                  </div>
+                  <div className="monitor-meta">
+                    <div className="monitor-last">{formatTimeAgo(check.last_checked_at)}</div>
+                  </div>
+                  <button
+                    className={`check-run-btn${runningIds.has(check.id) ? ' running' : ''}`}
+                    title="Run now"
+                    onClick={e => { e.stopPropagation(); void handleRun(check.id) }}
+                    disabled={runningIds.has(check.id)}
+                  >
+                    {runningIds.has(check.id) ? <span className="check-spinner" /> : '▶'}
+                  </button>
+                </div>
+
+                {expandedId === check.id && (
+                  <div className="check-expand">
+                    <div className="check-expand-details">
+                      {formatResult(check.last_result)}
+                    </div>
+                    <CheckForm
+                      form={editForm}
+                      onChange={handleEditChange}
+                      onSubmit={() => void handleEditSubmit(check.id)}
+                      onCancel={() => setExpandedId(null)}
+                      error={editError}
+                      submitting={editSubmitting}
+                      title="Edit Check"
+                      submitLabel="Save"
+                      extraAction={
+                        <button
+                          className="form-btn danger"
+                          onClick={() => void handleDelete(check.id)}
+                          disabled={deletingIds.has(check.id)}
+                          style={{ marginLeft: 'auto' }}
+                        >
+                          {deletingIds.has(check.id) ? 'Deleting…' : 'Delete'}
+                        </button>
+                      }
+                    />
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {sslCerts.length > 0 && (
+          <>
+            <div className="section-header" style={{ marginTop: 24 }}>
+              <span className="section-title">SSL Certificates</span>
+            </div>
+            <div className="ssl-panel">
+              {sslCerts.map(cert => (
+                <SSLRow key={cert.domain} cert={cert} />
+              ))}
+            </div>
+          </>
+        )}
+
       </div>
     </>
   )


### PR DESCRIPTION
## What
Full implementation of the Monitor Checks screen at `/checks`.

## Why
Closes T-23. Provides a usable interface for viewing, adding, editing, running, and deleting monitor checks, plus an SSL certificate expiry panel.

## How
- **Checks list**: each check renders with a status block (UP/DOWN/WARN/SSL), name, target/type/interval, last-checked time, and a manual run button (▶)
- **Manual run**: `POST /api/v1/checks/{id}/run` → shows CSS spinner while in-flight → re-fetches the updated check via `GET /api/v1/checks/{id}` and updates the row in place
- **Row expand**: clicking a row expands it to show the last result JSON and a pre-filled edit form (Save + Delete actions)
- **Add form**: inline panel toggled by `+ Add check` or the topbar `+` button; type selector (Ping/URL/SSL) controls conditional fields (expected status for URL, warn/crit thresholds for SSL); client-side validation before submit; optimistic prepend to list
- **Edit form**: same `CheckForm` component reused inside the expand panel; calls `PUT /api/v1/checks/{id}`
- **Delete**: `DELETE /api/v1/checks/{id}` with loading state; removes from list on success
- **SSL panel**: extracts `days_remaining` and `expires_at` from `last_result` JSON on ssl-type checks, sorts by days remaining (soonest first), renders via existing `SSLRow` component with red (<10d) / yellow (10-30d) / green (>30d) colors
- `Checks.css` fully rewritten with all needed styles (no dependency on Dashboard.css)

## Test coverage
- `go test ./...` passes
- `npm run build` passes with zero TypeScript errors

## Closes
Closes #23