### PR TITLE
feat: T-25 event retention + monthly rollup + hourly metrics

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -48,7 +48,8 @@ func main() {
 	customProfileRepo := repo.NewCustomProfileRepo(db)
 	infraRepo := repo.NewInfraRepo(db)
 	settingsRepo := repo.NewSettingsRepo(db)
-	store := repo.NewStore(appRepo, eventRepo, checkRepo, rollupRepo, resourceRepo, resourceRollupRepo, physicalHostRepo, virtualHostRepo, dockerEngineRepo, infraRepo, settingsRepo)
+	metricsRepo := repo.NewMetricsRepo(db)
+	store := repo.NewStore(appRepo, eventRepo, checkRepo, rollupRepo, resourceRepo, resourceRollupRepo, physicalHostRepo, virtualHostRepo, dockerEngineRepo, infraRepo, settingsRepo, metricsRepo)
 
 	// App template registry — load all bundled YAML app templates
 	registry, err := apptemplate.NewRegistry(noraappprofiles.Files)
@@ -69,6 +70,13 @@ func main() {
 	defer rollupCancel()
 	go jobs.StartHourlyRollup(rollupCtx, store)
 	go jobs.StartDailyRollup(rollupCtx, store)
+
+	// Event jobs — monthly rollup (midnight on 1st), nightly retention (02:00), hourly metrics.
+	eventJobCtx, eventJobCancel := context.WithCancel(context.Background())
+	defer eventJobCancel()
+	go jobs.StartMonthlyRollup(eventJobCtx, store)
+	go jobs.StartEventRetention(eventJobCtx, store)
+	go jobs.StartMetricsCollection(eventJobCtx, store)
 
 	// Digest job — fires at 08:00 daily; checks stored schedule before sending.
 	digestJob := jobs.NewDigestJob(store, cfg)

--- a/internal/api/digest_test.go
+++ b/internal/api/digest_test.go
@@ -30,6 +30,7 @@ func newDigestRouter(t *testing.T) (http.Handler, *repo.Store) {
 		repo.NewDockerEngineRepo(db),
 		repo.NewInfraRepo(db),
 		repo.NewSettingsRepo(db),
+		nil,
 	)
 	digestJob := jobs.NewDigestJob(store, &config.Config{})
 	h := api.NewDigestHandler(store, digestJob)
@@ -61,6 +62,7 @@ func newDigestRouterWithSMTP(t *testing.T) (http.Handler, *repo.Store) {
 		repo.NewDockerEngineRepo(db),
 		repo.NewInfraRepo(db),
 		repo.NewSettingsRepo(db),
+		nil,
 	)
 	digestJob2 := jobs.NewDigestJob(store2, cfg)
 	h2 := api.NewDigestHandler(store2, digestJob2)

--- a/internal/api/ingest_test.go
+++ b/internal/api/ingest_test.go
@@ -21,7 +21,7 @@ func newIngestRouter(t *testing.T) (http.Handler, *repo.Store) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 	profiler := &apptemplate.NoopLoader{}
 
@@ -44,7 +44,7 @@ func TestHandleIngest_HappyPath(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()
@@ -131,7 +131,7 @@ func TestHandleIngest_RateLimit(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()

--- a/internal/docker/resources_test.go
+++ b/internal/docker/resources_test.go
@@ -49,7 +49,7 @@ func (r *mockResourceReadingRepo) Create(_ context.Context, reading *models.Reso
 // --- helpers --------------------------------------------------------------
 
 func newTestResourcePoller(appRepo repo.AppRepo, eventRepo repo.EventRepo, resRepo repo.ResourceReadingRepo, cli resourcePollerAPI) *ResourcePoller {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo, nil, nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo, nil, nil, nil, nil, nil, nil, nil)
 	return newResourcePollerWithClient(store, cli)
 }
 

--- a/internal/docker/watcher_test.go
+++ b/internal/docker/watcher_test.go
@@ -74,11 +74,20 @@ func (r *mockEventRepo) SparklineBuckets(_ context.Context, _ repo.CategoryFilte
 func (r *mockEventRepo) LatestPerApp(_ context.Context, _ []string) (map[string]*models.Event, error) {
 	return nil, nil
 }
+func (r *mockEventRepo) DeleteBySeverityBefore(_ context.Context, _ string, _ time.Time) (int64, error) {
+	return 0, nil
+}
+func (r *mockEventRepo) GroupByTypeAndSeverity(_ context.Context, _ string, _, _ time.Time) ([]repo.EventTypeCount, error) {
+	return nil, nil
+}
+func (r *mockEventRepo) MetricsForApp(_ context.Context, _ string, _, _ time.Time) (repo.EventMetrics, error) {
+	return repo.EventMetrics{}, nil
+}
 
 // --- helpers -------------------------------------------------------------
 
 func newTestWatcher(appRepo repo.AppRepo, eventRepo repo.EventRepo, dc dockerAPI) *Watcher {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	return &Watcher{store: store, client: dc}
 }
 

--- a/internal/ingest/pipeline_test.go
+++ b/internal/ingest/pipeline_test.go
@@ -24,7 +24,7 @@ func newTestStore(t *testing.T) *repo.Store {
 	t.Cleanup(func() { db.Close() })
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil)
+	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func seedApp(t *testing.T, store *repo.Store, token string, rateLimit int) models.App {

--- a/internal/jobs/event_rollup.go
+++ b/internal/jobs/event_rollup.go
@@ -1,0 +1,64 @@
+package jobs
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// RunMetricsCollection computes per-app event metrics for the previous
+// complete hour and upserts the results into the metrics table.
+func RunMetricsCollection(ctx context.Context, store *repo.Store) error {
+	now := time.Now().UTC()
+	hourEnd := now.Truncate(time.Hour)
+	hourStart := hourEnd.Add(-time.Hour)
+
+	apps, err := store.Apps.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, app := range apps {
+		m, err := store.Events.MetricsForApp(ctx, app.ID, hourStart, hourEnd)
+		if err != nil {
+			return err
+		}
+		metric := &models.Metric{
+			AppID:           app.ID,
+			Period:          hourStart,
+			EventsPerHour:   m.EventsPerHour,
+			AvgPayloadBytes: m.AvgPayloadBytes,
+			PeakPerMinute:   m.PeakPerMinute,
+		}
+		if err := store.Metrics.Upsert(ctx, metric); err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+
+	log.Printf("metrics: collected hourly metrics for %d apps at %s", len(apps), hourStart.Format("2006-01-02T15:04"))
+	return nil
+}
+
+// StartMetricsCollection runs RunMetricsCollection every hour until ctx is cancelled.
+func StartMetricsCollection(ctx context.Context, store *repo.Store) {
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+
+	log.Printf("metrics: hourly collection job started")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := RunMetricsCollection(ctx, store); err != nil && ctx.Err() == nil {
+				log.Printf("metrics: hourly collection error: %v", err)
+			}
+		}
+	}
+}

--- a/internal/jobs/resource_rollup_test.go
+++ b/internal/jobs/resource_rollup_test.go
@@ -31,7 +31,7 @@ func newTestStore(t *testing.T) (*repo.Store, *sqlx.DB) {
 		repo.NewRollupRepo(db),
 		repo.NewResourceReadingRepo(db),
 		repo.NewResourceRollupRepo(db),
-		nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil,
 	)
 	return store, db
 }

--- a/internal/jobs/retention.go
+++ b/internal/jobs/retention.go
@@ -1,0 +1,79 @@
+package jobs
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// retentionWindows maps each event severity to its retention duration.
+var retentionWindows = map[string]time.Duration{
+	"debug":    24 * time.Hour,
+	"info":     7 * 24 * time.Hour,
+	"warn":     30 * 24 * time.Hour,
+	"error":    90 * 24 * time.Hour,
+	"critical": 90 * 24 * time.Hour,
+}
+
+// RunEventRetention purges events whose received_at is older than the
+// configured retention window for their severity. Rollup rows are never
+// touched by this function.
+func RunEventRetention(ctx context.Context, store *repo.Store) error {
+	now := time.Now().UTC()
+	for severity, window := range retentionWindows {
+		cutoff := now.Add(-window)
+		n, err := store.Events.DeleteBySeverityBefore(ctx, severity, cutoff)
+		if err != nil {
+			return err
+		}
+		if n > 0 {
+			log.Printf("retention: deleted %d %s events older than %s", n, severity, window)
+		}
+	}
+	return nil
+}
+
+// durationUntilNext2AM returns the duration from now until the next 02:00 UTC.
+func durationUntilNext2AM() time.Duration {
+	now := time.Now().UTC()
+	next := time.Date(now.Year(), now.Month(), now.Day(), 2, 0, 0, 0, time.UTC)
+	if !next.After(now) {
+		next = next.Add(24 * time.Hour)
+	}
+	return next.Sub(now)
+}
+
+// StartEventRetention waits until 02:00 UTC, runs RunEventRetention, then
+// repeats every 24 hours until ctx is cancelled.
+func StartEventRetention(ctx context.Context, store *repo.Store) {
+	delay := durationUntilNext2AM()
+	log.Printf("retention: event retention job waiting %s until next 02:00 UTC", delay.Round(time.Minute))
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(delay):
+	}
+
+	run := func() {
+		if err := RunEventRetention(ctx, store); err != nil && ctx.Err() == nil {
+			log.Printf("retention: event retention error: %v", err)
+		}
+	}
+
+	run()
+
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			run()
+		}
+	}
+}

--- a/internal/jobs/retention_test.go
+++ b/internal/jobs/retention_test.go
@@ -1,0 +1,133 @@
+package jobs_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/jobs"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+// insertEvent creates an event with the given severity at the specified time.
+// app_id is empty so it is stored as NULL (the column is nullable).
+func insertEvent(t *testing.T, store *repo.Store, severity string, at time.Time) {
+	t.Helper()
+	ev := &models.Event{
+		ID:          uuid.NewString(),
+		AppID:       "",
+		ReceivedAt:  at,
+		Severity:    severity,
+		DisplayText: "test",
+		RawPayload:  "{}",
+		Fields:      "{}",
+	}
+	if err := store.Events.Create(context.Background(), ev); err != nil {
+		t.Fatalf("insertEvent: %v", err)
+	}
+}
+
+// ---- retention tests -----------------------------------------------------
+
+func TestRunEventRetention_DeletesExpiredEvents(t *testing.T) {
+	store, db := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+
+	// Each severity: one event just past the window (expired) and one inside (live).
+	insertEvent(t, store, "debug", now.Add(-25*time.Hour))      // expired (window=24h)
+	insertEvent(t, store, "debug", now.Add(-1*time.Hour))       // live
+	insertEvent(t, store, "info", now.Add(-8*24*time.Hour))     // expired (window=7d)
+	insertEvent(t, store, "info", now.Add(-1*24*time.Hour))     // live
+	insertEvent(t, store, "warn", now.Add(-31*24*time.Hour))    // expired (window=30d)
+	insertEvent(t, store, "warn", now.Add(-1*24*time.Hour))     // live
+	insertEvent(t, store, "error", now.Add(-91*24*time.Hour))   // expired (window=90d)
+	insertEvent(t, store, "error", now.Add(-1*24*time.Hour))    // live
+	insertEvent(t, store, "critical", now.Add(-91*24*time.Hour)) // expired (window=90d)
+	insertEvent(t, store, "critical", now.Add(-1*24*time.Hour)) // live
+
+	if err := jobs.RunEventRetention(ctx, store); err != nil {
+		t.Fatalf("RunEventRetention: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events").Scan(&count); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	// 5 expired deleted, 5 live remain.
+	if count != 5 {
+		t.Errorf("expected 5 events after retention, got %d", count)
+	}
+}
+
+func TestRunEventRetention_KeepsEventsWithinWindow(t *testing.T) {
+	store, db := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+
+	// All within their retention windows — none should be deleted.
+	insertEvent(t, store, "debug", now.Add(-1*time.Hour))
+	insertEvent(t, store, "info", now.Add(-6*24*time.Hour))
+	insertEvent(t, store, "warn", now.Add(-29*24*time.Hour))
+	insertEvent(t, store, "error", now.Add(-89*24*time.Hour))
+	insertEvent(t, store, "critical", now.Add(-89*24*time.Hour))
+
+	if err := jobs.RunEventRetention(ctx, store); err != nil {
+		t.Fatalf("RunEventRetention: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events").Scan(&count); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if count != 5 {
+		t.Errorf("expected all 5 events kept, got %d", count)
+	}
+}
+
+func TestRunEventRetention_NeverDeletesRollups(t *testing.T) {
+	store, db := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+
+	// Expired debug event so retention has something to purge.
+	insertEvent(t, store, "debug", now.Add(-48*time.Hour))
+
+	// Create an app and a rollup row.
+	app := &models.App{
+		ID: uuid.NewString(), Name: "test-app", Token: uuid.NewString(),
+		Config: "{}", RateLimit: 100,
+	}
+	if err := store.Apps.Create(ctx, app); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO rollups (app_id, year, month, event_type, severity, count)
+		VALUES (?, 2025, 1, 'deploy', 'info', 42)`, app.ID); err != nil {
+		t.Fatalf("insert rollup: %v", err)
+	}
+
+	if err := jobs.RunEventRetention(ctx, store); err != nil {
+		t.Fatalf("RunEventRetention: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM rollups").Scan(&count); err != nil {
+		t.Fatalf("count rollups: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("rollup rows must never be deleted by retention, got %d", count)
+	}
+}
+
+func TestRunEventRetention_NoEvents_NoError(t *testing.T) {
+	store, _ := newTestStore(t)
+	if err := jobs.RunEventRetention(context.Background(), store); err != nil {
+		t.Fatalf("RunEventRetention with no data: %v", err)
+	}
+}

--- a/internal/jobs/rollup.go
+++ b/internal/jobs/rollup.go
@@ -1,0 +1,90 @@
+package jobs
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// RunMonthlyRollup processes the previous calendar month: for each app it
+// groups events by event_type (from the fields JSON column) and severity,
+// then upserts the counts into the rollups table. Safe to call multiple times.
+func RunMonthlyRollup(ctx context.Context, store *repo.Store) error {
+	now := time.Now().UTC()
+	// The first day of the current month is the exclusive upper bound.
+	firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	firstOfPrev := firstOfMonth.AddDate(0, -1, 0)
+
+	year := firstOfPrev.Year()
+	month := int(firstOfPrev.Month())
+
+	apps, err := store.Apps.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, app := range apps {
+		rows, err := store.Events.GroupByTypeAndSeverity(ctx, app.ID, firstOfPrev, firstOfMonth)
+		if err != nil {
+			return err
+		}
+		for _, row := range rows {
+			rollup := &models.Rollup{
+				AppID:     app.ID,
+				Year:      year,
+				Month:     month,
+				EventType: row.EventType,
+				Severity:  row.Severity,
+				Count:     row.Count,
+			}
+			if err := store.Rollups.Upsert(ctx, rollup); err != nil {
+				return err
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+
+	log.Printf("rollup: processed %d apps for %04d-%02d", len(apps), year, month)
+	return nil
+}
+
+// StartMonthlyRollup wakes up daily at UTC midnight. On the 1st of each month
+// it runs RunMonthlyRollup (which should complete before StartEventRetention
+// runs at 02:00) until ctx is cancelled.
+func StartMonthlyRollup(ctx context.Context, store *repo.Store) {
+	delay := durationUntilNextMidnight()
+	log.Printf("rollup: monthly rollup job waiting %s until next midnight", delay.Round(time.Minute))
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(delay):
+	}
+
+	run := func() {
+		if time.Now().UTC().Day() == 1 {
+			if err := RunMonthlyRollup(ctx, store); err != nil && ctx.Err() == nil {
+				log.Printf("rollup: monthly rollup error: %v", err)
+			}
+		}
+	}
+
+	run()
+
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			run()
+		}
+	}
+}

--- a/internal/jobs/rollup_test.go
+++ b/internal/jobs/rollup_test.go
@@ -1,0 +1,207 @@
+package jobs_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/jobs"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+// createApp inserts a minimal app and returns its ID.
+func createApp(t *testing.T, store *repo.Store) string {
+	t.Helper()
+	app := &models.App{
+		ID:        uuid.NewString(),
+		Name:      "test-app-" + uuid.NewString()[:8],
+		Token:     uuid.NewString(),
+		Config:    "{}",
+		RateLimit: 100,
+	}
+	if err := store.Apps.Create(context.Background(), app); err != nil {
+		t.Fatalf("create app: %v", err)
+	}
+	return app.ID
+}
+
+// insertAppEvent creates an event attached to a specific app with an event_type
+// value embedded in the fields JSON.
+func insertAppEvent(t *testing.T, store *repo.Store, appID, severity, eventType string, at time.Time) {
+	t.Helper()
+	ev := &models.Event{
+		ID:          uuid.NewString(),
+		AppID:       appID,
+		ReceivedAt:  at,
+		Severity:    severity,
+		DisplayText: "test",
+		RawPayload:  "{}",
+		Fields:      `{"event_type":"` + eventType + `"}`,
+	}
+	if err := store.Events.Create(context.Background(), ev); err != nil {
+		t.Fatalf("insertAppEvent: %v", err)
+	}
+}
+
+// ---- rollup tests --------------------------------------------------------
+
+func TestRunMonthlyRollup_CountsByTypeAndSeverity(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	appID := createApp(t, store)
+
+	// Compute previous month bounds the same way RunMonthlyRollup does.
+	now := time.Now().UTC()
+	firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	firstOfPrev := firstOfMonth.AddDate(0, -1, 0)
+	midPrev := firstOfPrev.Add(15 * 24 * time.Hour)
+
+	// Seed: 3×deploy/info, 2×deploy/warn, 1×restart/info in previous month.
+	insertAppEvent(t, store, appID, "info", "deploy", midPrev)
+	insertAppEvent(t, store, appID, "info", "deploy", midPrev.Add(time.Hour))
+	insertAppEvent(t, store, appID, "info", "deploy", midPrev.Add(2*time.Hour))
+	insertAppEvent(t, store, appID, "warn", "deploy", midPrev)
+	insertAppEvent(t, store, appID, "warn", "deploy", midPrev.Add(time.Hour))
+	insertAppEvent(t, store, appID, "info", "restart", midPrev)
+
+	// This event is in the current month and must NOT be counted.
+	insertAppEvent(t, store, appID, "info", "deploy", firstOfMonth.Add(time.Hour))
+
+	if err := jobs.RunMonthlyRollup(ctx, store); err != nil {
+		t.Fatalf("RunMonthlyRollup: %v", err)
+	}
+
+	year := firstOfPrev.Year()
+	month := int(firstOfPrev.Month())
+	rollups, err := store.Rollups.ListByPeriod(ctx, year, month)
+	if err != nil {
+		t.Fatalf("ListByPeriod: %v", err)
+	}
+
+	got := make(map[string]int)
+	for _, r := range rollups {
+		got[r.EventType+"/"+r.Severity] = r.Count
+	}
+
+	if got["deploy/info"] != 3 {
+		t.Errorf("deploy/info: want 3, got %d", got["deploy/info"])
+	}
+	if got["deploy/warn"] != 2 {
+		t.Errorf("deploy/warn: want 2, got %d", got["deploy/warn"])
+	}
+	if got["restart/info"] != 1 {
+		t.Errorf("restart/info: want 1, got %d", got["restart/info"])
+	}
+}
+
+func TestRunMonthlyRollup_Idempotent(t *testing.T) {
+	store, db := newTestStore(t)
+	ctx := context.Background()
+
+	appID := createApp(t, store)
+
+	now := time.Now().UTC()
+	firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	midPrev := firstOfMonth.AddDate(0, -1, 0).Add(15 * 24 * time.Hour)
+
+	insertAppEvent(t, store, appID, "info", "deploy", midPrev)
+
+	if err := jobs.RunMonthlyRollup(ctx, store); err != nil {
+		t.Fatalf("first RunMonthlyRollup: %v", err)
+	}
+	if err := jobs.RunMonthlyRollup(ctx, store); err != nil {
+		t.Fatalf("second RunMonthlyRollup: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM rollups").Scan(&count); err != nil {
+		t.Fatalf("count rollups: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 rollup row after idempotent runs, got %d", count)
+	}
+}
+
+func TestRunMonthlyRollup_NoApps_NoError(t *testing.T) {
+	store, _ := newTestStore(t)
+	if err := jobs.RunMonthlyRollup(context.Background(), store); err != nil {
+		t.Fatalf("RunMonthlyRollup with no apps: %v", err)
+	}
+}
+
+func TestRunMonthlyRollup_EventsOutsideWindowNotCounted(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	appID := createApp(t, store)
+
+	// Only an event in the current month — previous-month rollup must be empty.
+	now := time.Now().UTC()
+	firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	insertAppEvent(t, store, appID, "info", "deploy", firstOfMonth.Add(time.Hour))
+
+	if err := jobs.RunMonthlyRollup(ctx, store); err != nil {
+		t.Fatalf("RunMonthlyRollup: %v", err)
+	}
+
+	firstOfPrev := firstOfMonth.AddDate(0, -1, 0)
+	rollups, err := store.Rollups.ListByPeriod(ctx, firstOfPrev.Year(), int(firstOfPrev.Month()))
+	if err != nil {
+		t.Fatalf("ListByPeriod: %v", err)
+	}
+	if len(rollups) != 0 {
+		t.Errorf("expected 0 rollup rows for previous month, got %d", len(rollups))
+	}
+}
+
+// TestRollupRunsBeforeRetention verifies that running rollup before retention
+// preserves summary data even when the raw events are subsequently purged.
+func TestRollupRunsBeforeRetention(t *testing.T) {
+	store, db := newTestStore(t)
+	ctx := context.Background()
+
+	appID := createApp(t, store)
+
+	now := time.Now().UTC()
+	firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	firstOfPrev := firstOfMonth.AddDate(0, -1, 0)
+	midPrev := firstOfPrev.Add(15 * 24 * time.Hour)
+
+	// Only insert if mid-prev is outside the info retention window (>7d ago).
+	if now.Sub(midPrev) < 7*24*time.Hour {
+		t.Skip("mid-prev is within the info retention window; skipping boundary test")
+	}
+
+	insertAppEvent(t, store, appID, "info", "deploy", midPrev)
+
+	// Rollup first (production order), then retention.
+	if err := jobs.RunMonthlyRollup(ctx, store); err != nil {
+		t.Fatalf("RunMonthlyRollup: %v", err)
+	}
+	if err := jobs.RunEventRetention(ctx, store); err != nil {
+		t.Fatalf("RunEventRetention: %v", err)
+	}
+
+	// Raw event should be purged by the info retention window (7d).
+	var eventCount int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events WHERE app_id = ?", appID).Scan(&eventCount); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if eventCount != 0 {
+		t.Errorf("expected expired event to be purged, got %d remaining", eventCount)
+	}
+
+	// But the rollup must survive.
+	var rollupTotal int
+	if err := db.QueryRowContext(ctx,
+		"SELECT COALESCE(SUM(count), 0) FROM rollups WHERE app_id = ?", appID,
+	).Scan(&rollupTotal); err != nil {
+		t.Fatalf("sum rollups: %v", err)
+	}
+	if rollupTotal == 0 {
+		t.Error("rollup should have preserved event count before retention purge")
+	}
+}

--- a/internal/models/metric.go
+++ b/internal/models/metric.go
@@ -1,0 +1,12 @@
+package models
+
+import "time"
+
+// Metric holds per-app hourly event metrics for a specific period.
+type Metric struct {
+	AppID           string    `db:"app_id"`
+	Period          time.Time `db:"period"`
+	EventsPerHour   int       `db:"events_per_hour"`
+	AvgPayloadBytes int       `db:"avg_payload_bytes"`
+	PeakPerMinute   int       `db:"peak_per_minute"`
+}

--- a/internal/repo/events.go
+++ b/internal/repo/events.go
@@ -33,6 +33,20 @@ type CategoryFilter struct {
 	Until         time.Time // inclusive upper bound
 }
 
+// EventTypeCount is a grouped count row returned by GroupByTypeAndSeverity.
+type EventTypeCount struct {
+	EventType string `db:"event_type"`
+	Severity  string `db:"severity"`
+	Count     int    `db:"count"`
+}
+
+// EventMetrics holds per-app event statistics for a time window.
+type EventMetrics struct {
+	EventsPerHour   int
+	AvgPayloadBytes int
+	PeakPerMinute   int
+}
+
 // EventRepo defines read/write operations for the events table.
 type EventRepo interface {
 	// Create persists a new event.
@@ -48,6 +62,15 @@ type EventRepo interface {
 	SparklineBuckets(ctx context.Context, f CategoryFilter, startTime time.Time, bucketDur time.Duration) ([7]int, error)
 	// LatestPerApp returns the most recent event per app, keyed by app ID.
 	LatestPerApp(ctx context.Context, appIDs []string) (map[string]*models.Event, error)
+	// DeleteBySeverityBefore deletes events with the given severity older than
+	// before and returns the number of rows deleted.
+	DeleteBySeverityBefore(ctx context.Context, severity string, before time.Time) (int64, error)
+	// GroupByTypeAndSeverity returns event counts grouped by event_type (from
+	// the fields JSON column) and severity for a specific app and time range.
+	GroupByTypeAndSeverity(ctx context.Context, appID string, since, until time.Time) ([]EventTypeCount, error)
+	// MetricsForApp computes event count, average payload size, and peak
+	// per-minute rate for a single app over [since, until).
+	MetricsForApp(ctx context.Context, appID string, since, until time.Time) (EventMetrics, error)
 }
 
 type sqliteEventRepo struct {
@@ -228,6 +251,84 @@ func (r *sqliteEventRepo) SparklineBuckets(ctx context.Context, f CategoryFilter
 		counts[i] = n
 	}
 	return counts, nil
+}
+
+func (r *sqliteEventRepo) DeleteBySeverityBefore(ctx context.Context, severity string, before time.Time) (int64, error) {
+	res, err := r.db.ExecContext(ctx,
+		`DELETE FROM events WHERE severity = ? AND datetime(received_at) < datetime(?)`,
+		severity, before.UTC().Format(time.RFC3339))
+	if err != nil {
+		return 0, fmt.Errorf("delete events by severity: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+func (r *sqliteEventRepo) GroupByTypeAndSeverity(ctx context.Context, appID string, since, until time.Time) ([]EventTypeCount, error) {
+	var rows []EventTypeCount
+	err := r.db.SelectContext(ctx, &rows, `
+		SELECT
+			COALESCE(json_extract(fields, '$.event_type'), '') AS event_type,
+			severity,
+			COUNT(*) AS count
+		FROM events
+		WHERE app_id = ?
+		  AND datetime(received_at) >= datetime(?)
+		  AND datetime(received_at) < datetime(?)
+		GROUP BY event_type, severity`,
+		appID,
+		since.UTC().Format(time.RFC3339),
+		until.UTC().Format(time.RFC3339),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("group events by type and severity: %w", err)
+	}
+	if rows == nil {
+		rows = []EventTypeCount{}
+	}
+	return rows, nil
+}
+
+func (r *sqliteEventRepo) MetricsForApp(ctx context.Context, appID string, since, until time.Time) (EventMetrics, error) {
+	sinceStr := since.UTC().Format(time.RFC3339)
+	untilStr := until.UTC().Format(time.RFC3339)
+
+	var count int
+	var avgBytes float64
+	err := r.db.QueryRowContext(ctx, `
+		SELECT COUNT(*), COALESCE(AVG(LENGTH(raw_payload)), 0)
+		FROM events
+		WHERE app_id = ?
+		  AND datetime(received_at) >= datetime(?)
+		  AND datetime(received_at) < datetime(?)`,
+		appID, sinceStr, untilStr,
+	).Scan(&count, &avgBytes)
+	if err != nil {
+		return EventMetrics{}, fmt.Errorf("metrics count/avg: %w", err)
+	}
+
+	var peak int
+	err = r.db.QueryRowContext(ctx, `
+		SELECT COALESCE(MAX(cnt), 0)
+		FROM (
+			SELECT COUNT(*) AS cnt
+			FROM events
+			WHERE app_id = ?
+			  AND datetime(received_at) >= datetime(?)
+			  AND datetime(received_at) < datetime(?)
+			GROUP BY strftime('%Y-%m-%dT%H:%M', received_at)
+		)`,
+		appID, sinceStr, untilStr,
+	).Scan(&peak)
+	if err != nil {
+		return EventMetrics{}, fmt.Errorf("metrics peak: %w", err)
+	}
+
+	return EventMetrics{
+		EventsPerHour:   count,
+		AvgPayloadBytes: int(avgBytes),
+		PeakPerMinute:   peak,
+	}, nil
 }
 
 func (r *sqliteEventRepo) LatestPerApp(ctx context.Context, appIDs []string) (map[string]*models.Event, error) {

--- a/internal/repo/metrics.go
+++ b/internal/repo/metrics.go
@@ -1,0 +1,40 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/jmoiron/sqlx"
+)
+
+// MetricsRepo defines write operations for the metrics table.
+type MetricsRepo interface {
+	Upsert(ctx context.Context, m *models.Metric) error
+}
+
+type sqliteMetricsRepo struct {
+	db *sqlx.DB
+}
+
+// NewMetricsRepo returns a MetricsRepo backed by the given SQLite database.
+func NewMetricsRepo(db *sqlx.DB) MetricsRepo {
+	return &sqliteMetricsRepo{db: db}
+}
+
+func (r *sqliteMetricsRepo) Upsert(ctx context.Context, m *models.Metric) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT OR REPLACE INTO metrics (app_id, period, events_per_hour, avg_payload_bytes, peak_per_minute)
+		VALUES (?, ?, ?, ?, ?)`,
+		m.AppID,
+		m.Period.UTC().Format(time.RFC3339),
+		m.EventsPerHour,
+		m.AvgPayloadBytes,
+		m.PeakPerMinute,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert metric: %w", err)
+	}
+	return nil
+}

--- a/internal/repo/rollups.go
+++ b/internal/repo/rollups.go
@@ -8,9 +8,12 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// RollupRepo defines read operations for the rollups table.
+
+// RollupRepo defines read/write operations for the rollups table.
 type RollupRepo interface {
 	ListByPeriod(ctx context.Context, year, month int) ([]models.Rollup, error)
+	// Upsert inserts or replaces a rollup row. Safe to call multiple times.
+	Upsert(ctx context.Context, rollup *models.Rollup) error
 }
 
 type sqliteRollupRepo struct {
@@ -20,6 +23,17 @@ type sqliteRollupRepo struct {
 // NewRollupRepo returns a RollupRepo backed by the given SQLite database.
 func NewRollupRepo(db *sqlx.DB) RollupRepo {
 	return &sqliteRollupRepo{db: db}
+}
+
+func (r *sqliteRollupRepo) Upsert(ctx context.Context, rollup *models.Rollup) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT OR REPLACE INTO rollups (app_id, year, month, event_type, severity, count)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		rollup.AppID, rollup.Year, rollup.Month, rollup.EventType, rollup.Severity, rollup.Count)
+	if err != nil {
+		return fmt.Errorf("upsert rollup: %w", err)
+	}
+	return nil
 }
 
 func (r *sqliteRollupRepo) ListByPeriod(ctx context.Context, year, month int) ([]models.Rollup, error) {

--- a/internal/repo/store.go
+++ b/internal/repo/store.go
@@ -13,10 +13,11 @@ type Store struct {
 	DockerEngines   DockerEngineRepo
 	Infra           InfraRepo
 	Settings        SettingsRepo
+	Metrics         MetricsRepo
 }
 
 // NewStore creates a Store backed by the given repositories.
-func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRepo, resources ResourceReadingRepo, resourceRollups ResourceRollupRepo, physicalHosts PhysicalHostRepo, virtualHosts VirtualHostRepo, dockerEngines DockerEngineRepo, infra InfraRepo, settings SettingsRepo) *Store {
+func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRepo, resources ResourceReadingRepo, resourceRollups ResourceRollupRepo, physicalHosts PhysicalHostRepo, virtualHosts VirtualHostRepo, dockerEngines DockerEngineRepo, infra InfraRepo, settings SettingsRepo, metrics MetricsRepo) *Store {
 	return &Store{
 		Apps:            apps,
 		Events:          events,
@@ -29,5 +30,6 @@ func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRe
 		DockerEngines:   dockerEngines,
 		Infra:           infra,
 		Settings:        settings,
+		Metrics:         metrics,
 	}
 }


### PR DESCRIPTION
## What
Implements event lifecycle management: severity-based retention purge, monthly event rollup into summary counts, and hourly metrics collection.

## Why
Closes #25. Raw events accumulate indefinitely without a retention policy. Rolling up counts before purging ensures historical summary data is preserved even after raw events expire.

## How

**`internal/jobs/retention.go`** — `RunEventRetention` / `StartEventRetention`
- Purges events per severity: debug 24h, info 7d, warn 30d, error/critical 90d
- Starts at 02:00 UTC, then every 24h (using `durationUntilNext2AM`)
- Never touches rollup rows

**`internal/jobs/rollup.go`** — `RunMonthlyRollup` / `StartMonthlyRollup`
- Groups previous calendar month's events by `json_extract(fields, '$.event_type')` + severity
- Upserts into `rollups` table — safe to re-run (INSERT OR REPLACE)
- Fires daily at midnight, only does work on the 1st of the month
- Starts before `StartEventRetention` in main.go so data is always preserved first

**`internal/jobs/event_rollup.go`** — `RunMetricsCollection` / `StartMetricsCollection`
- Every hour: counts events, avg payload bytes, peak-per-minute per app
- Upserts into `metrics` table

**New repo surface**
- `EventRepo`: `DeleteBySeverityBefore`, `GroupByTypeAndSeverity`, `MetricsForApp`
- `RollupRepo`: `Upsert`
- `repo.MetricsRepo` (new) + `models.Metric` (new)
- `Store.Metrics MetricsRepo` field added; `NewStore` gains a 12th parameter — all callers updated

## Test coverage
- `retention_test.go`: boundary ages across all 5 severities; within-window kept; rollup rows never deleted; empty DB no-error
- `rollup_test.go`: counts by type+severity; current-month events excluded; idempotent; rollup-before-retention ordering

## Closes
Closes #25