### PR TITLE
feat: T-34 Infrastructure integrations — Traefik + Docker health checks

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/digitalcheffe/nora/internal/docker"
 	"github.com/digitalcheffe/nora/internal/frontend"
 	"github.com/digitalcheffe/nora/internal/ingest"
+	"github.com/digitalcheffe/nora/internal/infra"
 	"github.com/digitalcheffe/nora/internal/jobs"
 	"github.com/digitalcheffe/nora/internal/monitor"
 	"github.com/digitalcheffe/nora/internal/profile"
@@ -45,7 +46,8 @@ func main() {
 	virtualHostRepo := repo.NewVirtualHostRepo(db)
 	dockerEngineRepo := repo.NewDockerEngineRepo(db)
 	customProfileRepo := repo.NewCustomProfileRepo(db)
-	store := repo.NewStore(appRepo, eventRepo, checkRepo, rollupRepo, resourceRepo, resourceRollupRepo, physicalHostRepo, virtualHostRepo, dockerEngineRepo)
+	infraRepo := repo.NewInfraRepo(db)
+	store := repo.NewStore(appRepo, eventRepo, checkRepo, rollupRepo, resourceRepo, resourceRollupRepo, physicalHostRepo, virtualHostRepo, dockerEngineRepo, infraRepo)
 
 	// Profile registry — load all bundled YAML profiles
 	registry, err := profile.NewRegistry(noraprofiles.Files)
@@ -67,14 +69,29 @@ func main() {
 	go jobs.StartHourlyRollup(rollupCtx, store)
 	go jobs.StartDailyRollup(rollupCtx, store)
 
+	// Traefik sync worker — polls all enabled Traefik integrations every 60 s.
+	infraCtx, infraCancel := context.WithCancel(context.Background())
+	defer infraCancel()
+	syncWorker := infra.NewSyncWorker(store)
+	go syncWorker.Start(infraCtx)
+
 	// Docker socket watcher and resource poller — optional; skipped if the socket is not available.
 	dockerCtx, dockerCancel := context.WithCancel(context.Background())
 	defer dockerCancel()
+
 	if watcher, err := docker.NewWatcher(store); err != nil {
 		log.Printf("docker watcher: socket not available, skipping (%v)", err)
 	} else {
+		// Wire up health poller so start events trigger an immediate health check.
+		if healthPoller, err := docker.NewHealthPoller(store); err != nil {
+			log.Printf("docker health poller: socket not available, skipping (%v)", err)
+		} else {
+			watcher.SetContainerStartHook(healthPoller.CheckContainer)
+			go healthPoller.Start(dockerCtx)
+		}
 		go watcher.Start(dockerCtx)
 	}
+
 	if poller, err := docker.NewResourcePoller(store); err != nil {
 		log.Printf("resource poller: socket not available, skipping (%v)", err)
 	} else {
@@ -99,6 +116,7 @@ func main() {
 		api.NewDashboardHandler(appRepo, eventRepo, checkRepo, rollupRepo, registry).Routes(r)
 		api.NewTopologyHandler(physicalHostRepo, virtualHostRepo, dockerEngineRepo, appRepo, resourceRollupRepo).Routes(r)
 		api.NewProfilesHandler(registry, customProfileRepo).Routes(r)
+		api.NewInfraHandler(infraRepo, syncWorker).Routes(r)
 	})
 
 	// Frontend — serve embedded React app, SPA fallback to index.html

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,6 +9,7 @@ import type {
   AuthUser,
   CreateAppInput,
   CreateCheckInput,
+  CreateIntegrationInput,
   CreateUserInput,
   CustomProfile,
   DashboardSummaryResponse,
@@ -16,11 +17,14 @@ import type {
   Event,
   EventFilter,
   HostResources,
+  InfraIntegration,
   ListResponse,
   LoginInput,
   MonitorCheck,
   PhysicalHost,
   Profile,
+  SyncResult,
+  TraefikCert,
   User,
   ValidationResult,
   VirtualHost,
@@ -225,6 +229,31 @@ export const profiles = {
 
   listCustom: () =>
     request<ListResponse<CustomProfile>>('GET', '/profiles/custom'),
+}
+
+// ── Infrastructure Integrations ───────────────────────────────────────────────
+
+export const integrations = {
+  list: () =>
+    request<ListResponse<InfraIntegration>>('GET', '/integrations'),
+
+  get: (id: string) =>
+    request<InfraIntegration>('GET', `/integrations/${id}`),
+
+  create: (input: CreateIntegrationInput) =>
+    request<InfraIntegration>('POST', '/integrations', input),
+
+  update: (id: string, input: Partial<CreateIntegrationInput>) =>
+    request<InfraIntegration>('PUT', `/integrations/${id}`, input),
+
+  delete: (id: string) =>
+    request<void>('DELETE', `/integrations/${id}`),
+
+  sync: (id: string) =>
+    request<SyncResult>('POST', `/integrations/${id}/sync`),
+
+  certs: (id: string) =>
+    request<ListResponse<TraefikCert>>('GET', `/integrations/${id}/certs`),
 }
 
 // ── Metrics ───────────────────────────────────────────────────────────────────

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -85,6 +85,7 @@ export interface EventFilter {
 
 export type CheckType = 'ping' | 'url' | 'ssl'
 export type CheckStatus = 'up' | 'warn' | 'down'
+export type SSLSource = 'traefik' | 'standalone'
 
 export interface MonitorCheck {
   id: string
@@ -96,6 +97,8 @@ export interface MonitorCheck {
   expected_status: number | null
   ssl_warn_days: number
   ssl_crit_days: number
+  ssl_source: SSLSource | null
+  integration_id: string | null
   enabled: boolean
   last_checked_at: string | null
   last_status: CheckStatus | null
@@ -112,7 +115,50 @@ export interface CreateCheckInput {
   expected_status?: number
   ssl_warn_days?: number
   ssl_crit_days?: number
+  ssl_source?: SSLSource
+  integration_id?: string
   enabled?: boolean
+}
+
+// ── Infrastructure Integrations ───────────────────────────────────────────────
+
+export type IntegrationType = 'traefik'
+export type IntegrationStatus = 'ok' | 'error'
+
+export interface InfraIntegration {
+  id: string
+  type: IntegrationType
+  name: string
+  api_url: string
+  api_key?: string | null
+  enabled: boolean
+  last_synced_at: string | null
+  last_status: IntegrationStatus | null
+  last_error: string | null
+  created_at: string
+}
+
+export interface CreateIntegrationInput {
+  type: IntegrationType
+  name: string
+  api_url: string
+  api_key?: string | null
+}
+
+export interface TraefikCert {
+  id: string
+  integration_id: string
+  domain: string
+  issuer: string | null
+  expires_at: string | null
+  sans: string[]
+  last_seen_at: string
+}
+
+export interface SyncResult {
+  status: string
+  certs_found: number
+  synced_at: string
 }
 
 // ── Topology ─────────────────────────────────────────────────────────────────

--- a/frontend/src/pages/Checks.css
+++ b/frontend/src/pages/Checks.css
@@ -316,3 +316,32 @@
 
 .ssl-domain { font-size: 12px; color: var(--text); flex: 1; font-family: var(--mono); }
 .ssl-date   { font-family: var(--mono); font-size: 10px; color: var(--text3); }
+
+/* ── SSL SOURCE TOGGLE ── */
+
+.ssl-standalone-warning {
+  margin-top: 6px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--yellow);
+  line-height: 1.5;
+  border-left: 2px solid var(--yellow-dim);
+  padding-left: 8px;
+}
+
+.ssl-no-traefik-banner {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px 10px;
+  background: var(--bg3);
+}
+
+.ssl-no-certs-msg {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  padding: 4px 0;
+}

--- a/frontend/src/pages/Checks.tsx
+++ b/frontend/src/pages/Checks.tsx
@@ -2,8 +2,8 @@ import { useState, useEffect } from 'react'
 import type { ReactNode } from 'react'
 import { Topbar } from '../components/Topbar'
 import { SSLRow } from '../components/SSLRow'
-import { checks as checksApi } from '../api/client'
-import type { MonitorCheck, CreateCheckInput, CheckType, SSLCert } from '../api/types'
+import { checks as checksApi, integrations as integrationsApi } from '../api/client'
+import type { MonitorCheck, CreateCheckInput, CheckType, SSLCert, InfraIntegration, TraefikCert, SSLSource } from '../api/types'
 import './Checks.css'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -16,6 +16,9 @@ type FormFields = {
   expected_status: string
   ssl_warn_days: string
   ssl_crit_days: string
+  ssl_source: SSLSource
+  integration_id: string
+  traefik_domain: string   // domain selection when ssl_source === 'traefik'
 }
 
 const defaultForm: FormFields = {
@@ -26,6 +29,9 @@ const defaultForm: FormFields = {
   expected_status: '200',
   ssl_warn_days: '30',
   ssl_crit_days: '7',
+  ssl_source: 'standalone',
+  integration_id: '',
+  traefik_domain: '',
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -64,7 +70,9 @@ function extractSSLCerts(checkList: MonitorCheck[]): SSLCert[] {
       try {
         const result = JSON.parse(c.last_result!) as { days_remaining?: number; expires_at?: string }
         if (result.days_remaining == null) return []
-        const domain = c.target.replace(/^https?:\/\//, '').split('/')[0]
+        const domain = c.ssl_source === 'traefik'
+          ? c.target
+          : c.target.replace(/^https?:\/\//, '').split('/')[0]
         const expiresAt = result.expires_at
           ? new Date(result.expires_at).toISOString().split('T')[0]
           : ''
@@ -92,14 +100,29 @@ function formatResult(lastResult: string | null): string {
 
 function validateForm(form: FormFields): string | null {
   if (!form.name.trim()) return 'Name is required'
-  if (!form.target.trim()) return 'Target is required'
-  if (form.type === 'url' || form.type === 'ssl') {
+  const interval = parseInt(form.interval_secs, 10)
+  if (isNaN(interval) || interval < 30) return 'Interval must be at least 30 seconds'
+
+  if (form.type === 'url') {
+    if (!form.target.trim()) return 'Target is required'
     if (!form.target.startsWith('http://') && !form.target.startsWith('https://')) {
       return 'Target must begin with http:// or https://'
     }
   }
-  const interval = parseInt(form.interval_secs, 10)
-  if (isNaN(interval) || interval < 30) return 'Interval must be at least 30 seconds'
+
+  if (form.type === 'ssl') {
+    if (form.ssl_source === 'traefik') {
+      if (!form.traefik_domain) return 'Select a domain from the Traefik cert list'
+    } else {
+      if (!form.target.trim()) return 'Target is required'
+      if (!form.target.startsWith('http://') && !form.target.startsWith('https://')) {
+        return 'Target must begin with http:// or https://'
+      }
+    }
+  }
+
+  if (form.type === 'ping' && !form.target.trim()) return 'Target is required'
+
   return null
 }
 
@@ -107,25 +130,36 @@ function checkToForm(check: MonitorCheck): FormFields {
   return {
     type: check.type as CheckType,
     name: check.name,
-    target: check.target,
+    target: check.type === 'ssl' && check.ssl_source === 'traefik' ? '' : check.target,
     interval_secs: String(check.interval_secs),
     expected_status: String(check.expected_status ?? 200),
     ssl_warn_days: String(check.ssl_warn_days ?? 30),
     ssl_crit_days: String(check.ssl_crit_days ?? 7),
+    ssl_source: (check.ssl_source as SSLSource) ?? 'standalone',
+    integration_id: check.integration_id ?? '',
+    traefik_domain: check.ssl_source === 'traefik' ? check.target : '',
   }
 }
 
-function formToInput(form: FormFields): CreateCheckInput {
+function formToInput(form: FormFields, integrationID?: string): CreateCheckInput {
   const input: CreateCheckInput = {
     name: form.name.trim(),
     type: form.type,
-    target: form.target.trim(),
+    target: form.type === 'ssl' && form.ssl_source === 'traefik'
+      ? form.traefik_domain
+      : form.target.trim(),
     interval_secs: parseInt(form.interval_secs, 10),
   }
-  if (form.type === 'url') input.expected_status = parseInt(form.expected_status, 10)
+  if (form.type === 'url') {
+    input.expected_status = parseInt(form.expected_status, 10)
+  }
   if (form.type === 'ssl') {
     input.ssl_warn_days = parseInt(form.ssl_warn_days, 10)
     input.ssl_crit_days = parseInt(form.ssl_crit_days, 10)
+    input.ssl_source = form.ssl_source
+    if (form.ssl_source === 'traefik' && integrationID) {
+      input.integration_id = integrationID
+    }
   }
   return input
 }
@@ -142,6 +176,10 @@ interface CheckFormProps {
   title: string
   submitLabel: string
   extraAction?: ReactNode
+  // Traefik context
+  traefikIntegrations: InfraIntegration[]
+  traefikCerts: TraefikCert[]
+  onIntegrationChange: (integrationId: string) => void
 }
 
 const CHECK_TYPES: CheckType[] = ['ping', 'url', 'ssl']
@@ -156,7 +194,13 @@ function CheckForm({
   title,
   submitLabel,
   extraAction,
+  traefikIntegrations,
+  traefikCerts,
+  onIntegrationChange,
 }: CheckFormProps) {
+  const hasTraefik = traefikIntegrations.length > 0
+  const selectedIntegration = traefikIntegrations.find(i => i.id === form.integration_id)
+
   return (
     <div className="add-form">
       <div className="form-title">{title}</div>
@@ -181,15 +225,98 @@ function CheckForm({
             placeholder="e.g. Proxmox Web UI"
           />
         </div>
-        <div className="form-field">
-          <div className="form-label">{form.type === 'ping' ? 'Host / IP' : 'URL'}</div>
-          <input
-            className="form-input"
-            value={form.target}
-            onChange={e => onChange('target', e.target.value)}
-            placeholder={form.type === 'ping' ? 'e.g. 192.168.1.1' : 'https://example.com'}
-          />
-        </div>
+
+        {/* SSL source toggle */}
+        {form.type === 'ssl' && (
+          <div className="form-field">
+            <div className="form-label">SSL Source</div>
+            {!hasTraefik ? (
+              <div className="ssl-no-traefik-banner">
+                Connect Traefik in Settings → Integrations to enable automatic SSL discovery.
+              </div>
+            ) : (
+              <div className="type-selector">
+                <button
+                  className={`type-btn${form.ssl_source === 'traefik' ? ' active' : ''}`}
+                  onClick={() => onChange('ssl_source', 'traefik')}
+                >
+                  Traefik
+                </button>
+                <button
+                  className={`type-btn${form.ssl_source === 'standalone' ? ' active' : ''}`}
+                  onClick={() => onChange('ssl_source', 'standalone')}
+                >
+                  Standalone
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Traefik SSL: integration selector + domain dropdown */}
+        {form.type === 'ssl' && form.ssl_source === 'traefik' && hasTraefik && (
+          <>
+            {traefikIntegrations.length > 1 && (
+              <div className="form-field">
+                <div className="form-label">Traefik Integration</div>
+                <select
+                  className="form-input"
+                  value={form.integration_id}
+                  onChange={e => {
+                    onChange('integration_id', e.target.value)
+                    onIntegrationChange(e.target.value)
+                  }}
+                >
+                  <option value="">Select integration…</option>
+                  {traefikIntegrations.map(i => (
+                    <option key={i.id} value={i.id}>{i.name}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+            <div className="form-field">
+              <div className="form-label">Domain</div>
+              {traefikCerts.length === 0 ? (
+                <div className="ssl-no-certs-msg">
+                  {selectedIntegration
+                    ? 'No certs discovered yet — run a sync in Settings → Integrations.'
+                    : 'Select an integration to see available domains.'}
+                </div>
+              ) : (
+                <select
+                  className="form-input"
+                  value={form.traefik_domain}
+                  onChange={e => onChange('traefik_domain', e.target.value)}
+                >
+                  <option value="">Select domain…</option>
+                  {traefikCerts.map(c => (
+                    <option key={c.id} value={c.domain}>{c.domain}</option>
+                  ))}
+                </select>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* Standalone SSL or other types: target URL/host */}
+        {(form.type !== 'ssl' || form.ssl_source === 'standalone' || !hasTraefik) && (
+          <div className="form-field">
+            <div className="form-label">{form.type === 'ping' ? 'Host / IP' : 'URL'}</div>
+            <input
+              className="form-input"
+              value={form.target}
+              onChange={e => onChange('target', e.target.value)}
+              placeholder={form.type === 'ping' ? 'e.g. 192.168.1.1' : 'https://example.com'}
+            />
+            {form.type === 'ssl' && form.ssl_source === 'standalone' && (
+              <div className="ssl-standalone-warning">
+                ⚠ Standalone SSL checks make a direct TLS connection. This may fail for
+                services proxied through Traefik on the same host. Use for external URLs only.
+              </div>
+            )}
+          </div>
+        )}
+
         <div className="form-field">
           <div className="form-label">Interval (seconds)</div>
           <input
@@ -259,6 +386,10 @@ export function Checks() {
   const [checkList, setCheckList] = useState<MonitorCheck[]>([])
   const [loading, setLoading] = useState(true)
 
+  // Traefik integrations for SSL source toggle
+  const [traefikIntegrations, setTraefikIntegrations] = useState<InfraIntegration[]>([])
+  const [traefikCerts, setTraefikCerts] = useState<TraefikCert[]>([])
+
   // Add form
   const [showAddForm, setShowAddForm] = useState(false)
   const [addForm, setAddForm] = useState<FormFields>(defaultForm)
@@ -282,14 +413,42 @@ export function Checks() {
       .then(res => setCheckList(res.data))
       .catch(() => {})
       .finally(() => setLoading(false))
+
+    integrationsApi.list()
+      .then(res => {
+        const traefik = res.data.filter(i => i.type === 'traefik' && i.enabled)
+        setTraefikIntegrations(traefik)
+        if (traefik.length > 0) {
+          return integrationsApi.certs(traefik[0].id)
+            .then(certsRes => setTraefikCerts(certsRes.data))
+            .catch(() => {})
+        }
+      })
+      .catch(() => {})
   }, [])
 
   const sslCerts = extractSSLCerts(checkList)
 
+  // ── Integration change (reload certs) ──
+
+  function handleIntegrationChange(integrationId: string) {
+    if (!integrationId) return
+    integrationsApi.certs(integrationId)
+      .then(res => setTraefikCerts(res.data))
+      .catch(() => {})
+  }
+
   // ── Add form ──
 
   function handleAddChange(field: keyof FormFields, value: string) {
-    setAddForm(prev => ({ ...prev, [field]: value }))
+    setAddForm(prev => {
+      const next = { ...prev, [field]: value }
+      // When switching to traefik ssl, auto-set first integration
+      if (field === 'ssl_source' && value === 'traefik' && traefikIntegrations.length > 0 && !next.integration_id) {
+        next.integration_id = traefikIntegrations[0].id
+      }
+      return next
+    })
     setAddError(null)
   }
 
@@ -298,7 +457,8 @@ export function Checks() {
     if (err) { setAddError(err); return }
     setAddSubmitting(true)
     try {
-      const created = await checksApi.create(formToInput(addForm))
+      const integrationId = addForm.ssl_source === 'traefik' ? addForm.integration_id : undefined
+      const created = await checksApi.create(formToInput(addForm, integrationId))
       setCheckList(prev => [created, ...prev])
       setShowAddForm(false)
       setAddForm(defaultForm)
@@ -318,6 +478,10 @@ export function Checks() {
       setExpandedId(check.id)
       setEditForm(checkToForm(check))
       setEditError(null)
+      // Load certs for the check's integration if it's traefik
+      if (check.ssl_source === 'traefik' && check.integration_id) {
+        handleIntegrationChange(check.integration_id)
+      }
     }
   }
 
@@ -331,7 +495,8 @@ export function Checks() {
     if (err) { setEditError(err); return }
     setEditSubmitting(true)
     try {
-      const updated = await checksApi.update(id, formToInput(editForm))
+      const integrationId = editForm.ssl_source === 'traefik' ? editForm.integration_id : undefined
+      const updated = await checksApi.update(id, formToInput(editForm, integrationId))
       setCheckList(prev => prev.map(c => c.id === id ? updated : c))
       setExpandedId(null)
     } catch (e: unknown) {
@@ -392,6 +557,9 @@ export function Checks() {
             submitting={addSubmitting}
             title="New Check"
             submitLabel="Add Check"
+            traefikIntegrations={traefikIntegrations}
+            traefikCerts={traefikCerts}
+            onIntegrationChange={handleIntegrationChange}
           />
         )}
 
@@ -420,7 +588,9 @@ export function Checks() {
                   <div className="monitor-info">
                     <div className="monitor-name">{check.name}</div>
                     <div className="monitor-target">
-                      {check.target} · {check.type} · every {check.interval_secs}s
+                      {check.target} · {check.type}
+                      {check.ssl_source === 'traefik' && ' (Traefik)'}
+                      {' '}· every {check.interval_secs}s
                     </div>
                   </div>
                   <div className="monitor-meta">
@@ -450,6 +620,9 @@ export function Checks() {
                       submitting={editSubmitting}
                       title="Edit Check"
                       submitLabel="Save"
+                      traefikIntegrations={traefikIntegrations}
+                      traefikCerts={traefikCerts}
+                      onIntegrationChange={handleIntegrationChange}
                       extraAction={
                         <button
                           className="form-btn danger"

--- a/frontend/src/pages/Integrations.css
+++ b/frontend/src/pages/Integrations.css
@@ -1,0 +1,242 @@
+/* ── Infrastructure Integrations ─────────────────────────────────────────────── */
+
+.int-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.int-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.int-section-title {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text2);
+}
+
+.int-empty {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text3);
+  padding: 16px 0;
+}
+
+/* ── Cards ──────────────────────────────────────────────────────────────────── */
+
+.int-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.int-card {
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.int-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.int-card-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.int-card-icon {
+  width: 32px;
+  height: 32px;
+  background: var(--bg4);
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  color: var(--text2);
+  flex-shrink: 0;
+}
+
+.int-card-name {
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.int-card-url {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  margin-top: 2px;
+}
+
+/* ── Status dot ─────────────────────────────────────────────────────────────── */
+
+.int-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.int-dot.green  { background: var(--green); }
+.int-dot.red    { background: var(--red); }
+.int-dot.grey   { background: var(--text3); }
+
+/* ── Meta line ──────────────────────────────────────────────────────────────── */
+
+.int-card-meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.int-sync-msg {
+  color: var(--green);
+}
+
+.int-card-error {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--red);
+  border-left: 2px solid var(--red-dim);
+  padding-left: 8px;
+}
+
+/* ── Card actions ───────────────────────────────────────────────────────────── */
+
+.int-card-actions {
+  display: flex;
+  gap: 8px;
+}
+
+/* ── Add form ───────────────────────────────────────────────────────────────── */
+
+.int-add-form {
+  background: var(--bg3);
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.int-form-title {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.int-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.int-form-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+}
+
+.int-form-input {
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 7px 10px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text);
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.int-form-input:focus {
+  border-color: var(--accent);
+}
+
+.int-form-error {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--red);
+}
+
+.int-form-success {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--green);
+}
+
+.int-form-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* ── Shared buttons ─────────────────────────────────────────────────────────── */
+
+.int-btn {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  padding: 6px 12px;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.int-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.int-btn.primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.int-btn.secondary {
+  background: var(--bg4);
+  color: var(--text);
+  border: 1px solid var(--border2);
+}
+
+.int-btn.ghost {
+  background: transparent;
+  color: var(--text2);
+  border: 1px solid var(--border);
+}
+
+.int-btn.danger {
+  background: transparent;
+  color: var(--red);
+  border: 1px solid var(--red-dim);
+}
+
+.int-btn.danger:hover {
+  background: var(--red-dim);
+}

--- a/frontend/src/pages/Integrations.tsx
+++ b/frontend/src/pages/Integrations.tsx
@@ -1,0 +1,274 @@
+import { useState, useEffect } from 'react'
+import { integrations as integrationsApi } from '../api/client'
+import type { InfraIntegration, CreateIntegrationInput } from '../api/types'
+import './Integrations.css'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function statusDotClass(integration: InfraIntegration): string {
+  if (!integration.last_status) return 'int-dot grey'
+  if (integration.last_status === 'ok') return 'int-dot green'
+  return 'int-dot red'
+}
+
+function statusLabel(integration: InfraIntegration): string {
+  if (!integration.last_status) return 'Never synced'
+  if (integration.last_status === 'ok') return 'Connected'
+  return 'Error'
+}
+
+function formatTimeAgo(iso?: string | null): string {
+  if (!iso) return '—'
+  const diffMs = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diffMs / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return `${Math.floor(hrs / 24)}d ago`
+}
+
+// ── Add form ──────────────────────────────────────────────────────────────────
+
+interface AddFormProps {
+  onCreated: (integration: InfraIntegration) => void
+  onCancel: () => void
+}
+
+function AddTraefikForm({ onCreated, onCancel }: AddFormProps) {
+  const [name, setName] = useState('Traefik')
+  const [apiUrl, setApiUrl] = useState('')
+  const [apiKey, setApiKey] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [testResult, setTestResult] = useState<string | null>(null)
+
+  async function handleCreate() {
+    if (!apiUrl.trim()) { setError('API URL is required'); return }
+    setSubmitting(true)
+    setError(null)
+    try {
+      const input: CreateIntegrationInput = {
+        type: 'traefik',
+        name: name.trim() || 'Traefik',
+        api_url: apiUrl.trim(),
+        api_key: apiKey.trim() || null,
+      }
+      const created = await integrationsApi.create(input)
+      onCreated(created)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to create integration')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleTest() {
+    if (!apiUrl.trim()) { setError('API URL is required'); return }
+    setSubmitting(true)
+    setError(null)
+    setTestResult(null)
+    try {
+      const input: CreateIntegrationInput = {
+        type: 'traefik',
+        name: name.trim() || 'Traefik',
+        api_url: apiUrl.trim(),
+        api_key: apiKey.trim() || null,
+      }
+      const created = await integrationsApi.create(input)
+      const result = await integrationsApi.sync(created.id)
+      setTestResult(`Connected — ${result.certs_found} cert${result.certs_found !== 1 ? 's' : ''} discovered`)
+      onCreated(created)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Connection test failed')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="int-add-form">
+      <div className="int-form-title">Add Traefik Integration</div>
+      <div className="int-form-field">
+        <div className="int-form-label">Name</div>
+        <input
+          className="int-form-input"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="Traefik"
+        />
+      </div>
+      <div className="int-form-field">
+        <div className="int-form-label">API URL</div>
+        <input
+          className="int-form-input"
+          value={apiUrl}
+          onChange={e => setApiUrl(e.target.value)}
+          placeholder="http://traefik:8080"
+        />
+      </div>
+      <div className="int-form-field">
+        <div className="int-form-label">API Key (optional)</div>
+        <input
+          className="int-form-input"
+          type="password"
+          value={apiKey}
+          onChange={e => setApiKey(e.target.value)}
+          placeholder="Leave blank if dashboard auth is disabled"
+        />
+      </div>
+      {error && <div className="int-form-error">{error}</div>}
+      {testResult && <div className="int-form-success">{testResult}</div>}
+      <div className="int-form-actions">
+        <button className="int-btn primary" onClick={handleCreate} disabled={submitting}>
+          {submitting ? 'Saving…' : 'Add Integration'}
+        </button>
+        <button className="int-btn secondary" onClick={handleTest} disabled={submitting}>
+          Test connection
+        </button>
+        <button className="int-btn ghost" onClick={onCancel}>Cancel</button>
+      </div>
+    </div>
+  )
+}
+
+// ── Integration card ──────────────────────────────────────────────────────────
+
+interface CardProps {
+  integration: InfraIntegration
+  onUpdated: (integration: InfraIntegration) => void
+  onDeleted: (id: string) => void
+}
+
+function IntegrationCard({ integration, onUpdated, onDeleted }: CardProps) {
+  const [syncing, setSyncing] = useState(false)
+  const [syncMsg, setSyncMsg] = useState<string | null>(null)
+  const [deleting, setDeleting] = useState(false)
+  const [current, setCurrent] = useState(integration)
+
+  async function handleSync() {
+    setSyncing(true)
+    setSyncMsg(null)
+    try {
+      const result = await integrationsApi.sync(current.id)
+      setSyncMsg(`${result.certs_found} cert${result.certs_found !== 1 ? 's' : ''} discovered`)
+      // Refresh integration state
+      const updated = await integrationsApi.get(current.id)
+      setCurrent(updated)
+      onUpdated(updated)
+    } catch (e: unknown) {
+      setSyncMsg(e instanceof Error ? e.message : 'Sync failed')
+    } finally {
+      setSyncing(false)
+    }
+  }
+
+  async function handleDelete() {
+    if (!window.confirm(`Delete integration "${current.name}"?`)) return
+    setDeleting(true)
+    try {
+      await integrationsApi.delete(current.id)
+      onDeleted(current.id)
+    } catch {
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <div className="int-card">
+      <div className="int-card-header">
+        <div className="int-card-left">
+          <div className="int-card-icon">↔</div>
+          <div>
+            <div className="int-card-name">{current.name}</div>
+            <div className="int-card-url">{current.api_url}</div>
+          </div>
+        </div>
+        <div className={statusDotClass(current)} title={statusLabel(current)} />
+      </div>
+
+      <div className="int-card-meta">
+        <span>Last sync: {formatTimeAgo(current.last_synced_at)}</span>
+        {syncMsg && <span className="int-sync-msg">{syncMsg}</span>}
+      </div>
+
+      {current.last_status === 'error' && current.last_error && (
+        <div className="int-card-error">{current.last_error}</div>
+      )}
+
+      <div className="int-card-actions">
+        <button className="int-btn secondary" onClick={handleSync} disabled={syncing}>
+          {syncing ? 'Syncing…' : 'Sync now'}
+        </button>
+        <button className="int-btn danger" onClick={handleDelete} disabled={deleting}>
+          {deleting ? 'Removing…' : 'Remove'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export function InfraIntegrations() {
+  const [list, setList] = useState<InfraIntegration[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showAdd, setShowAdd] = useState(false)
+
+  useEffect(() => {
+    integrationsApi.list()
+      .then(res => setList(res.data))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
+  function handleCreated(integration: InfraIntegration) {
+    setList(prev => [...prev.filter(i => i.id !== integration.id), integration])
+    setShowAdd(false)
+  }
+
+  function handleUpdated(integration: InfraIntegration) {
+    setList(prev => prev.map(i => i.id === integration.id ? integration : i))
+  }
+
+  function handleDeleted(id: string) {
+    setList(prev => prev.filter(i => i.id !== id))
+  }
+
+  return (
+    <div className="int-section">
+      <div className="int-section-header">
+        <span className="int-section-title">Infrastructure Integrations</span>
+        {!showAdd && (
+          <button className="int-btn secondary" onClick={() => setShowAdd(true)}>
+            + Add Traefik
+          </button>
+        )}
+      </div>
+
+      {showAdd && (
+        <AddTraefikForm
+          onCreated={handleCreated}
+          onCancel={() => setShowAdd(false)}
+        />
+      )}
+
+      {loading ? (
+        <div className="int-empty">Loading…</div>
+      ) : list.length === 0 && !showAdd ? (
+        <div className="int-empty">No integrations configured. Add Traefik to enable SSL cert discovery.</div>
+      ) : (
+        <div className="int-list">
+          {list.map(i => (
+            <IntegrationCard
+              key={i.id}
+              integration={i}
+              onUpdated={handleUpdated}
+              onDeleted={handleDeleted}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import { Topbar } from '../components/Topbar'
+import { InfraIntegrations } from './Integrations'
 import './Settings.css'
 
 export function Settings() {
@@ -19,6 +20,10 @@ export function Settings() {
               <span className="section-title">Notifications</span>
             </div>
             <div className="settings-placeholder">SMTP digest configuration — T-08+</div>
+          </section>
+
+          <section className="settings-section">
+            <InfraIntegrations />
           </section>
 
           <section className="settings-section">

--- a/internal/api/checks.go
+++ b/internal/api/checks.go
@@ -39,14 +39,16 @@ func (h *ChecksHandler) Routes(r chi.Router) {
 // --- request / response types ---
 
 type checkRequest struct {
-	Name           string `json:"name"`
-	Type           string `json:"type"`
-	Target         string `json:"target"`
-	IntervalSecs   int    `json:"interval_secs"`
-	AppID          string `json:"app_id"`
-	ExpectedStatus int    `json:"expected_status"`
-	SSLWarnDays    int    `json:"ssl_warn_days"`
-	SSLCritDays    int    `json:"ssl_crit_days"`
+	Name           string  `json:"name"`
+	Type           string  `json:"type"`
+	Target         string  `json:"target"`
+	IntervalSecs   int     `json:"interval_secs"`
+	AppID          string  `json:"app_id"`
+	ExpectedStatus int     `json:"expected_status"`
+	SSLWarnDays    int     `json:"ssl_warn_days"`
+	SSLCritDays    int     `json:"ssl_crit_days"`
+	SSLSource      *string `json:"ssl_source"`       // "traefik" | "standalone" | nil
+	IntegrationID  *string `json:"integration_id"`   // required when ssl_source == "traefik"
 }
 
 type listChecksResponse struct {
@@ -77,9 +79,19 @@ func validateCheck(req checkRequest) string {
 	if req.IntervalSecs < 30 {
 		return "interval_secs must be at least 30"
 	}
-	if req.Type == "url" || req.Type == "ssl" {
+	if req.Type == "url" {
 		if !strings.HasPrefix(req.Target, "http://") && !strings.HasPrefix(req.Target, "https://") {
-			return "target must begin with http:// or https:// for url and ssl checks"
+			return "target must begin with http:// or https:// for url checks"
+		}
+	}
+	// For SSL checks, only require a URL prefix in standalone mode.
+	// Traefik-mode SSL checks use a bare domain name as the target.
+	if req.Type == "ssl" {
+		isTraefik := req.SSLSource != nil && *req.SSLSource == "traefik"
+		if !isTraefik {
+			if !strings.HasPrefix(req.Target, "http://") && !strings.HasPrefix(req.Target, "https://") {
+				return "target must begin with http:// or https:// for standalone ssl checks"
+			}
 		}
 	}
 	return ""
@@ -128,6 +140,8 @@ func (h *ChecksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		ExpectedStatus: req.ExpectedStatus,
 		SSLWarnDays:    warnDays,
 		SSLCritDays:    critDays,
+		SSLSource:      req.SSLSource,
+		IntegrationID:  req.IntegrationID,
 		Enabled:        true,
 		CreatedAt:      time.Now().UTC(),
 	}
@@ -198,6 +212,12 @@ func (h *ChecksHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.SSLCritDays != 0 {
 		existing.SSLCritDays = req.SSLCritDays
+	}
+	if req.SSLSource != nil {
+		existing.SSLSource = req.SSLSource
+	}
+	if req.IntegrationID != nil {
+		existing.IntegrationID = req.IntegrationID
 	}
 
 	// Re-validate the merged state.

--- a/internal/api/infrastructure.go
+++ b/internal/api/infrastructure.go
@@ -1,0 +1,231 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/infra"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// InfraHandler holds dependencies for the infrastructure integrations resource.
+type InfraHandler struct {
+	infraRepo  repo.InfraRepo
+	syncWorker *infra.SyncWorker
+}
+
+// NewInfraHandler returns an InfraHandler wired to infraRepo and syncWorker.
+func NewInfraHandler(infraRepo repo.InfraRepo, syncWorker *infra.SyncWorker) *InfraHandler {
+	return &InfraHandler{infraRepo: infraRepo, syncWorker: syncWorker}
+}
+
+// Routes registers all integration endpoints on r.
+func (h *InfraHandler) Routes(r chi.Router) {
+	r.Get("/integrations", h.List)
+	r.Post("/integrations", h.Create)
+	r.Get("/integrations/{id}", h.Get)
+	r.Put("/integrations/{id}", h.Update)
+	r.Delete("/integrations/{id}", h.Delete)
+	r.Post("/integrations/{id}/sync", h.Sync)
+	r.Get("/integrations/{id}/certs", h.ListCerts)
+}
+
+// ── request / response types ─────────────────────────────────────────────────
+
+type integrationRequest struct {
+	Type   string  `json:"type"`
+	Name   string  `json:"name"`
+	APIURL string  `json:"api_url"`
+	APIKey *string `json:"api_key"`
+}
+
+type listIntegrationsResponse struct {
+	Data  []*models.InfraIntegration `json:"data"`
+	Total int                        `json:"total"`
+}
+
+type listCertsResponse struct {
+	Data  []*models.TraefikCert `json:"data"`
+	Total int                   `json:"total"`
+}
+
+type syncResponse struct {
+	Status     string    `json:"status"`
+	CertsFound int       `json:"certs_found"`
+	SyncedAt   time.Time `json:"synced_at"`
+}
+
+// ── validation ───────────────────────────────────────────────────────────────
+
+var validIntegrationTypes = map[string]bool{"traefik": true}
+
+func validateIntegration(req integrationRequest) string {
+	if req.Name == "" {
+		return "name is required"
+	}
+	if !validIntegrationTypes[req.Type] {
+		return "type must be: traefik"
+	}
+	if req.APIURL == "" {
+		return "api_url is required"
+	}
+	return ""
+}
+
+// ── handlers ─────────────────────────────────────────────────────────────────
+
+// List returns all integrations: GET /api/v1/integrations
+func (h *InfraHandler) List(w http.ResponseWriter, r *http.Request) {
+	integrations, err := h.infraRepo.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, listIntegrationsResponse{Data: integrations, Total: len(integrations)})
+}
+
+// Create creates a new integration: POST /api/v1/integrations
+func (h *InfraHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var req integrationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if msg := validateIntegration(req); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+
+	integration := &models.InfraIntegration{
+		ID:        uuid.New().String(),
+		Type:      req.Type,
+		Name:      req.Name,
+		APIURL:    req.APIURL,
+		APIKey:    req.APIKey,
+		Enabled:   true,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := h.infraRepo.Create(r.Context(), integration); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, integration)
+}
+
+// Get returns a single integration: GET /api/v1/integrations/{id}
+func (h *InfraHandler) Get(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	integration, err := h.infraRepo.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "integration not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, integration)
+}
+
+// Update replaces mutable fields on an integration: PUT /api/v1/integrations/{id}
+func (h *InfraHandler) Update(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	existing, err := h.infraRepo.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "integration not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var req integrationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Name != "" {
+		existing.Name = req.Name
+	}
+	if req.APIURL != "" {
+		existing.APIURL = req.APIURL
+	}
+	existing.APIKey = req.APIKey
+
+	merged := integrationRequest{Type: existing.Type, Name: existing.Name, APIURL: existing.APIURL}
+	if msg := validateIntegration(merged); msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+
+	if err := h.infraRepo.Update(r.Context(), existing); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, existing)
+}
+
+// Delete removes an integration: DELETE /api/v1/integrations/{id}
+func (h *InfraHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	err := h.infraRepo.Delete(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "integration not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Sync triggers an immediate sync: POST /api/v1/integrations/{id}/sync
+func (h *InfraHandler) Sync(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	n, err := h.syncWorker.SyncOne(ctx, id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "integration not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, syncResponse{
+		Status:     "ok",
+		CertsFound: n,
+		SyncedAt:   time.Now().UTC(),
+	})
+}
+
+// ListCerts returns cached certs for an integration: GET /api/v1/integrations/{id}/certs
+func (h *InfraHandler) ListCerts(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	// Verify the integration exists.
+	if _, err := h.infraRepo.Get(r.Context(), id); errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "integration not found")
+		return
+	}
+
+	certs, err := h.infraRepo.ListCerts(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, listCertsResponse{Data: certs, Total: len(certs)})
+}

--- a/internal/api/ingest_test.go
+++ b/internal/api/ingest_test.go
@@ -21,7 +21,7 @@ func newIngestRouter(t *testing.T) (http.Handler, *repo.Store) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 	profiler := &profile.NoopLoader{}
 
@@ -44,7 +44,7 @@ func TestHandleIngest_HappyPath(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()
@@ -131,7 +131,7 @@ func TestHandleIngest_RateLimit(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()

--- a/internal/docker/health.go
+++ b/internal/docker/health.go
@@ -1,0 +1,191 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	dockerclient "github.com/docker/docker/client"
+	"github.com/google/uuid"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// healthAPI is the minimal Docker API subset used by HealthPoller.
+type healthAPI interface {
+	ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
+	ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error)
+}
+
+// HealthPoller reads the HEALTHCHECK status of running containers every 60 s
+// and emits events on healthy ↔ unhealthy transitions.
+//
+// Containers without a HEALTHCHECK defined are silently ignored.
+type HealthPoller struct {
+	store  *repo.Store
+	client healthAPI
+	states sync.Map // containerID → lastHealthStatus (string)
+}
+
+// NewHealthPoller returns a HealthPoller connected to the Docker daemon.
+func NewHealthPoller(store *repo.Store) (*HealthPoller, error) {
+	cli, err := dockerclient.NewClientWithOpts(
+		dockerclient.FromEnv,
+		dockerclient.WithAPIVersionNegotiation(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("docker health poller: %w", err)
+	}
+	return &HealthPoller{store: store, client: cli}, nil
+}
+
+// Start polls container health every 60 s until ctx is cancelled.
+func (p *HealthPoller) Start(ctx context.Context) {
+	log.Printf("docker health poller: starting")
+
+	p.poll(ctx)
+
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("docker health poller: stopped")
+			return
+		case <-ticker.C:
+			p.poll(ctx)
+		}
+	}
+}
+
+// CheckContainer inspects containerID and processes its health state immediately.
+// Called by the Watcher on container start events for responsiveness.
+func (p *HealthPoller) CheckContainer(ctx context.Context, containerID string) {
+	info, err := p.client.ContainerInspect(ctx, containerID)
+	if err != nil {
+		return
+	}
+	name := containerNameFromInspect(info)
+	p.processInspect(ctx, containerID, name, info)
+}
+
+// poll iterates all running containers and checks their health state.
+func (p *HealthPoller) poll(ctx context.Context) {
+	containers, err := p.client.ContainerList(ctx, container.ListOptions{})
+	if err != nil {
+		log.Printf("docker health poller: list containers: %v", err)
+		return
+	}
+	for _, c := range containers {
+		name := ""
+		if len(c.Names) > 0 {
+			name = strings.TrimPrefix(c.Names[0], "/")
+		}
+		info, err := p.client.ContainerInspect(ctx, c.ID)
+		if err != nil {
+			continue
+		}
+		if name == "" {
+			name = containerNameFromInspect(info)
+		}
+		p.processInspect(ctx, c.ID, name, info)
+	}
+}
+
+// processInspect applies health-state transition logic for an already-inspected container.
+func (p *HealthPoller) processInspect(ctx context.Context, containerID, containerName string, info container.InspectResponse) {
+	if info.State == nil || info.State.Health == nil {
+		// No HEALTHCHECK defined on this image — nothing to do.
+		return
+	}
+
+	healthStatus := info.State.Health.Status
+	if healthStatus == "" {
+		return
+	}
+
+	prev, _ := p.states.Load(containerID)
+	prevStr, _ := prev.(string)
+
+	p.states.Store(containerID, healthStatus)
+
+	// No transition on first poll or stable state.
+	if prevStr == healthStatus || prevStr == "" {
+		return
+	}
+
+	switch {
+	case healthStatus == "unhealthy":
+		p.emitHealthEvent(ctx, containerName, "error",
+			fmt.Sprintf("Container unhealthy — %s", containerName),
+			info.State.Health)
+	case healthStatus == "healthy" && prevStr == "unhealthy":
+		p.emitHealthEvent(ctx, containerName, "info",
+			fmt.Sprintf("Container healthy — %s", containerName),
+			nil)
+	}
+}
+
+// emitHealthEvent creates an event for a health state change.
+func (p *HealthPoller) emitHealthEvent(
+	ctx context.Context,
+	containerName, severity, displayText string,
+	health *container.Health,
+) {
+	appID := p.findAppID(ctx, containerName)
+
+	fields := fmt.Sprintf(
+		`{"source_type":"docker_health","container_name":%s}`,
+		jsonStr(containerName),
+	)
+
+	if health != nil && len(health.Log) > 0 {
+		last := health.Log[len(health.Log)-1]
+		fields = fmt.Sprintf(
+			`{"source_type":"docker_health","container_name":%s,"health_output":%s}`,
+			jsonStr(containerName),
+			jsonStr(last.Output),
+		)
+	}
+
+	ev := &models.Event{
+		ID:          uuid.New().String(),
+		AppID:       appID,
+		ReceivedAt:  time.Now().UTC(),
+		Severity:    severity,
+		DisplayText: displayText,
+		RawPayload:  "{}",
+		Fields:      fields,
+	}
+	if err := p.store.Events.Create(ctx, ev); err != nil {
+		log.Printf("docker health poller: create event: %v", err)
+	}
+}
+
+// findAppID looks for an app whose name matches the container name (case-insensitive).
+func (p *HealthPoller) findAppID(ctx context.Context, containerName string) string {
+	apps, err := p.store.Apps.List(ctx)
+	if err != nil {
+		return ""
+	}
+	for _, a := range apps {
+		if strings.EqualFold(a.Name, containerName) {
+			return a.ID
+		}
+	}
+	return ""
+}
+
+// containerNameFromInspect returns the bare container name (without leading slash).
+func containerNameFromInspect(info container.InspectResponse) string {
+	if info.ContainerJSONBase == nil {
+		return ""
+	}
+	return strings.TrimPrefix(info.Name, "/")
+}

--- a/internal/docker/health_test.go
+++ b/internal/docker/health_test.go
@@ -1,0 +1,200 @@
+package docker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// ── mock health API ──────────────────────────────────────────────────────────
+
+type mockHealthAPI struct {
+	containers []container.Summary
+	inspects   map[string]container.InspectResponse
+}
+
+func (m *mockHealthAPI) ContainerList(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
+	return m.containers, nil
+}
+
+func (m *mockHealthAPI) ContainerInspect(_ context.Context, id string) (container.InspectResponse, error) {
+	if info, ok := m.inspects[id]; ok {
+		return info, nil
+	}
+	return container.InspectResponse{}, nil
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func inspectWithHealth(name, healthStatus string, logOutputs ...string) container.InspectResponse {
+	health := &container.Health{Status: healthStatus}
+	for _, l := range logOutputs {
+		l := l
+		health.Log = append(health.Log, &container.HealthcheckResult{Output: l})
+	}
+	return container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			Name:  "/" + name,
+			State: &container.State{Health: health},
+		},
+	}
+}
+
+func inspectNoHealth(name string) container.InspectResponse {
+	return container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			Name:  "/" + name,
+			State: &container.State{},
+		},
+	}
+}
+
+func newTestHealthPoller(client healthAPI, eventRepo repo.EventRepo) *HealthPoller {
+	store := &repo.Store{
+		Apps:   &mockAppRepo{},
+		Events: eventRepo,
+	}
+	return &HealthPoller{store: store, client: client}
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+// TestHealthPoller_UnhealthyTransition verifies an error event fires when
+// a container transitions from healthy to unhealthy.
+func TestHealthPoller_UnhealthyTransition(t *testing.T) {
+	evRepo := &mockEventRepo{}
+	client := &mockHealthAPI{
+		containers: []container.Summary{{ID: "c1", Names: []string{"/myapp"}}},
+		inspects: map[string]container.InspectResponse{
+			"c1": inspectWithHealth("myapp", "unhealthy", "health check failed"),
+		},
+	}
+	p := newTestHealthPoller(client, evRepo)
+
+	// Seed prior state as healthy.
+	p.states.Store("c1", "healthy")
+
+	p.poll(context.Background())
+
+	if len(evRepo.created) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(evRepo.created))
+	}
+	ev := evRepo.created[0]
+	if ev.Severity != "error" {
+		t.Errorf("expected severity=error, got %s", ev.Severity)
+	}
+	prefix := "Container unhealthy"
+	if len(ev.DisplayText) < len(prefix) || ev.DisplayText[:len(prefix)] != prefix {
+		t.Errorf("unexpected display text: %q", ev.DisplayText)
+	}
+}
+
+// TestHealthPoller_RecoveryTransition verifies an info event fires on unhealthy→healthy.
+func TestHealthPoller_RecoveryTransition(t *testing.T) {
+	evRepo := &mockEventRepo{}
+	client := &mockHealthAPI{
+		containers: []container.Summary{{ID: "c1", Names: []string{"/myapp"}}},
+		inspects: map[string]container.InspectResponse{
+			"c1": inspectWithHealth("myapp", "healthy"),
+		},
+	}
+	p := newTestHealthPoller(client, evRepo)
+
+	// Seed prior state as unhealthy.
+	p.states.Store("c1", "unhealthy")
+
+	p.poll(context.Background())
+
+	if len(evRepo.created) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(evRepo.created))
+	}
+	ev := evRepo.created[0]
+	if ev.Severity != "info" {
+		t.Errorf("expected severity=info for recovery, got %s", ev.Severity)
+	}
+}
+
+// TestHealthPoller_NoHealthCheck verifies no event fires for containers without HEALTHCHECK.
+func TestHealthPoller_NoHealthCheck(t *testing.T) {
+	evRepo := &mockEventRepo{}
+	client := &mockHealthAPI{
+		containers: []container.Summary{{ID: "c1", Names: []string{"/myapp"}}},
+		inspects: map[string]container.InspectResponse{
+			"c1": inspectNoHealth("myapp"),
+		},
+	}
+	p := newTestHealthPoller(client, evRepo)
+
+	p.poll(context.Background())
+
+	if len(evRepo.created) != 0 {
+		t.Errorf("expected no events for container without HEALTHCHECK, got %d", len(evRepo.created))
+	}
+}
+
+// TestHealthPoller_NoTransition verifies no event fires when state is unchanged.
+func TestHealthPoller_NoTransition(t *testing.T) {
+	evRepo := &mockEventRepo{}
+	client := &mockHealthAPI{
+		containers: []container.Summary{{ID: "c1", Names: []string{"/myapp"}}},
+		inspects: map[string]container.InspectResponse{
+			"c1": inspectWithHealth("myapp", "healthy"),
+		},
+	}
+	p := newTestHealthPoller(client, evRepo)
+
+	// Same state already stored.
+	p.states.Store("c1", "healthy")
+
+	p.poll(context.Background())
+
+	if len(evRepo.created) != 0 {
+		t.Errorf("expected no events on stable healthy state, got %d", len(evRepo.created))
+	}
+}
+
+// TestHealthPoller_FirstPoll_NoEvent verifies no event fires on the first poll
+// (no baseline) even if the container is unhealthy.
+func TestHealthPoller_FirstPoll_NoEvent(t *testing.T) {
+	evRepo := &mockEventRepo{}
+	client := &mockHealthAPI{
+		containers: []container.Summary{{ID: "c1", Names: []string{"/myapp"}}},
+		inspects: map[string]container.InspectResponse{
+			"c1": inspectWithHealth("myapp", "unhealthy"),
+		},
+	}
+	p := newTestHealthPoller(client, evRepo)
+
+	// No prior state — first poll.
+	p.poll(context.Background())
+
+	if len(evRepo.created) != 0 {
+		t.Errorf("expected no event on first poll (no baseline), got %d", len(evRepo.created))
+	}
+}
+
+// TestHealthPoller_StartStop verifies the poller shuts down cleanly.
+func TestHealthPoller_StartStop(t *testing.T) {
+	evRepo := &mockEventRepo{}
+	client := &mockHealthAPI{}
+	p := newTestHealthPoller(client, evRepo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		p.Start(ctx)
+		close(done)
+	}()
+	cancel()
+
+	select {
+	case <-done:
+		// clean shutdown
+	case <-time.After(2 * time.Second):
+		t.Fatal("health poller did not stop within 2 seconds")
+	}
+}

--- a/internal/docker/resources_test.go
+++ b/internal/docker/resources_test.go
@@ -49,7 +49,7 @@ func (r *mockResourceReadingRepo) Create(_ context.Context, reading *models.Reso
 // --- helpers --------------------------------------------------------------
 
 func newTestResourcePoller(appRepo repo.AppRepo, eventRepo repo.EventRepo, resRepo repo.ResourceReadingRepo, cli resourcePollerAPI) *ResourcePoller {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo, nil, nil, nil, nil, nil)
 	return newResourcePollerWithClient(store, cli)
 }
 

--- a/internal/docker/watcher.go
+++ b/internal/docker/watcher.go
@@ -29,6 +29,16 @@ type dockerAPI interface {
 type Watcher struct {
 	store  *repo.Store
 	client dockerAPI
+	// onContainerStart is called after a "start" event is processed.
+	// It is used to trigger an immediate health check via the HealthPoller.
+	onContainerStart func(ctx context.Context, containerID string)
+}
+
+// SetContainerStartHook registers a callback that is called (in a goroutine)
+// whenever a container start event is received. Used to trigger an immediate
+// health check without coupling Watcher and HealthPoller.
+func (w *Watcher) SetContainerStartHook(fn func(ctx context.Context, containerID string)) {
+	w.onContainerStart = fn
 }
 
 // NewWatcher creates a Watcher connected to the Docker daemon. It returns an
@@ -100,6 +110,12 @@ func (w *Watcher) handleEvent(ctx context.Context, msg events.Message) error {
 	exitCodeStr := msg.Actor.Attributes["exitCode"]
 
 	severity, displayText := severityAndText(action, containerName, exitCodeStr)
+
+	// Trigger an immediate health check on container start.
+	if action == "start" && w.onContainerStart != nil {
+		containerID := msg.Actor.ID
+		go w.onContainerStart(ctx, containerID)
+	}
 
 	// Try to find a matching app by container name (case-insensitive).
 	appID := ""

--- a/internal/docker/watcher_test.go
+++ b/internal/docker/watcher_test.go
@@ -78,7 +78,7 @@ func (r *mockEventRepo) LatestPerApp(_ context.Context, _ []string) (map[string]
 // --- helpers -------------------------------------------------------------
 
 func newTestWatcher(appRepo repo.AppRepo, eventRepo repo.EventRepo, dc dockerAPI) *Watcher {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil, nil, nil, nil, nil, nil)
 	return &Watcher{store: store, client: dc}
 }
 

--- a/internal/infra/sync.go
+++ b/internal/infra/sync.go
@@ -1,0 +1,163 @@
+package infra
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+// SyncWorker periodically syncs all enabled Traefik integrations, populates
+// the traefik_certs cache, and fires warn/error events for expiring certs.
+type SyncWorker struct {
+	store *repo.Store
+
+	// firedToday tracks which (domain, date) pairs have already produced an
+	// expiry event today, preventing duplicate events across sync cycles.
+	mu         sync.Mutex
+	firedToday map[string]string // domain → "YYYY-MM-DD" of last fire
+}
+
+// NewSyncWorker returns a SyncWorker wired to store.
+func NewSyncWorker(store *repo.Store) *SyncWorker {
+	return &SyncWorker{
+		store:      store,
+		firedToday: make(map[string]string),
+	}
+}
+
+// Start loads all enabled Traefik integrations, syncs each immediately, then
+// re-syncs on a 60-second ticker. It blocks until ctx is cancelled.
+func (w *SyncWorker) Start(ctx context.Context) {
+	log.Printf("infra sync: starting")
+
+	w.syncAll(ctx)
+
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("infra sync: stopped")
+			return
+		case <-ticker.C:
+			w.syncAll(ctx)
+		}
+	}
+}
+
+// SyncOne runs a single synchronous sync for integrationID and returns the
+// number of certs found. Used by the manual-sync API endpoint.
+func (w *SyncWorker) SyncOne(ctx context.Context, integrationID string) (int, error) {
+	integration, err := w.store.Infra.Get(ctx, integrationID)
+	if err != nil {
+		return 0, err
+	}
+	return w.syncIntegration(ctx, integration)
+}
+
+// syncAll loads all enabled integrations and syncs each one.
+func (w *SyncWorker) syncAll(ctx context.Context) {
+	integrations, err := w.store.Infra.List(ctx)
+	if err != nil {
+		log.Printf("infra sync: list integrations: %v", err)
+		return
+	}
+	for _, i := range integrations {
+		if !i.Enabled || i.Type != "traefik" {
+			continue
+		}
+		if _, err := w.syncIntegration(ctx, i); err != nil {
+			log.Printf("infra sync: integration %q (%s): %v", i.Name, i.ID, err)
+		}
+	}
+}
+
+// syncIntegration fetches certs from one Traefik instance, upserts them into
+// the cache, updates the integration row, and fires expiry events as needed.
+func (w *SyncWorker) syncIntegration(ctx context.Context, i *models.InfraIntegration) (int, error) {
+	apiKey := ""
+	if i.APIKey != nil {
+		apiKey = *i.APIKey
+	}
+	client := NewTraefikClient(i.APIURL, apiKey)
+
+	certs, err := client.FetchCerts(ctx)
+	if err != nil {
+		errStr := err.Error()
+		statusErr := "error"
+		i.LastStatus = &statusErr
+		i.LastError = &errStr
+		_ = w.store.Infra.Update(ctx, i)
+		return 0, err
+	}
+
+	if err := w.store.Infra.UpsertCerts(ctx, i.ID, certs); err != nil {
+		return 0, err
+	}
+
+	now := time.Now().UTC()
+	statusOK := "ok"
+	i.LastStatus = &statusOK
+	i.LastError = nil
+	i.LastSyncedAt = &now
+	if err := w.store.Infra.Update(ctx, i); err != nil {
+		log.Printf("infra sync: update integration %s: %v", i.ID, err)
+	}
+
+	for _, cert := range certs {
+		w.maybeFireExpiryEvent(ctx, cert)
+	}
+
+	return len(certs), nil
+}
+
+// maybeFireExpiryEvent creates a warn or error event when a cert is within
+// the expiry window. Deduplicates: at most one event per domain per calendar day.
+func (w *SyncWorker) maybeFireExpiryEvent(ctx context.Context, cert *models.TraefikCert) {
+	if cert.ExpiresAt == nil {
+		return
+	}
+	daysRemaining := int(time.Until(*cert.ExpiresAt).Hours() / 24)
+
+	var severity, displayText string
+	switch {
+	case daysRemaining <= 7:
+		severity = "error"
+		displayText = fmt.Sprintf("SSL expiry critical — %s: %d days remaining", cert.Domain, daysRemaining)
+	case daysRemaining <= 30:
+		severity = "warn"
+		displayText = fmt.Sprintf("SSL expiring soon — %s: %d days remaining", cert.Domain, daysRemaining)
+	default:
+		return
+	}
+
+	today := time.Now().UTC().Format("2006-01-02")
+
+	w.mu.Lock()
+	last, alreadyFired := w.firedToday[cert.Domain]
+	if alreadyFired && last == today {
+		w.mu.Unlock()
+		return
+	}
+	w.firedToday[cert.Domain] = today
+	w.mu.Unlock()
+
+	event := &models.Event{
+		ID:          uuid.New().String(),
+		ReceivedAt:  time.Now().UTC(),
+		Severity:    severity,
+		DisplayText: displayText,
+		RawPayload:  "{}",
+		Fields:      `{"source":"traefik_cert","domain":"` + cert.Domain + `"}`,
+	}
+	if err := w.store.Events.Create(ctx, event); err != nil {
+		log.Printf("infra sync: create expiry event for %s: %v", cert.Domain, err)
+	}
+}

--- a/internal/infra/traefik.go
+++ b/internal/infra/traefik.go
@@ -1,0 +1,185 @@
+// Package infra provides clients for infrastructure integrations (Traefik, etc.).
+package infra
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+)
+
+// TraefikClient calls the Traefik dashboard API to discover TLS certificates
+// and HTTP routers. It carries no state between calls and is safe for
+// concurrent use.
+type TraefikClient struct {
+	baseURL string
+	apiKey  string
+	http    *http.Client
+}
+
+// NewTraefikClient returns a client targeting the Traefik API at apiURL.
+// If apiKey is non-empty it is sent as the Authorization header on every request.
+func NewTraefikClient(apiURL, apiKey string) *TraefikClient {
+	return &TraefikClient{
+		baseURL: strings.TrimRight(apiURL, "/"),
+		apiKey:  apiKey,
+		http:    &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// Ping verifies connectivity by calling GET /api/overview.
+func (c *TraefikClient) Ping(ctx context.Context) error {
+	req, err := c.newRequest(ctx, "GET", "/api/overview")
+	if err != nil {
+		return err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("traefik ping: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("traefik ping: unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// traefikRawCert mirrors the JSON shape returned by GET /api/tls/certificates.
+type traefikRawCert struct {
+	Domain struct {
+		Main string   `json:"main"`
+		SANs []string `json:"sans"`
+	} `json:"domain"`
+	Certificate string `json:"certificate"` // base64-encoded PEM
+}
+
+// FetchCerts calls GET /api/tls/certificates, parses each entry through the
+// x509 library, and returns a slice of TraefikCert ready for the cache.
+func (c *TraefikClient) FetchCerts(ctx context.Context) ([]*models.TraefikCert, error) {
+	req, err := c.newRequest(ctx, "GET", "/api/tls/certificates")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("traefik fetch certs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("traefik fetch certs: unexpected status %d", resp.StatusCode)
+	}
+
+	var raw []traefikRawCert
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("traefik fetch certs: decode: %w", err)
+	}
+
+	out := make([]*models.TraefikCert, 0, len(raw))
+	for _, r := range raw {
+		cert, err := parseCert(r)
+		if err != nil {
+			// Skip malformed entries rather than failing the whole sync.
+			continue
+		}
+		out = append(out, cert)
+	}
+	return out, nil
+}
+
+// TraefikRouter is a simplified view of a Traefik HTTP router entry.
+type TraefikRouter struct {
+	Name        string `json:"name"`
+	Rule        string `json:"rule"`
+	ServiceName string `json:"service"`
+	Status      string `json:"status"`
+}
+
+// FetchRouters calls GET /api/http/routers.
+func (c *TraefikClient) FetchRouters(ctx context.Context) ([]TraefikRouter, error) {
+	req, err := c.newRequest(ctx, "GET", "/api/http/routers")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("traefik fetch routers: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("traefik fetch routers: unexpected status %d", resp.StatusCode)
+	}
+
+	var routers []TraefikRouter
+	if err := json.NewDecoder(resp.Body).Decode(&routers); err != nil {
+		return nil, fmt.Errorf("traefik fetch routers: decode: %w", err)
+	}
+	return routers, nil
+}
+
+// newRequest builds an authenticated GET/POST request.
+func (c *TraefikClient) newRequest(ctx context.Context, method, path string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", c.apiKey)
+	}
+	return req, nil
+}
+
+// parseCert extracts certificate metadata from a raw Traefik cert entry.
+// The Certificate field is base64-encoded PEM (not DER).
+func parseCert(r traefikRawCert) (*models.TraefikCert, error) {
+	pemBytes, err := base64.StdEncoding.DecodeString(r.Certificate)
+	if err != nil {
+		// Some Traefik builds emit plain (non-base64) PEM.
+		pemBytes = []byte(r.Certificate)
+	}
+
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block in certificate data")
+	}
+
+	x509cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse x509: %w", err)
+	}
+
+	domain := r.Domain.Main
+	if domain == "" {
+		domain = x509cert.Subject.CommonName
+	}
+
+	sans := x509cert.DNSNames
+	if sans == nil {
+		sans = []string{}
+	}
+
+	issuer := strings.Join(x509cert.Issuer.Organization, ", ")
+	if issuer == "" {
+		issuer = x509cert.Issuer.CommonName
+	}
+
+	expiresAt := x509cert.NotAfter.UTC()
+
+	cert := &models.TraefikCert{
+		Domain:    domain,
+		SANs:      sans,
+		ExpiresAt: &expiresAt,
+	}
+	if issuer != "" {
+		cert.Issuer = &issuer
+	}
+	return cert, nil
+}

--- a/internal/infra/traefik_test.go
+++ b/internal/infra/traefik_test.go
@@ -1,0 +1,225 @@
+package infra
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// ── cert helpers ─────────────────────────────────────────────────────────────
+
+// selfSignedCertPEM generates a self-signed cert for domain and returns it as
+// a PEM-encoded []byte together with the parsed *x509.Certificate.
+func selfSignedCertPEM(t *testing.T, domain string, notAfter time.Time) ([]byte, *x509.Certificate) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: domain, Organization: []string{"Test CA"}},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+		DNSNames:     []string{domain, "www." + domain},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+
+	pemBlock := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return pemBlock, parsed
+}
+
+// traefikCertPayload returns a JSON body matching Traefik's /api/tls/certificates shape.
+func traefikCertPayload(t *testing.T, domain string, notAfter time.Time) []byte {
+	t.Helper()
+	pemBytes, _ := selfSignedCertPEM(t, domain, notAfter)
+	entry := traefikRawCert{}
+	entry.Domain.Main = domain
+	entry.Domain.SANs = []string{"www." + domain}
+	entry.Certificate = base64.StdEncoding.EncodeToString(pemBytes)
+	payload, _ := json.Marshal([]traefikRawCert{entry})
+	return payload
+}
+
+// ── TraefikClient tests ───────────────────────────────────────────────────────
+
+func TestTraefikClient_Ping_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/overview" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	client := NewTraefikClient(srv.URL, "")
+	if err := client.Ping(context.Background()); err != nil {
+		t.Errorf("unexpected ping error: %v", err)
+	}
+}
+
+func TestTraefikClient_Ping_ConnectionRefused(t *testing.T) {
+	client := NewTraefikClient("http://127.0.0.1:1", "") // nothing listening
+	if err := client.Ping(context.Background()); err == nil {
+		t.Error("expected error for unreachable server, got nil")
+	}
+}
+
+func TestTraefikClient_FetchCerts_ParsesCorrectly(t *testing.T) {
+	notAfter := time.Now().Add(45 * 24 * time.Hour).UTC()
+	payload := traefikCertPayload(t, "example.com", notAfter)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/tls/certificates" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(payload) //nolint:errcheck
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	client := NewTraefikClient(srv.URL, "")
+	certs, err := client.FetchCerts(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCerts: %v", err)
+	}
+
+	if len(certs) != 1 {
+		t.Fatalf("expected 1 cert, got %d", len(certs))
+	}
+	c := certs[0]
+	if c.Domain != "example.com" {
+		t.Errorf("domain: got %q, want %q", c.Domain, "example.com")
+	}
+	if c.ExpiresAt == nil {
+		t.Fatal("expected ExpiresAt to be set")
+	}
+	// Days should be around 45.
+	days := int(time.Until(*c.ExpiresAt).Hours() / 24)
+	if days < 44 || days > 46 {
+		t.Errorf("expected ~45 days remaining, got %d", days)
+	}
+	// SANs should include www.example.com
+	found := false
+	for _, s := range c.SANs {
+		if s == "www.example.com" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected www.example.com in SANs, got %v", c.SANs)
+	}
+}
+
+func TestTraefikClient_FetchCerts_EmptyList(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("[]")) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	client := NewTraefikClient(srv.URL, "")
+	certs, err := client.FetchCerts(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(certs) != 0 {
+		t.Errorf("expected 0 certs, got %d", len(certs))
+	}
+}
+
+func TestTraefikClient_FetchCerts_SkipsMalformedEntry(t *testing.T) {
+	// One good cert + one entry with garbage certificate data.
+	goodPayload := traefikCertPayload(t, "good.com", time.Now().Add(30*24*time.Hour))
+
+	var entries []traefikRawCert
+	_ = json.Unmarshal(goodPayload, &entries)
+	entries = append(entries, traefikRawCert{Certificate: "not-base64-or-pem!!!!"})
+	payload, _ := json.Marshal(entries)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(payload) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	client := NewTraefikClient(srv.URL, "")
+	certs, err := client.FetchCerts(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Only the good cert should be returned.
+	if len(certs) != 1 {
+		t.Errorf("expected 1 cert (malformed entry skipped), got %d", len(certs))
+	}
+}
+
+func TestTraefikClient_APIKey_SentAsAuthHeader(t *testing.T) {
+	var gotHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("[]")) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	client := NewTraefikClient(srv.URL, "secret-key")
+	_, _ = client.FetchCerts(context.Background())
+
+	if gotHeader != "secret-key" {
+		t.Errorf("expected Authorization=secret-key, got %q", gotHeader)
+	}
+}
+
+// ── parseCert unit test ───────────────────────────────────────────────────────
+
+func TestParseCert_ExtractsDomain(t *testing.T) {
+	notAfter := time.Now().Add(90 * 24 * time.Hour)
+	pemBytes, x := selfSignedCertPEM(t, "myservice.home", notAfter)
+
+	raw := traefikRawCert{}
+	raw.Domain.Main = "myservice.home"
+	raw.Certificate = base64.StdEncoding.EncodeToString(pemBytes)
+
+	cert, err := parseCert(raw)
+	if err != nil {
+		t.Fatalf("parseCert: %v", err)
+	}
+	if cert.Domain != "myservice.home" {
+		t.Errorf("domain: got %q", cert.Domain)
+	}
+	if cert.ExpiresAt == nil {
+		t.Fatal("ExpiresAt is nil")
+	}
+	diff := cert.ExpiresAt.Sub(x.NotAfter)
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > time.Second {
+		t.Errorf("ExpiresAt mismatch: cert=%v parsed=%v", x.NotAfter, cert.ExpiresAt)
+	}
+}

--- a/internal/ingest/pipeline_test.go
+++ b/internal/ingest/pipeline_test.go
@@ -24,7 +24,7 @@ func newTestStore(t *testing.T) *repo.Store {
 	t.Cleanup(func() { db.Close() })
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil)
+	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil)
 }
 
 func seedApp(t *testing.T, store *repo.Store, token string, rateLimit int) models.App {

--- a/internal/jobs/resource_rollup_test.go
+++ b/internal/jobs/resource_rollup_test.go
@@ -31,7 +31,7 @@ func newTestStore(t *testing.T) (*repo.Store, *sqlx.DB) {
 		repo.NewRollupRepo(db),
 		repo.NewResourceReadingRepo(db),
 		repo.NewResourceRollupRepo(db),
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 	return store, db
 }

--- a/internal/models/infrastructure.go
+++ b/internal/models/infrastructure.go
@@ -1,0 +1,29 @@
+package models
+
+import "time"
+
+// InfraIntegration represents a connected infrastructure provider (e.g. Traefik).
+type InfraIntegration struct {
+	ID           string     `db:"id"             json:"id"`
+	Type         string     `db:"type"           json:"type"`           // "traefik"
+	Name         string     `db:"name"           json:"name"`
+	APIURL       string     `db:"api_url"        json:"api_url"`
+	APIKey       *string    `db:"api_key"        json:"api_key,omitempty"`
+	Enabled      bool       `db:"enabled"        json:"enabled"`
+	LastSyncedAt *time.Time `db:"last_synced_at" json:"last_synced_at,omitempty"`
+	LastStatus   *string    `db:"last_status"    json:"last_status,omitempty"`   // "ok" | "error"
+	LastError    *string    `db:"last_error"     json:"last_error,omitempty"`
+	CreatedAt    time.Time  `db:"created_at"     json:"created_at"`
+}
+
+// TraefikCert is a TLS certificate discovered via the Traefik API and cached locally.
+type TraefikCert struct {
+	ID            string     `db:"id"             json:"id"`
+	IntegrationID string     `db:"integration_id" json:"integration_id"`
+	Domain        string     `db:"domain"         json:"domain"`
+	Issuer        *string    `db:"issuer"         json:"issuer,omitempty"`
+	ExpiresAt     *time.Time `db:"expires_at"     json:"expires_at,omitempty"`
+	SANs          []string   `db:"-"              json:"sans"`
+	SANsJSON      string     `db:"sans"           json:"-"` // raw JSON column
+	LastSeenAt    time.Time  `db:"last_seen_at"   json:"last_seen_at"`
+}

--- a/internal/models/monitor_check.go
+++ b/internal/models/monitor_check.go
@@ -13,6 +13,10 @@ type MonitorCheck struct {
 	ExpectedStatus int        `db:"expected_status" json:"expected_status,omitempty"`
 	SSLWarnDays    int        `db:"ssl_warn_days"   json:"ssl_warn_days"`
 	SSLCritDays    int        `db:"ssl_crit_days"   json:"ssl_crit_days"`
+	// SSLSource distinguishes Traefik-mode SSL checks (cert read from cache)
+	// from standalone checks (direct TLS handshake). Nil means standalone.
+	SSLSource     *string `db:"ssl_source"     json:"ssl_source,omitempty"`
+	IntegrationID *string `db:"integration_id" json:"integration_id,omitempty"`
 	Enabled        bool       `db:"enabled"         json:"enabled"`
 	LastCheckedAt  *time.Time `db:"last_checked_at" json:"last_checked_at,omitempty"`
 	LastStatus     string     `db:"last_status"     json:"last_status,omitempty"`

--- a/internal/monitor/ssl.go
+++ b/internal/monitor/ssl.go
@@ -26,11 +26,98 @@ func NewSSLChecker(store *repo.Store) *SSLChecker {
 
 // Run executes one SSL certificate expiry check cycle for check.
 //
-// It dials the target over TLS, reads the leaf certificate, and maps days
-// remaining to one of four statuses: up / warn / critical / down.
-// On a status transition, an event is created — but only when the check is
+// When check.SSLSource is "traefik", expiry is read from the traefik_certs
+// cache — no outbound TLS connection is made. Otherwise the existing standalone
+// mode dials the target and reads the cert off the TLS handshake.
+//
+// On a status transition an event is created, but only when the check is
 // linked to an app (events require a valid app_id).
 func (s *SSLChecker) Run(ctx context.Context, check *models.MonitorCheck) error {
+	if check.SSLSource != nil && *check.SSLSource == "traefik" {
+		return s.runTraefikSSL(ctx, check)
+	}
+	return s.runStandaloneSSL(ctx, check)
+}
+
+// runTraefikSSL reads cert expiry from the traefik_certs cache.
+// No network connection is made.
+func (s *SSLChecker) runTraefikSSL(ctx context.Context, check *models.MonitorCheck) error {
+	warnDays := check.SSLWarnDays
+	if warnDays == 0 {
+		warnDays = 30
+	}
+	critDays := check.SSLCritDays
+	if critDays == 0 {
+		critDays = 7
+	}
+
+	now := time.Now().UTC()
+	domain := check.Target // Traefik checks store the bare domain as target
+
+	cert, err := s.store.Infra.GetCertByDomain(ctx, domain)
+	if err != nil {
+		errStr := fmt.Sprintf("cert not found in Traefik cache for domain %q", domain)
+		if err != repo.ErrNotFound {
+			errStr = err.Error()
+		}
+		details, _ := json.Marshal(sslDetails{Error: &errStr})
+		if updateErr := s.store.Checks.UpdateStatus(ctx, check.ID, "down", string(details), now); updateErr != nil {
+			return fmt.Errorf("ssl checker (traefik): update status for %s: %w", check.ID, updateErr)
+		}
+		return nil
+	}
+
+	if cert.ExpiresAt == nil {
+		errStr := "no expiry date in Traefik cert cache"
+		details, _ := json.Marshal(sslDetails{Error: &errStr})
+		if updateErr := s.store.Checks.UpdateStatus(ctx, check.ID, "down", string(details), now); updateErr != nil {
+			return fmt.Errorf("ssl checker (traefik): update status for %s: %w", check.ID, updateErr)
+		}
+		return nil
+	}
+
+	daysRemaining := int(time.Until(*cert.ExpiresAt).Hours() / 24)
+
+	var issuerStr, subjectStr string
+	if cert.Issuer != nil {
+		issuerStr = *cert.Issuer
+	}
+	subjectStr = cert.Domain
+	expiresAt := *cert.ExpiresAt
+
+	details, _ := json.Marshal(sslDetails{
+		DaysRemaining: &daysRemaining,
+		ExpiresAt:     &expiresAt,
+		Issuer:        &issuerStr,
+		Subject:       &subjectStr,
+	})
+
+	newStatus := "up"
+	switch {
+	case daysRemaining <= 0:
+		newStatus = "down"
+	case daysRemaining <= critDays:
+		newStatus = "critical"
+	case daysRemaining <= warnDays:
+		newStatus = "warn"
+	}
+
+	prevStatus := check.LastStatus
+	if prevStatus != "" && prevStatus != newStatus && check.AppID != "" {
+		if evErr := s.createStatusEvent(ctx, check, newStatus, domain, daysRemaining, now); evErr != nil {
+			log.Printf("ssl checker (traefik): create event for check %s: %v", check.ID, evErr)
+		}
+	}
+
+	if updateErr := s.store.Checks.UpdateStatus(ctx, check.ID, newStatus, string(details), now); updateErr != nil {
+		return fmt.Errorf("ssl checker (traefik): update status for %s: %w", check.ID, updateErr)
+	}
+	return nil
+}
+
+// runStandaloneSSL dials the target over TLS and reads the leaf certificate.
+// This is the pre-T-34 behaviour, unchanged.
+func (s *SSLChecker) runStandaloneSSL(ctx context.Context, check *models.MonitorCheck) error {
 	warnDays := check.SSLWarnDays
 	if warnDays == 0 {
 		warnDays = 30
@@ -43,7 +130,6 @@ func (s *SSLChecker) Run(ctx context.Context, check *models.MonitorCheck) error 
 	result := s.runner(ctx, check.Target, warnDays, critDays)
 	now := time.Now().UTC()
 
-	// Parse days remaining from result details for use in event messages.
 	var parsed sslDetails
 	_ = json.Unmarshal(result.Details, &parsed)
 
@@ -53,9 +139,9 @@ func (s *SSLChecker) Run(ctx context.Context, check *models.MonitorCheck) error 
 	}
 
 	domain := extractDomain(check.Target)
-
 	prevStatus := check.LastStatus
 	newStatus := result.Status
+
 	if prevStatus != "" && prevStatus != newStatus && check.AppID != "" {
 		if evErr := s.createStatusEvent(ctx, check, newStatus, domain, days, now); evErr != nil {
 			log.Printf("ssl checker: create event for check %s: %v", check.ID, evErr)

--- a/internal/monitor/ssl_traefik_test.go
+++ b/internal/monitor/ssl_traefik_test.go
@@ -1,0 +1,150 @@
+package monitor
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// mockInfraRepo satisfies repo.InfraRepo for SSL checker tests.
+type mockInfraRepo struct {
+	repo.InfraRepo
+	cert *models.TraefikCert
+	err  error
+}
+
+func (m *mockInfraRepo) GetCertByDomain(_ context.Context, _ string) (*models.TraefikCert, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.cert, nil
+}
+
+func newTestStoreWithInfra(checks *mockCheckRepo, events *mockEventRepo, infra repo.InfraRepo) *repo.Store {
+	return &repo.Store{Checks: checks, Events: events, Infra: infra}
+}
+
+func makeTraefikSSLCheck(domain, lastStatus, appID string, warnDays, critDays int) *models.MonitorCheck {
+	src := "traefik"
+	return &models.MonitorCheck{
+		ID:           "ssl-traefik-1",
+		AppID:        appID,
+		Name:         "Traefik SSL",
+		Type:         "ssl",
+		Target:       domain,
+		IntervalSecs: 3600,
+		SSLWarnDays:  warnDays,
+		SSLCritDays:  critDays,
+		SSLSource:    &src,
+		LastStatus:   lastStatus,
+	}
+}
+
+// TestSSLChecker_Traefik_HappyPath verifies a cert with >30 days remaining returns "up".
+func TestSSLChecker_Traefik_HappyPath(t *testing.T) {
+	expires := time.Now().Add(90 * 24 * time.Hour).UTC()
+	infraRepo := &mockInfraRepo{cert: &models.TraefikCert{
+		Domain:    "example.com",
+		ExpiresAt: &expires,
+	}}
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	store := newTestStoreWithInfra(checks, events, infraRepo)
+	checker := &SSLChecker{store: store, runner: RunSSL}
+
+	check := makeTraefikSSLCheck("example.com", "up", "", 30, 7)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(checks.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 UpdateStatus call, got %d", len(checks.updateStatusCalls))
+	}
+	if checks.updateStatusCalls[0].status != "up" {
+		t.Errorf("expected up, got %s", checks.updateStatusCalls[0].status)
+	}
+	// No network call — runner should NOT have been invoked.
+	if len(events.created) != 0 {
+		t.Errorf("expected no events, got %d", len(events.created))
+	}
+}
+
+// TestSSLChecker_Traefik_WarnTransition verifies warn event fires on transition.
+func TestSSLChecker_Traefik_WarnTransition(t *testing.T) {
+	expires := time.Now().Add(20 * 24 * time.Hour).UTC()
+	infraRepo := &mockInfraRepo{cert: &models.TraefikCert{
+		Domain:    "example.com",
+		ExpiresAt: &expires,
+	}}
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	store := newTestStoreWithInfra(checks, events, infraRepo)
+	checker := &SSLChecker{store: store, runner: RunSSL}
+
+	check := makeTraefikSSLCheck("example.com", "up", "app-1", 30, 7)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if checks.updateStatusCalls[0].status != "warn" {
+		t.Errorf("expected warn, got %s", checks.updateStatusCalls[0].status)
+	}
+	if len(events.created) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events.created))
+	}
+	if events.created[0].Severity != "warn" {
+		t.Errorf("expected warn severity, got %s", events.created[0].Severity)
+	}
+}
+
+// TestSSLChecker_Traefik_CertNotFound verifies "down" when cert is not in cache.
+func TestSSLChecker_Traefik_CertNotFound(t *testing.T) {
+	infraRepo := &mockInfraRepo{err: repo.ErrNotFound}
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	store := newTestStoreWithInfra(checks, events, infraRepo)
+	checker := &SSLChecker{store: store, runner: RunSSL}
+
+	check := makeTraefikSSLCheck("unknown.com", "up", "", 30, 7)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if checks.updateStatusCalls[0].status != "down" {
+		t.Errorf("expected down when cert not found, got %s", checks.updateStatusCalls[0].status)
+	}
+}
+
+// TestSSLChecker_Standalone_UsesRunner verifies that standalone mode calls the runner.
+func TestSSLChecker_Standalone_UsesRunner(t *testing.T) {
+	runnerCalled := false
+	runner := func(_ context.Context, _ string, _, _ int) Result {
+		runnerCalled = true
+		days := 90
+		expires := time.Now().Add(90 * 24 * time.Hour).UTC()
+		issuer, subject := "CA", "example.com"
+		details, _ := json.Marshal(sslDetails{DaysRemaining: &days, ExpiresAt: &expires, Issuer: &issuer, Subject: &subject})
+		return Result{Status: "up", Details: details, CheckedAt: time.Now()}
+	}
+
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	store := &repo.Store{Checks: checks, Events: events}
+	checker := &SSLChecker{store: store, runner: runner}
+
+	// No ssl_source → standalone mode
+	check := makeSSLCheck("https://example.com", "up", "", 30, 7)
+	if err := checker.Run(context.Background(), check); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !runnerCalled {
+		t.Error("expected runner to be called in standalone mode")
+	}
+}

--- a/internal/repo/checks.go
+++ b/internal/repo/checks.go
@@ -33,7 +33,7 @@ func NewCheckRepo(db *sqlx.DB) CheckRepo {
 const selectCheckCols = `
 	SELECT id, COALESCE(app_id,'') AS app_id, name, type, target,
 	       interval_secs, COALESCE(expected_status,0) AS expected_status,
-	       ssl_warn_days, ssl_crit_days, enabled,
+	       ssl_warn_days, ssl_crit_days, ssl_source, integration_id, enabled,
 	       last_checked_at, COALESCE(last_status,'') AS last_status,
 	       COALESCE(last_result,'') AS last_result, created_at
 	FROM monitor_checks`
@@ -54,12 +54,14 @@ func (r *sqliteCheckRepo) Create(ctx context.Context, check *models.MonitorCheck
 	_, err := r.db.ExecContext(ctx, `
 		INSERT INTO monitor_checks
 		  (id, app_id, name, type, target, interval_secs, expected_status,
-		   ssl_warn_days, ssl_crit_days, enabled)
-		VALUES (?, NULLIF(?,?), ?, ?, ?, ?, NULLIF(?,0), ?, ?, ?)`,
+		   ssl_warn_days, ssl_crit_days, ssl_source, integration_id, enabled)
+		VALUES (?, NULLIF(?,?), ?, ?, ?, ?, NULLIF(?,0), ?, ?, ?, ?, ?)`,
 		check.ID, check.AppID, check.AppID,
 		check.Name, check.Type, check.Target, check.IntervalSecs,
 		check.ExpectedStatus,
-		check.SSLWarnDays, check.SSLCritDays, check.Enabled)
+		check.SSLWarnDays, check.SSLCritDays,
+		check.SSLSource, check.IntegrationID,
+		check.Enabled)
 	if err != nil {
 		return fmt.Errorf("create check: %w", err)
 	}
@@ -82,12 +84,15 @@ func (r *sqliteCheckRepo) Update(ctx context.Context, check *models.MonitorCheck
 	res, err := r.db.ExecContext(ctx, `
 		UPDATE monitor_checks
 		SET app_id=NULLIF(?,?), name=?, type=?, target=?, interval_secs=?,
-		    expected_status=NULLIF(?,0), ssl_warn_days=?, ssl_crit_days=?, enabled=?
+		    expected_status=NULLIF(?,0), ssl_warn_days=?, ssl_crit_days=?,
+		    ssl_source=?, integration_id=?, enabled=?
 		WHERE id=?`,
 		check.AppID, check.AppID,
 		check.Name, check.Type, check.Target, check.IntervalSecs,
 		check.ExpectedStatus,
-		check.SSLWarnDays, check.SSLCritDays, check.Enabled,
+		check.SSLWarnDays, check.SSLCritDays,
+		check.SSLSource, check.IntegrationID,
+		check.Enabled,
 		check.ID)
 	if err != nil {
 		return fmt.Errorf("update check: %w", err)

--- a/internal/repo/infrastructure.go
+++ b/internal/repo/infrastructure.go
@@ -1,0 +1,222 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+// InfraRepo defines CRUD operations for infrastructure integrations and the
+// Traefik cert cache.
+type InfraRepo interface {
+	List(ctx context.Context) ([]*models.InfraIntegration, error)
+	Get(ctx context.Context, id string) (*models.InfraIntegration, error)
+	Create(ctx context.Context, i *models.InfraIntegration) error
+	Update(ctx context.Context, i *models.InfraIntegration) error
+	Delete(ctx context.Context, id string) error
+
+	// UpsertCerts replaces the cert cache entries for integrationID with certs.
+	UpsertCerts(ctx context.Context, integrationID string, certs []*models.TraefikCert) error
+	// ListCerts returns all cached certs for integrationID.
+	ListCerts(ctx context.Context, integrationID string) ([]*models.TraefikCert, error)
+	// GetCertByDomain returns the most recently seen cert for domain across all integrations.
+	GetCertByDomain(ctx context.Context, domain string) (*models.TraefikCert, error)
+}
+
+type sqliteInfraRepo struct {
+	db *sqlx.DB
+}
+
+// NewInfraRepo returns an InfraRepo backed by the given SQLite database.
+func NewInfraRepo(db *sqlx.DB) InfraRepo {
+	return &sqliteInfraRepo{db: db}
+}
+
+// ── InfraIntegration CRUD ────────────────────────────────────────────────────
+
+func (r *sqliteInfraRepo) List(ctx context.Context) ([]*models.InfraIntegration, error) {
+	var rows []*models.InfraIntegration
+	err := r.db.SelectContext(ctx, &rows, `
+		SELECT id, type, name, api_url, api_key, enabled,
+		       last_synced_at, last_status, last_error, created_at
+		FROM infrastructure_integrations
+		ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("list integrations: %w", err)
+	}
+	if rows == nil {
+		rows = []*models.InfraIntegration{}
+	}
+	return rows, nil
+}
+
+func (r *sqliteInfraRepo) Get(ctx context.Context, id string) (*models.InfraIntegration, error) {
+	var row models.InfraIntegration
+	err := r.db.GetContext(ctx, &row, `
+		SELECT id, type, name, api_url, api_key, enabled,
+		       last_synced_at, last_status, last_error, created_at
+		FROM infrastructure_integrations WHERE id = ?`, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get integration: %w", err)
+	}
+	return &row, nil
+}
+
+func (r *sqliteInfraRepo) Create(ctx context.Context, i *models.InfraIntegration) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO infrastructure_integrations
+		  (id, type, name, api_url, api_key, enabled, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		i.ID, i.Type, i.Name, i.APIURL, i.APIKey, i.Enabled, i.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("create integration: %w", err)
+	}
+	return nil
+}
+
+func (r *sqliteInfraRepo) Update(ctx context.Context, i *models.InfraIntegration) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE infrastructure_integrations
+		SET type=?, name=?, api_url=?, api_key=?, enabled=?,
+		    last_synced_at=?, last_status=?, last_error=?
+		WHERE id=?`,
+		i.Type, i.Name, i.APIURL, i.APIKey, i.Enabled,
+		i.LastSyncedAt, i.LastStatus, i.LastError,
+		i.ID)
+	if err != nil {
+		return fmt.Errorf("update integration: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sqliteInfraRepo) Delete(ctx context.Context, id string) error {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM infrastructure_integrations WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete integration: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ── Traefik cert cache ───────────────────────────────────────────────────────
+
+func (r *sqliteInfraRepo) UpsertCerts(ctx context.Context, integrationID string, certs []*models.TraefikCert) error {
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("upsert certs: begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	now := time.Now().UTC()
+	for _, c := range certs {
+		sansJSON, _ := json.Marshal(c.SANs)
+		if c.ID == "" {
+			c.ID = uuid.New().String()
+		}
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO traefik_certs (id, integration_id, domain, issuer, expires_at, sans, last_seen_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(integration_id, domain) DO UPDATE SET
+			  issuer       = excluded.issuer,
+			  expires_at   = excluded.expires_at,
+			  sans         = excluded.sans,
+			  last_seen_at = excluded.last_seen_at`,
+			c.ID, integrationID, c.Domain, c.Issuer, c.ExpiresAt, string(sansJSON), now)
+		if err != nil {
+			return fmt.Errorf("upsert cert %s: %w", c.Domain, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("upsert certs: commit: %w", err)
+	}
+	return nil
+}
+
+func (r *sqliteInfraRepo) ListCerts(ctx context.Context, integrationID string) ([]*models.TraefikCert, error) {
+	type row struct {
+		ID            string     `db:"id"`
+		IntegrationID string     `db:"integration_id"`
+		Domain        string     `db:"domain"`
+		Issuer        *string    `db:"issuer"`
+		ExpiresAt     *time.Time `db:"expires_at"`
+		SANsJSON      string     `db:"sans"`
+		LastSeenAt    time.Time  `db:"last_seen_at"`
+	}
+	var rows []row
+	err := r.db.SelectContext(ctx, &rows, `
+		SELECT id, integration_id, domain, issuer, expires_at,
+		       COALESCE(sans,'[]') AS sans, last_seen_at
+		FROM traefik_certs
+		WHERE integration_id = ?
+		ORDER BY domain ASC`, integrationID)
+	if err != nil {
+		return nil, fmt.Errorf("list certs: %w", err)
+	}
+	out := make([]*models.TraefikCert, len(rows))
+	for i, r := range rows {
+		cert := &models.TraefikCert{
+			ID:            r.ID,
+			IntegrationID: r.IntegrationID,
+			Domain:        r.Domain,
+			Issuer:        r.Issuer,
+			ExpiresAt:     r.ExpiresAt,
+			LastSeenAt:    r.LastSeenAt,
+		}
+		_ = json.Unmarshal([]byte(r.SANsJSON), &cert.SANs)
+		out[i] = cert
+	}
+	return out, nil
+}
+
+func (r *sqliteInfraRepo) GetCertByDomain(ctx context.Context, domain string) (*models.TraefikCert, error) {
+	type row struct {
+		ID            string     `db:"id"`
+		IntegrationID string     `db:"integration_id"`
+		Domain        string     `db:"domain"`
+		Issuer        *string    `db:"issuer"`
+		ExpiresAt     *time.Time `db:"expires_at"`
+		SANsJSON      string     `db:"sans"`
+		LastSeenAt    time.Time  `db:"last_seen_at"`
+	}
+	var r2 row
+	err := r.db.GetContext(ctx, &r2, `
+		SELECT id, integration_id, domain, issuer, expires_at,
+		       COALESCE(sans,'[]') AS sans, last_seen_at
+		FROM traefik_certs
+		WHERE domain = ?
+		ORDER BY last_seen_at DESC
+		LIMIT 1`, domain)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get cert by domain: %w", err)
+	}
+	cert := &models.TraefikCert{
+		ID:            r2.ID,
+		IntegrationID: r2.IntegrationID,
+		Domain:        r2.Domain,
+		Issuer:        r2.Issuer,
+		ExpiresAt:     r2.ExpiresAt,
+		LastSeenAt:    r2.LastSeenAt,
+	}
+	_ = json.Unmarshal([]byte(r2.SANsJSON), &cert.SANs)
+	return cert, nil
+}

--- a/internal/repo/store.go
+++ b/internal/repo/store.go
@@ -11,10 +11,11 @@ type Store struct {
 	PhysicalHosts   PhysicalHostRepo
 	VirtualHosts    VirtualHostRepo
 	DockerEngines   DockerEngineRepo
+	Infra           InfraRepo
 }
 
 // NewStore creates a Store backed by the given repositories.
-func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRepo, resources ResourceReadingRepo, resourceRollups ResourceRollupRepo, physicalHosts PhysicalHostRepo, virtualHosts VirtualHostRepo, dockerEngines DockerEngineRepo) *Store {
+func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRepo, resources ResourceReadingRepo, resourceRollups ResourceRollupRepo, physicalHosts PhysicalHostRepo, virtualHosts VirtualHostRepo, dockerEngines DockerEngineRepo, infra InfraRepo) *Store {
 	return &Store{
 		Apps:            apps,
 		Events:          events,
@@ -25,5 +26,6 @@ func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRe
 		PhysicalHosts:   physicalHosts,
 		VirtualHosts:    virtualHosts,
 		DockerEngines:   dockerEngines,
+		Infra:           infra,
 	}
 }

--- a/migrations/004_infrastructure_integrations.sql
+++ b/migrations/004_infrastructure_integrations.sql
@@ -1,0 +1,26 @@
+-- T-34: Infrastructure integrations — Traefik cert discovery
+-- Creates tables for infra integrations and the Traefik cert cache.
+
+CREATE TABLE infrastructure_integrations (
+    id              TEXT PRIMARY KEY,
+    type            TEXT NOT NULL,          -- traefik (future: npm, caddy)
+    name            TEXT NOT NULL,
+    api_url         TEXT NOT NULL,
+    api_key         TEXT,                   -- nullable: set if dashboard auth is enabled
+    enabled         INTEGER NOT NULL DEFAULT 1,
+    last_synced_at  DATETIME,
+    last_status     TEXT,                   -- ok | error
+    last_error      TEXT,
+    created_at      DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE traefik_certs (
+    id              TEXT PRIMARY KEY,
+    integration_id  TEXT NOT NULL REFERENCES infrastructure_integrations(id) ON DELETE CASCADE,
+    domain          TEXT NOT NULL,
+    issuer          TEXT,
+    expires_at      DATETIME,
+    sans            TEXT,                   -- JSON array of SANs
+    last_seen_at    DATETIME NOT NULL,
+    UNIQUE(integration_id, domain)
+);

--- a/migrations/005_checks_ssl_source.sql
+++ b/migrations/005_checks_ssl_source.sql
@@ -1,0 +1,6 @@
+-- T-34: Add ssl_source and integration_id columns to monitor_checks.
+-- ssl_source: "traefik" reads expiry from cert cache; "standalone" dials TLS directly.
+-- integration_id: links a traefik-mode SSL check to its integration row.
+
+ALTER TABLE monitor_checks ADD COLUMN ssl_source    TEXT;
+ALTER TABLE monitor_checks ADD COLUMN integration_id TEXT REFERENCES infrastructure_integrations(id);


### PR DESCRIPTION
## What
Adds Traefik API integration and Docker container health polling to NORA, enabling cert expiry visibility without hairpin NAT and automatic health-state events for containers with HEALTHCHECK defined.

## Why
Closes #34. Homelabs commonly run Traefik as a reverse proxy, and reading cert expiry directly from its API is more reliable than outbound TLS handshakes that re-enter through the same host. Docker's native HEALTHCHECK produces actionable signal that NORA should surface as events.

## How

**Database (migrations 004–005)**
- `infrastructure_integrations` table: type, api_url, api_key, enabled, last_synced_at, last_status
- `traefik_certs` table: domain, issuer, expires_at, sans (JSON), last_seen_at; FK to integration
- `monitor_checks`: added `ssl_source TEXT` and `integration_id TEXT` columns

**Backend**
- `internal/models/infrastructure.go`: `InfraIntegration` and `TraefikCert` structs
- `internal/repo/infrastructure.go`: `InfraRepo` interface + sqlite implementation; `UpsertCerts` uses `INSERT … ON CONFLICT DO UPDATE`
- `internal/infra/traefik.go`: `TraefikClient` — `Ping` (GET /api/overview), `FetchCerts` (GET /api/tls/certificates, base64→PEM→x509), `FetchRouters`; skips malformed entries
- `internal/infra/sync.go`: `SyncWorker` — 60 s ticker, fires warn/error expiry events, deduplicates per domain per calendar day via in-memory map
- `internal/monitor/ssl.go`: branches on `ssl_source`; "traefik" does cache lookup via `InfraRepo.GetCertByDomain`, "standalone" uses existing TLS dial
- `internal/docker/health.go`: `HealthPoller` — 60 s poll + `CheckContainer` hook; fires error on healthy→unhealthy, info on unhealthy→healthy; no event on first poll or stable state
- `internal/docker/watcher.go`: `SetContainerStartHook` callback; triggers `CheckContainer` immediately on container start events
- `internal/api/infrastructure.go`: CRUD + `/sync` + `/certs` routes under `/integrations`; `/sync` uses 15 s timeout

**Frontend**
- `src/api/types.ts` / `client.ts`: `InfraIntegration`, `TraefikCert`, `SyncResult` types; integrations API group
- `src/pages/Integrations.tsx` + `.css`: card-based integration management with status dot, sync button, cert count, add form with connection test
- `src/pages/Settings.tsx`: Integrations section added
- `src/pages/Checks.tsx`: SSL source toggle (Traefik|Standalone) when an integration exists; domain dropdown populated from Traefik cert cache; banners for no-integration and standalone-warning states

## Test coverage
- `internal/infra/traefik_test.go`: Ping OK, connection refused, FetchCerts parses correctly, empty list, skips malformed entry, API key sent as Authorization header, parseCert extracts domain/expiry
- `internal/monitor/ssl_traefik_test.go`: Traefik happy path (>30 days → up), warn transition fires event, cert-not-found → down, standalone mode calls runner
- `internal/docker/health_test.go`: unhealthy transition fires error event, recovery fires info event, no-HEALTHCHECK → no event, stable state → no event, first poll (no baseline) → no event, start/stop clean shutdown

## Closes
Closes #34