### PR TITLE
feat: T-24 Host topology screen + host widgets on dashboard

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -97,7 +97,7 @@ func main() {
 		api.NewEventsHandler(eventRepo).Routes(r)
 		api.NewChecksHandler(checkRepo, eventRepo).Routes(r)
 		api.NewDashboardHandler(appRepo, eventRepo, checkRepo, rollupRepo, registry).Routes(r)
-		api.NewTopologyHandler(physicalHostRepo, virtualHostRepo, dockerEngineRepo, appRepo).Routes(r)
+		api.NewTopologyHandler(physicalHostRepo, virtualHostRepo, dockerEngineRepo, appRepo, resourceRollupRepo).Routes(r)
 		api.NewProfilesHandler(registry, customProfileRepo).Routes(r)
 	})
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -15,6 +15,7 @@ import type {
   DockerEngine,
   Event,
   EventFilter,
+  HostResources,
   ListResponse,
   LoginInput,
   MonitorCheck,
@@ -170,6 +171,8 @@ export const topology = {
       request<PhysicalHost>('PUT', `/hosts/physical/${id}`, input),
     delete: (id: string) =>
       request<void>('DELETE', `/hosts/physical/${id}`),
+    resources: (id: string, period = 'hour') =>
+      request<HostResources>('GET', `/hosts/physical/${id}/resources?period=${period}`),
   },
 
   virtualHosts: {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -148,6 +148,14 @@ export interface DockerEngine {
   created_at: string
 }
 
+// ── Host Resources ────────────────────────────────────────────────────────────
+
+export interface HostResources {
+  cpu: number
+  mem: number
+  disk: number
+}
+
 // ── Dashboard ─────────────────────────────────────────────────────────────
 
 export interface SummaryBarItem {

--- a/frontend/src/components/HostWidget.tsx
+++ b/frontend/src/components/HostWidget.tsx
@@ -20,9 +20,10 @@ function barFillClass(pct: number): string {
 
 interface Props {
   host: HostData
+  onClick?: () => void
 }
 
-export function HostWidget({ host }: Props) {
+export function HostWidget({ host, onClick }: Props) {
   const dotClass =
     host.status === 'online'
       ? 'green'
@@ -33,7 +34,7 @@ export function HostWidget({ host }: Props) {
       : 'grey'
 
   return (
-    <div className="host-widget">
+    <div className="host-widget" onClick={onClick} style={onClick ? { cursor: 'pointer' } : undefined}>
       <div className="host-widget-header">
         <div className="host-icon">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -6,8 +6,10 @@ import { AppWidget } from '../components/AppWidget'
 import { MonitorWidget } from '../components/MonitorWidget'
 import { SSLRow } from '../components/SSLRow'
 import { EventRow } from '../components/EventRow'
-import { dashboard as dashboardApi, events as eventsApi } from '../api/client'
-import type { DashboardSummaryResponse, Event } from '../api/types'
+import { HostWidget } from '../components/HostWidget'
+import type { HostData } from '../components/HostWidget'
+import { dashboard as dashboardApi, events as eventsApi, topology as topoApi } from '../api/client'
+import type { DashboardSummaryResponse, Event, PhysicalHost } from '../api/types'
 import './Dashboard.css'
 
 type TimeFilter = 'day' | 'week' | 'month'
@@ -17,6 +19,7 @@ export function Dashboard() {
   const [timeFilter, setTimeFilter] = useState<TimeFilter>('week')
   const [data, setData] = useState<DashboardSummaryResponse | null>(null)
   const [recentEvents, setRecentEvents] = useState<Event[]>([])
+  const [physicalHosts, setPhysicalHosts] = useState<PhysicalHost[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -24,10 +27,12 @@ export function Dashboard() {
     Promise.all([
       dashboardApi.summary(timeFilter),
       eventsApi.list({ limit: 5 }),
+      topoApi.physicalHosts.list(),
     ])
-      .then(([summary, evts]) => {
+      .then(([summary, evts, hosts]) => {
         setData(summary)
         setRecentEvents(evts.data)
+        setPhysicalHosts(hosts.data)
       })
       .catch(console.error)
       .finally(() => setLoading(false))
@@ -242,6 +247,41 @@ export function Dashboard() {
                   {data.ssl_certs.map((cert, i) => (
                     <SSLRow key={cert.domain || i} cert={cert} />
                   ))}
+                </div>
+              </div>
+            )}
+
+            {/* Infrastructure — only shown when hosts are configured */}
+            {physicalHosts.length > 0 && (
+              <div>
+                <div className="section-header">
+                  <div className="section-title">Infrastructure</div>
+                  <button className="section-action" onClick={() => navigate('/topology')}>
+                    View all →
+                  </button>
+                </div>
+                <div className="widget-grid">
+                  {physicalHosts.map(host => {
+                    const hostData: HostData = {
+                      id:        host.id,
+                      name:      host.name,
+                      type:      host.type === 'proxmox_node' ? 'Proxmox Node' : 'Bare Metal',
+                      ip:        host.ip,
+                      status:    'unknown',
+                      resources: [
+                        { label: 'CPU', pct: 0 },
+                        { label: 'MEM', pct: 0 },
+                        { label: 'DSK', pct: 0 },
+                      ],
+                    }
+                    return (
+                      <HostWidget
+                        key={host.id}
+                        host={hostData}
+                        onClick={() => navigate('/topology')}
+                      />
+                    )
+                  })}
                 </div>
               </div>
             )}

--- a/frontend/src/pages/Topology.css
+++ b/frontend/src/pages/Topology.css
@@ -1,3 +1,5 @@
+/* ── EMPTY STATES ── */
+
 .topology-empty {
   padding: 40px;
   text-align: center;
@@ -8,6 +10,181 @@
   border: 1px solid var(--border);
   border-radius: 8px;
 }
+
+.topo-empty-children {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  padding: 8px 14px;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+/* ── TREE STRUCTURE ── */
+
+.topo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.topo-node {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* ── TREE ROW ── */
+
+.topo-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.topo-row:hover {
+  border-color: var(--border2);
+}
+
+.topo-row.editing {
+  border-radius: 8px 8px 0 0;
+  border-color: var(--accent);
+}
+
+.topo-row.level-1 { background: var(--bg2); border-color: var(--border); }
+.topo-row.level-2 { background: var(--bg3); border-color: var(--border); cursor: default; }
+
+/* ── CHEVRON ── */
+
+.topo-chevron {
+  font-size: 9px;
+  color: var(--text3);
+  width: 10px;
+  flex-shrink: 0;
+  transition: color 0.15s;
+  user-select: none;
+}
+
+.topo-chevron.open { color: var(--accent); }
+
+.topo-chevron-leaf {
+  width: 10px;
+  flex-shrink: 0;
+}
+
+/* ── ICON ── */
+
+.topo-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--text3);
+}
+
+.topo-icon svg { width: 13px; height: 13px; }
+
+/* ── INFO ── */
+
+.topo-info  { flex: 1; min-width: 0; }
+.topo-name  { font-size: 13px; font-weight: 500; color: var(--text); }
+.topo-meta  { font-family: var(--mono); font-size: 10px; color: var(--text3); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* ── ROW ACTIONS (visible on hover) ── */
+
+.topo-actions {
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.15s;
+  flex-shrink: 0;
+}
+
+.topo-row:hover .topo-actions { opacity: 1; }
+
+.topo-action-btn {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  color: var(--text3);
+  font-size: 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+  line-height: 1;
+}
+
+.topo-action-btn:hover:not(:disabled) {
+  border-color: var(--border2);
+  color: var(--text);
+}
+
+.topo-action-btn.danger:hover:not(:disabled) {
+  border-color: var(--red);
+  color: var(--red);
+  background: var(--red-dim);
+}
+
+.topo-action-btn:disabled { opacity: 0.4; cursor: default; }
+
+/* ── CHILDREN CONTAINER ── */
+
+.topo-children {
+  padding-left: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+/* ── EDIT PANEL ── */
+
+.topo-edit-panel {
+  border-radius: 0 0 8px 8px;
+  border-top: none;
+}
+
+.topo-edit-panel .add-form {
+  border-radius: 0 0 8px 8px;
+  border-color: var(--accent);
+  margin-bottom: 0;
+}
+
+/* ── ADD ROW ── */
+
+.topo-add-row {
+  padding: 6px 2px;
+}
+
+.topo-add-btn {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent);
+  opacity: 0.55;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  transition: opacity 0.15s;
+}
+
+.topo-add-btn:hover { opacity: 1; }
 
 /* Host widget — extracted from dashboard mockup */
 .host-widget {

--- a/frontend/src/pages/Topology.tsx
+++ b/frontend/src/pages/Topology.tsx
@@ -1,18 +1,777 @@
+import { useState, useEffect } from 'react'
+import type { ReactNode } from 'react'
 import { Topbar } from '../components/Topbar'
+import { topology as topoApi } from '../api/client'
+import type {
+  PhysicalHost,
+  PhysicalHostType,
+  VirtualHost,
+  VirtualHostType,
+  DockerEngine,
+  SocketType,
+} from '../api/types'
+import './Checks.css'
 import './Topology.css'
 
-export function Topology() {
+// ── Form field types ──────────────────────────────────────────────────────────
+
+type PhysicalForm = { name: string; ip: string; type: PhysicalHostType; notes: string }
+type VirtualForm  = { name: string; ip: string; type: VirtualHostType }
+type DockerForm   = { name: string; socket_type: SocketType; socket_path: string }
+
+const defaultPhysical: PhysicalForm = { name: '', ip: '', type: 'bare_metal', notes: '' }
+const defaultVirtual: VirtualForm   = { name: '', ip: '', type: 'vm' }
+const defaultDocker: DockerForm     = { name: '', socket_type: 'local', socket_path: '/var/run/docker.sock' }
+
+// ── Interaction state types ───────────────────────────────────────────────────
+
+type AddTarget =
+  | { kind: 'physical' }
+  | { kind: 'virtual'; physicalId: string }
+  | { kind: 'docker'; virtualId: string }
+
+type EditTarget =
+  | { kind: 'physical'; id: string }
+  | { kind: 'virtual'; id: string }
+  | { kind: 'docker'; id: string }
+
+// ── Label helpers ─────────────────────────────────────────────────────────────
+
+function labelPhysicalType(t: PhysicalHostType): string {
+  return t === 'proxmox_node' ? 'Proxmox Node' : 'Bare Metal'
+}
+
+function labelVirtualType(t: VirtualHostType): string {
+  return t.toUpperCase()
+}
+
+// ── Inline form wrapper ───────────────────────────────────────────────────────
+
+interface FormWrapProps {
+  title: string
+  error: string | null
+  submitting: boolean
+  onSubmit: () => void
+  onCancel: () => void
+  children: ReactNode
+  isEdit?: boolean
+  onDelete?: () => void
+  deleting?: boolean
+}
+
+function FormWrap({
+  title, error, submitting, onSubmit, onCancel, children, isEdit, onDelete, deleting,
+}: FormWrapProps) {
+  return (
+    <div className="add-form">
+      <div className="form-title">{title}</div>
+      <div className="form-fields">{children}</div>
+      {error && <div className="form-error">{error}</div>}
+      <div className="form-actions">
+        <button className="form-btn primary" onClick={onSubmit} disabled={submitting}>
+          {submitting ? 'Saving…' : isEdit ? 'Save' : 'Add'}
+        </button>
+        <button className="form-btn secondary" onClick={onCancel}>
+          Cancel
+        </button>
+        {isEdit && onDelete && (
+          <button
+            className="form-btn danger"
+            onClick={onDelete}
+            disabled={deleting}
+            style={{ marginLeft: 'auto' }}
+          >
+            {deleting ? 'Deleting…' : 'Delete'}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Sub-form field groups ─────────────────────────────────────────────────────
+
+function PhysicalFormFields({ form, onChange }: { form: PhysicalForm; onChange: (f: PhysicalForm) => void }) {
   return (
     <>
-      <Topbar title="Infrastructure" onAdd={() => {}} />
+      <div className="form-field">
+        <div className="form-label">Name</div>
+        <input
+          className="form-input"
+          value={form.name}
+          onChange={e => onChange({ ...form, name: e.target.value })}
+          placeholder="e.g. proxmox-node1"
+        />
+      </div>
+      <div className="form-field">
+        <div className="form-label">IP Address</div>
+        <input
+          className="form-input"
+          value={form.ip}
+          onChange={e => onChange({ ...form, ip: e.target.value })}
+          placeholder="e.g. 192.168.1.10"
+        />
+      </div>
+      <div className="form-field">
+        <div className="form-label">Type</div>
+        <select
+          className="form-input"
+          value={form.type}
+          onChange={e => onChange({ ...form, type: e.target.value as PhysicalHostType })}
+        >
+          <option value="bare_metal">Bare Metal</option>
+          <option value="proxmox_node">Proxmox Node</option>
+        </select>
+      </div>
+      <div className="form-field">
+        <div className="form-label">Notes</div>
+        <input
+          className="form-input"
+          value={form.notes}
+          onChange={e => onChange({ ...form, notes: e.target.value })}
+          placeholder="Optional"
+        />
+      </div>
+    </>
+  )
+}
+
+function VirtualFormFields({ form, onChange }: { form: VirtualForm; onChange: (f: VirtualForm) => void }) {
+  return (
+    <>
+      <div className="form-field">
+        <div className="form-label">Name</div>
+        <input
+          className="form-input"
+          value={form.name}
+          onChange={e => onChange({ ...form, name: e.target.value })}
+          placeholder="e.g. rocky-vm01"
+        />
+      </div>
+      <div className="form-field">
+        <div className="form-label">IP Address</div>
+        <input
+          className="form-input"
+          value={form.ip}
+          onChange={e => onChange({ ...form, ip: e.target.value })}
+          placeholder="e.g. 192.168.1.20"
+        />
+      </div>
+      <div className="form-field">
+        <div className="form-label">Type</div>
+        <select
+          className="form-input"
+          value={form.type}
+          onChange={e => onChange({ ...form, type: e.target.value as VirtualHostType })}
+        >
+          <option value="vm">VM</option>
+          <option value="lxc">LXC</option>
+          <option value="wsl">WSL</option>
+        </select>
+      </div>
+    </>
+  )
+}
+
+function DockerFormFields({ form, onChange }: { form: DockerForm; onChange: (f: DockerForm) => void }) {
+  return (
+    <>
+      <div className="form-field">
+        <div className="form-label">Name</div>
+        <input
+          className="form-input"
+          value={form.name}
+          onChange={e => onChange({ ...form, name: e.target.value })}
+          placeholder="e.g. docker-engine-01"
+        />
+      </div>
+      <div className="form-field">
+        <div className="form-label">Socket Type</div>
+        <select
+          className="form-input"
+          value={form.socket_type}
+          onChange={e => onChange({ ...form, socket_type: e.target.value as SocketType })}
+        >
+          <option value="local">Local</option>
+          <option value="remote_proxy">Remote Proxy</option>
+        </select>
+      </div>
+      <div className="form-field" style={{ gridColumn: '1 / -1' }}>
+        <div className="form-label">Socket Path</div>
+        <input
+          className="form-input"
+          value={form.socket_path}
+          onChange={e => onChange({ ...form, socket_path: e.target.value })}
+          placeholder="/var/run/docker.sock"
+        />
+      </div>
+    </>
+  )
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export function Topology() {
+  const [physicalHosts, setPhysicalHosts] = useState<PhysicalHost[]>([])
+  const [virtualHosts,  setVirtualHosts]  = useState<VirtualHost[]>([])
+  const [dockerEngines, setDockerEngines] = useState<DockerEngine[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const [expandedPhysical, setExpandedPhysical] = useState<Set<string>>(new Set())
+  const [expandedVirtual,  setExpandedVirtual]  = useState<Set<string>>(new Set())
+
+  const [addTarget,  setAddTarget]  = useState<AddTarget | null>(null)
+  const [editTarget, setEditTarget] = useState<EditTarget | null>(null)
+
+  const [physicalForm, setPhysicalForm] = useState<PhysicalForm>(defaultPhysical)
+  const [virtualForm,  setVirtualForm]  = useState<VirtualForm>(defaultVirtual)
+  const [dockerForm,   setDockerForm]   = useState<DockerForm>(defaultDocker)
+
+  const [formError,   setFormError]   = useState<string | null>(null)
+  const [submitting,  setSubmitting]  = useState(false)
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set())
+
+  // ── Load ──────────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    Promise.all([
+      topoApi.physicalHosts.list(),
+      topoApi.virtualHosts.list(),
+      topoApi.dockerEngines.list(),
+    ])
+      .then(([ph, vh, de]) => {
+        setPhysicalHosts(ph.data)
+        setVirtualHosts(vh.data)
+        setDockerEngines(de.data)
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [])
+
+  // ── Tree helpers ──────────────────────────────────────────────────────────
+
+  function virtualsFor(physicalId: string): VirtualHost[] {
+    return virtualHosts.filter(v => v.physical_host_id === physicalId)
+  }
+
+  function enginesFor(virtualId: string): DockerEngine[] {
+    return dockerEngines.filter(e => e.virtual_host_id === virtualId)
+  }
+
+  // ── Expand / collapse ─────────────────────────────────────────────────────
+
+  function togglePhysical(id: string) {
+    setExpandedPhysical(prev => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+    setAddTarget(null)
+    setEditTarget(null)
+    setFormError(null)
+  }
+
+  function toggleVirtual(id: string) {
+    setExpandedVirtual(prev => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+    setAddTarget(null)
+    setEditTarget(null)
+    setFormError(null)
+  }
+
+  // ── Start edit ────────────────────────────────────────────────────────────
+
+  function startEditPhysical(ev: React.MouseEvent, host: PhysicalHost) {
+    ev.stopPropagation()
+    setEditTarget({ kind: 'physical', id: host.id })
+    setPhysicalForm({ name: host.name, ip: host.ip, type: host.type, notes: host.notes ?? '' })
+    setFormError(null)
+    setAddTarget(null)
+  }
+
+  function startEditVirtual(ev: React.MouseEvent, host: VirtualHost) {
+    ev.stopPropagation()
+    setEditTarget({ kind: 'virtual', id: host.id })
+    setVirtualForm({ name: host.name, ip: host.ip, type: host.type })
+    setFormError(null)
+    setAddTarget(null)
+  }
+
+  function startEditDocker(ev: React.MouseEvent, engine: DockerEngine) {
+    ev.stopPropagation()
+    setEditTarget({ kind: 'docker', id: engine.id })
+    setDockerForm({ name: engine.name, socket_type: engine.socket_type, socket_path: engine.socket_path })
+    setFormError(null)
+    setAddTarget(null)
+  }
+
+  function cancelForm() {
+    setAddTarget(null)
+    setEditTarget(null)
+    setFormError(null)
+  }
+
+  // ── Start add ─────────────────────────────────────────────────────────────
+
+  function startAddPhysical() {
+    setAddTarget({ kind: 'physical' })
+    setPhysicalForm(defaultPhysical)
+    setFormError(null)
+    setEditTarget(null)
+  }
+
+  function startAddVirtual(ev: React.MouseEvent, physicalId: string) {
+    ev.stopPropagation()
+    setAddTarget({ kind: 'virtual', physicalId })
+    setVirtualForm(defaultVirtual)
+    setFormError(null)
+    setEditTarget(null)
+  }
+
+  function startAddDocker(ev: React.MouseEvent, virtualId: string) {
+    ev.stopPropagation()
+    setAddTarget({ kind: 'docker', virtualId })
+    setDockerForm(defaultDocker)
+    setFormError(null)
+    setEditTarget(null)
+  }
+
+  // ── Submit add ────────────────────────────────────────────────────────────
+
+  async function handleAddPhysical() {
+    if (!physicalForm.name.trim()) { setFormError('Name is required'); return }
+    if (!physicalForm.ip.trim())   { setFormError('IP is required');   return }
+    setSubmitting(true)
+    try {
+      const created = await topoApi.physicalHosts.create({
+        name:  physicalForm.name.trim(),
+        ip:    physicalForm.ip.trim(),
+        type:  physicalForm.type,
+        notes: physicalForm.notes.trim() || null,
+      })
+      setPhysicalHosts(prev => [...prev, created])
+      cancelForm()
+    } catch (err: unknown) {
+      setFormError(err instanceof Error ? err.message : 'Failed to add host')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleAddVirtual(physicalId: string) {
+    if (!virtualForm.name.trim()) { setFormError('Name is required'); return }
+    if (!virtualForm.ip.trim())   { setFormError('IP is required');   return }
+    setSubmitting(true)
+    try {
+      const created = await topoApi.virtualHosts.create({
+        name:             virtualForm.name.trim(),
+        ip:               virtualForm.ip.trim(),
+        type:             virtualForm.type,
+        physical_host_id: physicalId,
+      })
+      setVirtualHosts(prev => [...prev, created])
+      cancelForm()
+    } catch (err: unknown) {
+      setFormError(err instanceof Error ? err.message : 'Failed to add VM')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleAddDocker(virtualId: string) {
+    if (!dockerForm.name.trim())        { setFormError('Name is required');        return }
+    if (!dockerForm.socket_path.trim()) { setFormError('Socket path is required'); return }
+    setSubmitting(true)
+    try {
+      const created = await topoApi.dockerEngines.create({
+        name:            dockerForm.name.trim(),
+        socket_type:     dockerForm.socket_type,
+        socket_path:     dockerForm.socket_path.trim(),
+        virtual_host_id: virtualId,
+      })
+      setDockerEngines(prev => [...prev, created])
+      cancelForm()
+    } catch (err: unknown) {
+      setFormError(err instanceof Error ? err.message : 'Failed to add Docker engine')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // ── Submit edit ───────────────────────────────────────────────────────────
+
+  async function handleEditPhysical(id: string) {
+    if (!physicalForm.name.trim()) { setFormError('Name is required'); return }
+    if (!physicalForm.ip.trim())   { setFormError('IP is required');   return }
+    setSubmitting(true)
+    try {
+      const updated = await topoApi.physicalHosts.update(id, {
+        name:  physicalForm.name.trim(),
+        ip:    physicalForm.ip.trim(),
+        type:  physicalForm.type,
+        notes: physicalForm.notes.trim() || null,
+      })
+      setPhysicalHosts(prev => prev.map(h => h.id === id ? updated : h))
+      setEditTarget(null)
+    } catch (err: unknown) {
+      setFormError(err instanceof Error ? err.message : 'Failed to save')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleEditVirtual(id: string) {
+    if (!virtualForm.name.trim()) { setFormError('Name is required'); return }
+    if (!virtualForm.ip.trim())   { setFormError('IP is required');   return }
+    setSubmitting(true)
+    try {
+      const updated = await topoApi.virtualHosts.update(id, {
+        name: virtualForm.name.trim(),
+        ip:   virtualForm.ip.trim(),
+        type: virtualForm.type,
+      })
+      setVirtualHosts(prev => prev.map(h => h.id === id ? updated : h))
+      setEditTarget(null)
+    } catch (err: unknown) {
+      setFormError(err instanceof Error ? err.message : 'Failed to save')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleEditDocker(id: string) {
+    if (!dockerForm.name.trim())        { setFormError('Name is required');        return }
+    if (!dockerForm.socket_path.trim()) { setFormError('Socket path is required'); return }
+    setSubmitting(true)
+    try {
+      const updated = await topoApi.dockerEngines.update(id, {
+        name:        dockerForm.name.trim(),
+        socket_type: dockerForm.socket_type,
+        socket_path: dockerForm.socket_path.trim(),
+      })
+      setDockerEngines(prev => prev.map(e => e.id === id ? updated : e))
+      setEditTarget(null)
+    } catch (err: unknown) {
+      setFormError(err instanceof Error ? err.message : 'Failed to save')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+
+  async function deletePhysical(ev: React.MouseEvent | null, id: string) {
+    ev?.stopPropagation()
+    setDeletingIds(prev => new Set(prev).add(id))
+    try {
+      await topoApi.physicalHosts.delete(id)
+      setPhysicalHosts(prev => prev.filter(h => h.id !== id))
+      setVirtualHosts(prev => prev.filter(v => v.physical_host_id !== id))
+      setEditTarget(null)
+      setExpandedPhysical(prev => { const n = new Set(prev); n.delete(id); return n })
+    } catch { /* keep in list */ } finally {
+      setDeletingIds(prev => { const n = new Set(prev); n.delete(id); return n })
+    }
+  }
+
+  async function deleteVirtual(ev: React.MouseEvent | null, id: string) {
+    ev?.stopPropagation()
+    setDeletingIds(prev => new Set(prev).add(id))
+    try {
+      await topoApi.virtualHosts.delete(id)
+      setVirtualHosts(prev => prev.filter(h => h.id !== id))
+      setDockerEngines(prev => prev.filter(de => de.virtual_host_id !== id))
+      setEditTarget(null)
+      setExpandedVirtual(prev => { const n = new Set(prev); n.delete(id); return n })
+    } catch { /* keep */ } finally {
+      setDeletingIds(prev => { const n = new Set(prev); n.delete(id); return n })
+    }
+  }
+
+  async function deleteDocker(ev: React.MouseEvent | null, id: string) {
+    ev?.stopPropagation()
+    setDeletingIds(prev => new Set(prev).add(id))
+    try {
+      await topoApi.dockerEngines.delete(id)
+      setDockerEngines(prev => prev.filter(de => de.id !== id))
+      setEditTarget(null)
+    } catch { /* keep */ } finally {
+      setDeletingIds(prev => { const n = new Set(prev); n.delete(id); return n })
+    }
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <>
+      <Topbar title="Infrastructure" onAdd={startAddPhysical} />
       <div className="content">
+
+        {addTarget?.kind === 'physical' && (
+          <FormWrap
+            title="Add Physical Host"
+            error={formError}
+            submitting={submitting}
+            onSubmit={() => void handleAddPhysical()}
+            onCancel={cancelForm}
+          >
+            <PhysicalFormFields form={physicalForm} onChange={setPhysicalForm} />
+          </FormWrap>
+        )}
+
         <div className="section-header">
           <span className="section-title">Physical Hosts</span>
-          <button className="section-action" onClick={() => {}}>+ Add host</button>
+          <button className="section-action" onClick={startAddPhysical}>+ Add host</button>
         </div>
-        <div className="topology-empty">
-          No infrastructure configured yet. Add a physical host to get started.
-        </div>
+
+        {loading ? (
+          <div className="topology-empty">Loading…</div>
+        ) : physicalHosts.length === 0 ? (
+          <div className="topology-empty">
+            No infrastructure configured yet. Add a physical host to get started.
+          </div>
+        ) : (
+          <div className="topo-list">
+            {physicalHosts.map(ph => {
+              const expanded  = expandedPhysical.has(ph.id)
+              const isEditing = editTarget?.kind === 'physical' && editTarget.id === ph.id
+              const vhosts    = virtualsFor(ph.id)
+
+              return (
+                <div key={ph.id} className="topo-node">
+
+                  {/* ── Physical host row ── */}
+                  <div
+                    className={`topo-row${isEditing ? ' editing' : ''}`}
+                    onClick={() => !isEditing && togglePhysical(ph.id)}
+                  >
+                    <span className={`topo-chevron${expanded ? ' open' : ''}`}>
+                      {expanded ? '▼' : '▶'}
+                    </span>
+                    <div className="topo-icon">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <rect x="2" y="2" width="20" height="8" rx="2" />
+                        <rect x="2" y="14" width="20" height="8" rx="2" />
+                        <line x1="6" y1="6" x2="6.01" y2="6" />
+                        <line x1="6" y1="18" x2="6.01" y2="18" />
+                      </svg>
+                    </div>
+                    <div className="topo-info">
+                      <div className="topo-name">{ph.name}</div>
+                      <div className="topo-meta">{labelPhysicalType(ph.type)} · {ph.ip}</div>
+                    </div>
+                    <div className="topo-actions">
+                      <button
+                        className="topo-action-btn"
+                        title="Edit"
+                        onClick={ev => startEditPhysical(ev, ph)}
+                      >✎</button>
+                      <button
+                        className="topo-action-btn danger"
+                        title="Delete"
+                        disabled={deletingIds.has(ph.id)}
+                        onClick={ev => void deletePhysical(ev, ph.id)}
+                      >✕</button>
+                    </div>
+                  </div>
+
+                  {/* ── Edit form ── */}
+                  {isEditing && (
+                    <div className="topo-edit-panel">
+                      <FormWrap
+                        title="Edit Physical Host"
+                        error={formError}
+                        submitting={submitting}
+                        onSubmit={() => void handleEditPhysical(ph.id)}
+                        onCancel={cancelForm}
+                        isEdit
+                        onDelete={() => void deletePhysical(null, ph.id)}
+                        deleting={deletingIds.has(ph.id)}
+                      >
+                        <PhysicalFormFields form={physicalForm} onChange={setPhysicalForm} />
+                      </FormWrap>
+                    </div>
+                  )}
+
+                  {/* ── Expanded: virtual hosts ── */}
+                  {expanded && (
+                    <div className="topo-children">
+                      {vhosts.length === 0 && addTarget?.kind !== 'virtual' && (
+                        <div className="topo-empty-children">No VMs configured under this host.</div>
+                      )}
+
+                      {vhosts.map(vh => {
+                        const vExpanded = expandedVirtual.has(vh.id)
+                        const vEditing  = editTarget?.kind === 'virtual' && editTarget.id === vh.id
+                        const engines   = enginesFor(vh.id)
+
+                        return (
+                          <div key={vh.id} className="topo-node">
+
+                            {/* ── VM row ── */}
+                            <div
+                              className={`topo-row level-1${vEditing ? ' editing' : ''}`}
+                              onClick={() => !vEditing && toggleVirtual(vh.id)}
+                            >
+                              <span className={`topo-chevron${vExpanded ? ' open' : ''}`}>
+                                {vExpanded ? '▼' : '▶'}
+                              </span>
+                              <div className="topo-icon">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                  <rect x="3" y="3" width="18" height="18" rx="2" />
+                                  <path d="M3 9h18M9 21V9" />
+                                </svg>
+                              </div>
+                              <div className="topo-info">
+                                <div className="topo-name">{vh.name}</div>
+                                <div className="topo-meta">{labelVirtualType(vh.type)} · {vh.ip}</div>
+                              </div>
+                              <div className="topo-actions">
+                                <button
+                                  className="topo-action-btn"
+                                  title="Edit"
+                                  onClick={ev => startEditVirtual(ev, vh)}
+                                >✎</button>
+                                <button
+                                  className="topo-action-btn danger"
+                                  title="Delete"
+                                  disabled={deletingIds.has(vh.id)}
+                                  onClick={ev => void deleteVirtual(ev, vh.id)}
+                                >✕</button>
+                              </div>
+                            </div>
+
+                            {vEditing && (
+                              <div className="topo-edit-panel">
+                                <FormWrap
+                                  title="Edit VM"
+                                  error={formError}
+                                  submitting={submitting}
+                                  onSubmit={() => void handleEditVirtual(vh.id)}
+                                  onCancel={cancelForm}
+                                  isEdit
+                                  onDelete={() => void deleteVirtual(null, vh.id)}
+                                  deleting={deletingIds.has(vh.id)}
+                                >
+                                  <VirtualFormFields form={virtualForm} onChange={setVirtualForm} />
+                                </FormWrap>
+                              </div>
+                            )}
+
+                            {/* ── Expanded: docker engines ── */}
+                            {vExpanded && (
+                              <div className="topo-children">
+                                {engines.length === 0 && addTarget?.kind !== 'docker' && (
+                                  <div className="topo-empty-children">No Docker engines configured.</div>
+                                )}
+
+                                {engines.map(de => {
+                                  const deEditing = editTarget?.kind === 'docker' && editTarget.id === de.id
+                                  return (
+                                    <div key={de.id} className="topo-node">
+                                      <div
+                                        className={`topo-row level-2${deEditing ? ' editing' : ''}`}
+                                        onClick={ev => ev.stopPropagation()}
+                                      >
+                                        <span className="topo-chevron-leaf" />
+                                        <div className="topo-icon">
+                                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                            <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+                                            <path d="M12 22V12M3.27 6.96 12 12.01l8.73-5.05M12 2.1V12" />
+                                          </svg>
+                                        </div>
+                                        <div className="topo-info">
+                                          <div className="topo-name">{de.name}</div>
+                                          <div className="topo-meta">{de.socket_type} · {de.socket_path}</div>
+                                        </div>
+                                        <div className="topo-actions">
+                                          <button
+                                            className="topo-action-btn"
+                                            title="Edit"
+                                            onClick={ev => startEditDocker(ev, de)}
+                                          >✎</button>
+                                          <button
+                                            className="topo-action-btn danger"
+                                            title="Delete"
+                                            disabled={deletingIds.has(de.id)}
+                                            onClick={ev => void deleteDocker(ev, de.id)}
+                                          >✕</button>
+                                        </div>
+                                      </div>
+
+                                      {deEditing && (
+                                        <div className="topo-edit-panel">
+                                          <FormWrap
+                                            title="Edit Docker Engine"
+                                            error={formError}
+                                            submitting={submitting}
+                                            onSubmit={() => void handleEditDocker(de.id)}
+                                            onCancel={cancelForm}
+                                            isEdit
+                                            onDelete={() => void deleteDocker(null, de.id)}
+                                            deleting={deletingIds.has(de.id)}
+                                          >
+                                            <DockerFormFields form={dockerForm} onChange={setDockerForm} />
+                                          </FormWrap>
+                                        </div>
+                                      )}
+                                    </div>
+                                  )
+                                })}
+
+                                {addTarget?.kind === 'docker' && addTarget.virtualId === vh.id && (
+                                  <FormWrap
+                                    title="Add Docker Engine"
+                                    error={formError}
+                                    submitting={submitting}
+                                    onSubmit={() => void handleAddDocker(vh.id)}
+                                    onCancel={cancelForm}
+                                  >
+                                    <DockerFormFields form={dockerForm} onChange={setDockerForm} />
+                                  </FormWrap>
+                                )}
+
+                                <div className="topo-add-row">
+                                  <button className="topo-add-btn" onClick={ev => startAddDocker(ev, vh.id)}>
+                                    + Add Docker Engine
+                                  </button>
+                                </div>
+                              </div>
+                            )}
+
+                          </div>
+                        )
+                      })}
+
+                      {addTarget?.kind === 'virtual' && addTarget.physicalId === ph.id && (
+                        <FormWrap
+                          title="Add VM"
+                          error={formError}
+                          submitting={submitting}
+                          onSubmit={() => void handleAddVirtual(ph.id)}
+                          onCancel={cancelForm}
+                        >
+                          <VirtualFormFields form={virtualForm} onChange={setVirtualForm} />
+                        </FormWrap>
+                      )}
+
+                      <div className="topo-add-row">
+                        <button className="topo-add-btn" onClick={ev => startAddVirtual(ev, ph.id)}>
+                          + Add VM
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
+                </div>
+              )
+            })}
+          </div>
+        )}
+
       </div>
     </>
   )

--- a/internal/api/topology.go
+++ b/internal/api/topology.go
@@ -18,15 +18,17 @@ type TopologyHandler struct {
 	virtualHosts  repo.VirtualHostRepo
 	dockerEngines repo.DockerEngineRepo
 	apps          repo.AppRepo
+	rollups       repo.ResourceRollupRepo
 }
 
 // NewTopologyHandler creates a TopologyHandler.
-func NewTopologyHandler(ph repo.PhysicalHostRepo, vh repo.VirtualHostRepo, de repo.DockerEngineRepo, apps repo.AppRepo) *TopologyHandler {
+func NewTopologyHandler(ph repo.PhysicalHostRepo, vh repo.VirtualHostRepo, de repo.DockerEngineRepo, apps repo.AppRepo, rollups repo.ResourceRollupRepo) *TopologyHandler {
 	return &TopologyHandler{
 		physicalHosts: ph,
 		virtualHosts:  vh,
 		dockerEngines: de,
 		apps:          apps,
+		rollups:       rollups,
 	}
 }
 
@@ -55,6 +57,9 @@ func (h *TopologyHandler) Routes(r chi.Router) {
 
 	// Full topology chain
 	r.Get("/topology", h.GetTopology)
+
+	// Resource rollup values for a physical host
+	r.Get("/hosts/physical/{id}/resources", h.GetPhysicalResources)
 }
 
 // ---- request / response types -----------------------------------------------
@@ -88,6 +93,13 @@ type dockerEngineRequest struct {
 	SocketType    string `json:"socket_type"`
 	SocketPath    string `json:"socket_path"`
 	VirtualHostID string `json:"virtual_host_id"`
+}
+
+// hostResourcesResponse holds the latest avg rollup values for CPU, memory, and disk.
+type hostResourcesResponse struct {
+	CPU  float64 `json:"cpu"`
+	Mem  float64 `json:"mem"`
+	Disk float64 `json:"disk"`
 }
 
 // topology chain response types
@@ -653,4 +665,48 @@ func (h *TopologyHandler) GetTopology(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, result)
+}
+
+// ---- host resources ---------------------------------------------------------
+
+// GetPhysicalResources returns the latest hourly resource rollup values (CPU/mem/disk %)
+// for a physical host. Returns zeroes when no rollup data exists yet.
+// GET /api/v1/hosts/physical/{id}/resources?period=hour
+func (h *TopologyHandler) GetPhysicalResources(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if _, err := h.physicalHosts.Get(r.Context(), id); errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "physical host not found")
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	period := r.URL.Query().Get("period")
+	if period == "" {
+		period = "hour"
+	}
+	if period != "hour" && period != "day" {
+		writeError(w, http.StatusBadRequest, "period must be hour or day")
+		return
+	}
+
+	rollups, err := h.rollups.LatestForSource(r.Context(), id, "host", period)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	resp := hostResourcesResponse{}
+	for _, rr := range rollups {
+		switch rr.Metric {
+		case "cpu_percent":
+			resp.CPU = rr.Avg
+		case "mem_percent":
+			resp.Mem = rr.Avg
+		case "disk_percent":
+			resp.Disk = rr.Avg
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/api/topology_test.go
+++ b/internal/api/topology_test.go
@@ -21,7 +21,8 @@ func newTopologyRouter(t *testing.T) http.Handler {
 	vh := repo.NewVirtualHostRepo(db)
 	de := repo.NewDockerEngineRepo(db)
 	apps := repo.NewAppRepo(db)
-	h := api.NewTopologyHandler(ph, vh, de, apps)
+	rollups := repo.NewResourceRollupRepo(db)
+	h := api.NewTopologyHandler(ph, vh, de, apps, rollups)
 	r := chi.NewRouter()
 	h.Routes(r)
 	return r
@@ -494,6 +495,42 @@ func TestGetTopology_FullChain(t *testing.T) {
 	}
 	if len(chain[0].VirtualHosts[0].DockerEngines[0].Apps) != 0 {
 		t.Errorf("expected 0 apps got %d", len(chain[0].VirtualHosts[0].DockerEngines[0].Apps))
+	}
+}
+
+// ---- GET /hosts/physical/{id}/resources -------------------------------------
+
+func TestGetPhysicalResources_HappyPath(t *testing.T) {
+	router := newTopologyRouter(t)
+	ph := createPhysicalHost(t, router, "host1", "10.0.0.1", "bare_metal")
+
+	req := httptest.NewRequest(http.MethodGet, "/hosts/physical/"+ph.ID+"/resources", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		CPU  float64 `json:"cpu"`
+		Mem  float64 `json:"mem"`
+		Disk float64 `json:"disk"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode resources: %v", err)
+	}
+	// No rollup data exists yet — all fields must be zero.
+	if resp.CPU != 0 || resp.Mem != 0 || resp.Disk != 0 {
+		t.Errorf("expected zeroes when no rollup data, got cpu=%.2f mem=%.2f disk=%.2f", resp.CPU, resp.Mem, resp.Disk)
+	}
+}
+
+func TestGetPhysicalResources_NotFound(t *testing.T) {
+	router := newTopologyRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/hosts/physical/does-not-exist/resources", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
 	}
 }
 

--- a/internal/repo/resource_rollups.go
+++ b/internal/repo/resource_rollups.go
@@ -31,6 +31,8 @@ type ResourceRollupRepo interface {
 	PurgeReadings(ctx context.Context, cutoff time.Time) (int64, error)
 	// PurgeHourlyRollups deletes hourly resource_rollups with period_start < cutoff. Returns rows deleted.
 	PurgeHourlyRollups(ctx context.Context, cutoff time.Time) (int64, error)
+	// LatestForSource returns the most recent rollup row per metric for the given source and period type.
+	LatestForSource(ctx context.Context, sourceID, sourceType, periodType string) ([]models.ResourceRollup, error)
 }
 
 type sqliteResourceRollupRepo struct {
@@ -113,4 +115,23 @@ func (r *sqliteResourceRollupRepo) PurgeHourlyRollups(ctx context.Context, cutof
 	}
 	n, _ := res.RowsAffected()
 	return n, nil
+}
+
+func (r *sqliteResourceRollupRepo) LatestForSource(ctx context.Context, sourceID, sourceType, periodType string) ([]models.ResourceRollup, error) {
+	var rows []models.ResourceRollup
+	err := r.db.SelectContext(ctx, &rows, `
+		SELECT source_id, source_type, metric, period_type, period_start, avg, min, max
+		FROM resource_rollups r1
+		WHERE source_id = ? AND source_type = ? AND period_type = ?
+		  AND period_start = (
+		      SELECT MAX(period_start) FROM resource_rollups r2
+		      WHERE r2.source_id = r1.source_id
+		        AND r2.metric = r1.metric
+		        AND r2.period_type = r1.period_type
+		  )`,
+		sourceID, sourceType, periodType)
+	if err != nil {
+		return nil, fmt.Errorf("latest for source: %w", err)
+	}
+	return rows, nil
 }


### PR DESCRIPTION
## What
Implements the host topology screen and infrastructure widgets on the dashboard.

## Why
Closes #24 — T-24: Host topology screen + host widgets on dashboard

## How
**Backend:**
- Added `LatestForSource(ctx, sourceID, sourceType, periodType)` to `ResourceRollupRepo` interface + SQLite implementation (returns most recent rollup row per metric for a given source)
- Added `GET /api/v1/hosts/physical/{id}/resources?period=hour` endpoint to `TopologyHandler` — returns `{cpu, mem, disk}` avg percentages from rollups; zeroes when no data exists yet
- Updated `NewTopologyHandler` to accept `ResourceRollupRepo`; wired in `main.go`
- Added happy-path and not-found tests for the new resources endpoint

**Frontend:**
- Replaced `Topology.tsx` stub with a full collapsible tree: physical hosts → VMs → Docker engines, each level with inline add/edit/delete forms following the Checks screen pattern
- Forms validate name + IP/path before submission; all errors shown inline
- Expanding a physical host shows its VMs; expanding a VM shows its Docker engines
- `Dashboard.tsx` fetches physical hosts on load; shows an "Infrastructure" section in the right column only when `> 0` hosts are configured; section is absent otherwise
- `HostWidget` accepts an optional `onClick` prop and navigates to `/topology`

## Test coverage
- `go test ./...` — all packages pass
- `npm run build` — zero TypeScript errors
- New tests: `TestGetPhysicalResources_HappyPath`, `TestGetPhysicalResources_NotFound`

## Closes
Closes #24