### PR TITLE
feat: Settings tabbed layout, sidebar nav brightness, profile navigation

### DIFF
--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -46,7 +46,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  color: var(--text3);
+  color: var(--text2);
   transition: all 0.15s;
 }
 
@@ -57,7 +57,7 @@
 
 .nav-item:hover {
   background: var(--bg3);
-  color: var(--text2);
+  color: var(--text);
 }
 
 .nav-item.active {
@@ -71,4 +71,18 @@
   flex-direction: column;
   align-items: center;
   gap: 4px;
+}
+
+.sidebar-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--accent-dim);
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom'
+import { NavLink, Link, useLocation } from 'react-router-dom'
 import './Sidebar.css'
 
 const NAV_ITEMS = [
@@ -60,20 +60,12 @@ const NAV_ITEMS = [
   },
 ]
 
-const BOTTOM_ITEMS = [
-  {
-    to: '/settings',
-    title: 'Settings',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
-        <circle cx="12" cy="12" r="3" />
-        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-      </svg>
-    ),
-  },
-]
-
 export function Sidebar() {
+  const location = useLocation()
+  const onSettings = location.pathname === '/settings'
+  const profileActive = onSettings && location.search === '?tab=profile'
+  const settingsActive = onSettings && !profileActive
+
   return (
     <nav className="sidebar">
       <div className="sidebar-logo" title="NORA">N</div>
@@ -93,16 +85,24 @@ export function Sidebar() {
       <div className="sidebar-divider" />
 
       <div className="sidebar-bottom">
-        {BOTTOM_ITEMS.map(({ to, title, icon }) => (
-          <NavLink
-            key={to}
-            to={to}
-            title={title}
-            className={({ isActive }) => `nav-item${isActive ? ' active' : ''}`}
-          >
-            {icon}
-          </NavLink>
-        ))}
+        <Link
+          to="/settings?tab=apps"
+          title="Settings"
+          className={`nav-item${settingsActive ? ' active' : ''}`}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </svg>
+        </Link>
+
+        <Link
+          to="/settings?tab=profile"
+          title="Profile"
+          className={`nav-item${profileActive ? ' active' : ''}`}
+        >
+          <div className="sidebar-avatar">A</div>
+        </Link>
       </div>
     </nav>
   )

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -1,3 +1,48 @@
+/* ── Tab bar ──────────────────────────────────────────────────────────────── */
+
+.settings-tabs-bar {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  padding: 0 20px;
+  background: var(--bg2);
+  position: sticky;
+  top: 52px;
+  z-index: 5;
+}
+
+.settings-tab {
+  padding: 12px 16px;
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text2);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.settings-tab:hover {
+  color: var(--text);
+}
+
+.settings-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ── Tab content ──────────────────────────────────────────────────────────── */
+
+.tab-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* ── Sections ─────────────────────────────────────────────────────────────── */
+
 .settings-sections {
   display: flex;
   flex-direction: column;
@@ -11,9 +56,244 @@
   padding: 16px;
 }
 
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.section-title {
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
 .settings-placeholder {
-  padding: 20px 0;
+  padding: 12px 0;
   font-family: var(--mono);
   font-size: 12px;
   color: var(--text3);
+}
+
+/* ── Form fields ──────────────────────────────────────────────────────────── */
+
+.settings-field-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.settings-label {
+  font-family: var(--sans);
+  font-size: 12px;
+  color: var(--text2);
+  width: 130px;
+  flex-shrink: 0;
+}
+
+.settings-input {
+  background: var(--bg3);
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  padding: 7px 10px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text);
+  flex: 1;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.settings-input:focus {
+  border-color: var(--accent);
+}
+
+.settings-input[readonly] {
+  color: var(--text2);
+}
+
+.settings-row-inline {
+  display: flex;
+  gap: 8px;
+  flex: 1;
+}
+
+/* ── Buttons ──────────────────────────────────────────────────────────────── */
+
+.settings-btn {
+  padding: 7px 14px;
+  border-radius: 6px;
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.settings-btn.primary {
+  background: var(--accent);
+  color: white;
+}
+
+.settings-btn.primary:hover {
+  opacity: 0.9;
+}
+
+.settings-btn.secondary {
+  background: var(--bg3);
+  border-color: var(--border2);
+  color: var(--text2);
+}
+
+.settings-btn.secondary:hover {
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.settings-btn.danger {
+  background: var(--red-dim);
+  border-color: var(--red);
+  color: var(--red);
+}
+
+.settings-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+/* ── Digest schedule option cards ─────────────────────────────────────────── */
+
+.settings-option-cards {
+  display: flex;
+  gap: 8px;
+}
+
+.settings-option-card {
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--border2);
+  background: var(--bg3);
+  font-family: var(--sans);
+  font-size: 12px;
+  color: var(--text2);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.settings-option-card:hover {
+  color: var(--text);
+}
+
+.settings-option-card.active {
+  border-color: var(--accent);
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+/* ── KV grid (metrics) ────────────────────────────────────────────────────── */
+
+.settings-kv-grid {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 8px 12px;
+}
+
+.settings-kv-key {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  align-self: center;
+}
+
+.settings-kv-val {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text);
+}
+
+/* ── Resource usage bars ──────────────────────────────────────────────────── */
+
+.settings-resource-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.settings-resource-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.settings-resource-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  width: 36px;
+}
+
+.settings-progress-track {
+  flex: 1;
+  height: 4px;
+  background: var(--bg4);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.settings-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+}
+
+.settings-resource-pct {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  width: 32px;
+  text-align: right;
+}
+
+/* ── Profile avatar ───────────────────────────────────────────────────────── */
+
+.settings-avatar-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.settings-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--accent-dim);
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: 18px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.settings-avatar-name {
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.settings-avatar-email {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  margin-top: 2px;
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,38 +1,269 @@
+import { useSearchParams } from 'react-router-dom'
 import { Topbar } from '../components/Topbar'
 import { InfraIntegrations } from './Integrations'
 import './Settings.css'
 
+type Tab = 'apps' | 'notifications' | 'metrics' | 'profile'
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: 'apps', label: 'Apps' },
+  { id: 'notifications', label: 'Notifications' },
+  { id: 'metrics', label: 'Instance Metrics' },
+  { id: 'profile', label: 'Profile' },
+]
+
+// ── Apps tab ──────────────────────────────────────────────────────────────────
+
+function AppsTab() {
+  return (
+    <div className="tab-content">
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title">Webhook Ingest</span>
+        </div>
+        <div className="settings-field-row">
+          <label className="settings-label">Ingest URL</label>
+          <input className="settings-input" readOnly value="http://localhost:8080/ingest/webhook" />
+        </div>
+        <div className="settings-field-row">
+          <label className="settings-label">Ingest Token</label>
+          <div className="settings-row-inline">
+            <input className="settings-input" readOnly value="••••••••••••••••" />
+            <button className="settings-btn secondary">Rotate</button>
+          </div>
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <InfraIntegrations />
+      </section>
+
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title">Apps</span>
+          <button className="settings-btn primary">+ Add app</button>
+        </div>
+        <div className="settings-placeholder">No apps configured. Add an app to start receiving webhook events.</div>
+      </section>
+    </div>
+  )
+}
+
+// ── Notifications tab ─────────────────────────────────────────────────────────
+
+function NotificationsTab() {
+  return (
+    <div className="tab-content">
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title">SMTP</span>
+        </div>
+        <div className="settings-field-row">
+          <label className="settings-label">Host</label>
+          <input className="settings-input" placeholder="smtp.example.com" />
+        </div>
+        <div className="settings-field-row">
+          <label className="settings-label">Port</label>
+          <input className="settings-input" placeholder="587" style={{ maxWidth: 120 }} />
+        </div>
+        <div className="settings-field-row">
+          <label className="settings-label">Username</label>
+          <input className="settings-input" placeholder="user@example.com" />
+        </div>
+        <div className="settings-field-row">
+          <label className="settings-label">Password</label>
+          <input className="settings-input" type="password" placeholder="••••••••" />
+        </div>
+        <div className="settings-field-row">
+          <label className="settings-label">From</label>
+          <input className="settings-input" placeholder="nora@example.com" />
+        </div>
+        <div className="settings-actions">
+          <button className="settings-btn primary">Save</button>
+          <button className="settings-btn secondary">Test Connection</button>
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title">Digest Schedule</span>
+        </div>
+        <div className="settings-option-cards">
+          <div className="settings-option-card">Disabled</div>
+          <div className="settings-option-card">Daily</div>
+          <div className="settings-option-card active">Weekly</div>
+        </div>
+        <div className="settings-field-row" style={{ marginTop: 12 }}>
+          <label className="settings-label">Time of day</label>
+          <input className="settings-input" type="time" defaultValue="08:00" style={{ maxWidth: 120 }} />
+        </div>
+      </section>
+    </div>
+  )
+}
+
+// ── Instance Metrics tab ──────────────────────────────────────────────────────
+
+function MetricsTab() {
+  return (
+    <div className="tab-content">
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title">NORA Process</span>
+        </div>
+        <div className="settings-kv-grid">
+          <span className="settings-kv-key">Version</span><span className="settings-kv-val">v0.1.0</span>
+          <span className="settings-kv-key">Uptime</span><span className="settings-kv-val">—</span>
+          <span className="settings-kv-key">Go runtime</span><span className="settings-kv-val">go1.22</span>
+          <span className="settings-kv-key">Goroutines</span><span className="settings-kv-val">—</span>
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title">Database</span>
+        </div>
+        <div className="settings-kv-grid">
+          <span className="settings-kv-key">Engine</span><span className="settings-kv-val">SQLite</span>
+          <span className="settings-kv-key">File size</span><span className="settings-kv-val">—</span>
+          <span className="settings-kv-key">Last vacuum</span><span className="settings-kv-val">—</span>
+        </div>
+        <div className="settings-actions" style={{ marginTop: 12 }}>
+          <button className="settings-btn secondary">Run Vacuum</button>
+          <button className="settings-btn secondary">Export DB</button>
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title">Retention Policy</span>
+        </div>
+        <div className="settings-kv-grid">
+          <span className="settings-kv-key">Raw events</span><span className="settings-kv-val">7 days</span>
+          <span className="settings-kv-key">Hourly rollups</span><span className="settings-kv-val">90 days</span>
+          <span className="settings-kv-key">Daily rollups</span><span className="settings-kv-val">Forever</span>
+          <span className="settings-kv-key">Error events</span><span className="settings-kv-val">90 days</span>
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title">Resource Usage</span>
+        </div>
+        <div className="settings-resource-bars">
+          <div className="settings-resource-row">
+            <span className="settings-resource-label">CPU</span>
+            <div className="settings-progress-track">
+              <div className="settings-progress-fill" style={{ width: '12%' }} />
+            </div>
+            <span className="settings-resource-pct">12%</span>
+          </div>
+          <div className="settings-resource-row">
+            <span className="settings-resource-label">MEM</span>
+            <div className="settings-progress-track">
+              <div className="settings-progress-fill" style={{ width: '34%' }} />
+            </div>
+            <span className="settings-resource-pct">34%</span>
+          </div>
+          <div className="settings-resource-row">
+            <span className="settings-resource-label">DISK</span>
+            <div className="settings-progress-track">
+              <div className="settings-progress-fill" style={{ width: '8%' }} />
+            </div>
+            <span className="settings-resource-pct">8%</span>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+// ── Profile tab ───────────────────────────────────────────────────────────────
+
+function ProfileTab() {
+  return (
+    <div className="tab-content">
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title">Profile</span>
+        </div>
+        <div className="settings-avatar-row">
+          <div className="settings-avatar">A</div>
+          <div>
+            <div className="settings-avatar-name">Admin</div>
+            <div className="settings-avatar-email">admin@nora.local</div>
+          </div>
+        </div>
+        <div className="settings-field-row" style={{ marginTop: 16 }}>
+          <label className="settings-label">Display name</label>
+          <input className="settings-input" defaultValue="Admin" />
+        </div>
+        <div className="settings-field-row">
+          <label className="settings-label">Email</label>
+          <input className="settings-input" defaultValue="admin@nora.local" />
+        </div>
+        <div className="settings-field-row">
+          <label className="settings-label">Timezone</label>
+          <input className="settings-input" defaultValue="UTC" />
+        </div>
+        <div className="settings-actions">
+          <button className="settings-btn primary">Save</button>
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title">Change Password</span>
+        </div>
+        <div className="settings-field-row">
+          <label className="settings-label">Current password</label>
+          <input className="settings-input" type="password" placeholder="••••••••" />
+        </div>
+        <div className="settings-field-row">
+          <label className="settings-label">New password</label>
+          <input className="settings-input" type="password" placeholder="••••••••" />
+        </div>
+        <div className="settings-actions">
+          <button className="settings-btn primary">Update Password</button>
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title" style={{ color: 'var(--red)' }}>Danger Zone</span>
+        </div>
+        <div className="settings-placeholder">Delete account — removes all data associated with this user.</div>
+        <button className="settings-btn danger" style={{ marginTop: 12 }}>Delete Account</button>
+      </section>
+    </div>
+  )
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
 export function Settings() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const activeTab = (searchParams.get('tab') as Tab) || 'apps'
+
   return (
     <>
       <Topbar title="Settings" />
+      <div className="settings-tabs-bar">
+        {TABS.map(t => (
+          <button
+            key={t.id}
+            className={`settings-tab${activeTab === t.id ? ' active' : ''}`}
+            onClick={() => setSearchParams({ tab: t.id })}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
       <div className="content">
-        <div className="settings-sections">
-          <section className="settings-section">
-            <div className="section-header">
-              <span className="section-title">Users</span>
-            </div>
-            <div className="settings-placeholder">User management — T-08+</div>
-          </section>
-
-          <section className="settings-section">
-            <div className="section-header">
-              <span className="section-title">Notifications</span>
-            </div>
-            <div className="settings-placeholder">SMTP digest configuration — T-08+</div>
-          </section>
-
-          <section className="settings-section">
-            <InfraIntegrations />
-          </section>
-
-          <section className="settings-section">
-            <div className="section-header">
-              <span className="section-title">Instance Metrics</span>
-            </div>
-            <div className="settings-placeholder">Database size, events per day, peak load — T-08+</div>
-          </section>
-        </div>
+        {activeTab === 'apps' && <AppsTab />}
+        {activeTab === 'notifications' && <NotificationsTab />}
+        {activeTab === 'metrics' && <MetricsTab />}
+        {activeTab === 'profile' && <ProfileTab />}
       </div>
     </>
   )


### PR DESCRIPTION
## What
- Sidebar inactive nav icons brightened (text3 → text2, ~2× more readable); hover goes to full text brightness
- Added profile avatar button (initials) to sidebar bottom — routes to `/settings?tab=profile`
- Gear icon routes to `/settings?tab=apps`; active state is tab-aware so only one icon highlights at a time
- Settings page consolidated into a proper tabbed layout with four tabs

## Why
UI polish pass — icons were near-invisible against the dark background, and Settings had no cohesive structure to build features into.

## How
- `useLocation` in Sidebar for tab-aware active state (no NavLink quirks with search params)
- `useSearchParams` in Settings for tab state; defaults to `apps` if no param present
- Tab bar is sticky at `top: 52px` (below the 52px Topbar) with accent underline indicator
- Apps tab: webhook ingest config block + InfraIntegrations component + apps list placeholder
- Notifications tab: SMTP form (host/port/user/pass/from) + digest schedule option cards
- Instance Metrics tab: process health KV grid, DB stats, retention policy summary, CPU/MEM/DISK progress bars
- Profile tab: avatar, editable display name/email/timezone, password change, danger zone

## Test coverage
- `npm run build` passes with zero TypeScript errors
- Verified in browser preview: all four tabs render, active tab indicator correct, gear → Apps, profile avatar → Profile

## Closes
Closes #69