### PR TITLE
feat: T-27 metrics API + users CRUD + settings screen expansion

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/digitalcheffe/nora/internal/api"
 	"github.com/digitalcheffe/nora/internal/apptemplate"
@@ -26,6 +27,7 @@ import (
 
 func main() {
 	cfg := config.Load()
+	startTime := time.Now()
 
 	db, err := repo.Open(cfg, migrations.Files)
 	if err != nil {
@@ -49,7 +51,8 @@ func main() {
 	infraRepo := repo.NewInfraRepo(db)
 	settingsRepo := repo.NewSettingsRepo(db)
 	metricsRepo := repo.NewMetricsRepo(db)
-	store := repo.NewStore(appRepo, eventRepo, checkRepo, rollupRepo, resourceRepo, resourceRollupRepo, physicalHostRepo, virtualHostRepo, dockerEngineRepo, infraRepo, settingsRepo, metricsRepo)
+	userRepo := repo.NewUserRepo(db)
+	store := repo.NewStore(appRepo, eventRepo, checkRepo, rollupRepo, resourceRepo, resourceRollupRepo, physicalHostRepo, virtualHostRepo, dockerEngineRepo, infraRepo, settingsRepo, metricsRepo, userRepo)
 
 	// App template registry — load all bundled YAML app templates
 	registry, err := apptemplate.NewRegistry(noraappprofiles.Files)
@@ -134,6 +137,8 @@ func main() {
 		api.NewInfraHandler(infraRepo, syncWorker).Routes(r)
 		api.NewDigestHandler(store, digestJob).Routes(r)
 		api.NewSettingsHandler(store).Routes(r)
+		api.NewMetricsHandler(eventRepo, appRepo, metricsRepo, cfg.DBPath, startTime).Routes(r)
+		api.NewUsersHandler(userRepo).Routes(r)
 	})
 
 	// Frontend — serve embedded React app, SPA fallback to index.html

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -20,6 +20,7 @@ import type {
   EventFilter,
   HostResources,
   InfraIntegration,
+  InstanceMetrics,
   ListResponse,
   LoginInput,
   MonitorCheck,
@@ -281,6 +282,9 @@ export const smtpSettings = {
 
   put: (s: SMTPSettings) =>
     request<SMTPSettings>('PUT', '/settings/smtp', s),
+
+  test: () =>
+    request<{ status: string; to: string }>('POST', '/settings/smtp/test'),
 }
 
 export const digestReport = {
@@ -292,5 +296,5 @@ export const digestReport = {
 
 export const metrics = {
   instance: () =>
-    request<unknown>('GET', '/metrics'),
+    request<InstanceMetrics>('GET', '/metrics'),
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -313,3 +313,23 @@ export interface AppMetric {
   avg_payload_bytes: number
   peak_per_minute: number
 }
+
+export interface TopAppItem {
+  app_id: string
+  app_name: string
+  events_per_hour: number
+}
+
+export interface AppEventItem {
+  app_id: string
+  app_name: string
+  count: number
+}
+
+export interface InstanceMetrics {
+  db_size_bytes: number
+  events_last_24h: number
+  uptime_seconds: number
+  top_apps: TopAppItem[]
+  app_events_24h: AppEventItem[]
+}

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -535,3 +535,34 @@
   margin-bottom: 16px;
 }
 
+
+/* ── Metrics table ───────────────────────────────────────────────────────── */
+
+.settings-metrics-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.settings-metrics-table th {
+  text-align: left;
+  color: var(--text2);
+  font-weight: 500;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.settings-metrics-table td {
+  padding: 7px 8px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text1);
+}
+
+.settings-metrics-table tr:last-child td {
+  border-bottom: none;
+}
+
+.settings-metrics-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2,17 +2,26 @@ import { useState, useEffect } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Topbar } from '../components/Topbar'
 import { InfraIntegrations } from './Integrations'
-import { appTemplates, digestSettings, digestReport, smtpSettings } from '../api/client'
-import type { AppTemplate, CustomProfile, DigestFrequency, DigestSchedule, SMTPSettings } from '../api/types'
+import { appTemplates, digestSettings, digestReport, smtpSettings, metrics, users } from '../api/client'
+import type {
+  AppTemplate,
+  CustomProfile,
+  DigestFrequency,
+  DigestSchedule,
+  InstanceMetrics,
+  SMTPSettings,
+  User,
+} from '../api/types'
 
 import './Settings.css'
 
-type Tab = 'apps' | 'notifications' | 'metrics'
+type Tab = 'apps' | 'notifications' | 'metrics' | 'users'
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'apps', label: 'Apps' },
   { id: 'notifications', label: 'Notifications' },
   { id: 'metrics', label: 'Instance Metrics' },
+  { id: 'users', label: 'Users' },
 ]
 
 // ── Delete confirmation modal ─────────────────────────────────────────────────
@@ -83,7 +92,6 @@ function AppsTab() {
   useEffect(() => {
     Promise.all([appTemplates.list(), appTemplates.listCustom()])
       .then(([bt, ct]) => {
-        // Sort built-ins by category then name
         const sorted = [...bt.data].sort((a, b) => a.name.localeCompare(b.name))
         setBuiltins(sorted)
         setCustoms(ct.data ?? [])
@@ -204,6 +212,8 @@ function NotificationsTab() {
   const [smtp, setSMTP] = useState<SMTPSettings>({ host: '', port: 587, user: '', pass: '', from: '' })
   const [smtpSaving, setSmtpSaving] = useState(false)
   const [smtpMsg, setSmtpMsg] = useState('')
+  const [smtpTesting, setSmtpTesting] = useState(false)
+  const [smtpTestMsg, setSmtpTestMsg] = useState('')
   const [smtpConfigured, setSmtpConfigured] = useState(false)
 
   // Digest schedule state
@@ -231,6 +241,19 @@ function NotificationsTab() {
       setSmtpMsg(e instanceof Error ? e.message : 'Save failed')
     } finally {
       setSmtpSaving(false)
+    }
+  }
+
+  const testSMTP = async () => {
+    setSmtpTesting(true)
+    setSmtpTestMsg('')
+    try {
+      const res = await smtpSettings.test()
+      setSmtpTestMsg(`Test email sent to ${res.to}`)
+    } catch (e: unknown) {
+      setSmtpTestMsg(e instanceof Error ? e.message : 'Test failed')
+    } finally {
+      setSmtpTesting(false)
     }
   }
 
@@ -320,7 +343,26 @@ function NotificationsTab() {
           <button className="settings-btn primary" onClick={saveSMTP} disabled={smtpSaving}>
             {smtpSaving ? 'Saving…' : 'Save'}
           </button>
+          <button
+            className="settings-btn secondary"
+            onClick={testSMTP}
+            disabled={smtpTesting || !smtpConfigured}
+            title={!smtpConfigured ? 'Configure and save SMTP first' : 'Send a test email to the configured from address'}
+          >
+            {smtpTesting ? 'Sending…' : 'Send test email'}
+          </button>
           {smtpMsg && <span className="settings-status-msg">{smtpMsg}</span>}
+          {smtpTestMsg && <span className="settings-status-msg">{smtpTestMsg}</span>}
+        </div>
+      </section>
+
+      {/* Web Push */}
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title">Web Push</span>
+        </div>
+        <div className="settings-placeholder" style={{ fontStyle: 'italic' }}>
+          Push notifications — coming soon
         </div>
       </section>
 
@@ -432,34 +474,53 @@ function NotificationsTab() {
 
 // ── Instance Metrics tab ──────────────────────────────────────────────────────
 
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function formatUptime(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  return `${h}h ${m}m`
+}
+
 function MetricsTab() {
+  const [data, setData] = useState<InstanceMetrics | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    setLoading(true)
+    metrics.instance()
+      .then(setData)
+      .catch(e => setError(e instanceof Error ? e.message : 'Failed to load metrics'))
+      .finally(() => setLoading(false))
+  }, [])
+
   return (
     <div className="tab-content">
       <section className="settings-section">
         <div className="section-header">
-          <span className="section-title">NORA Process</span>
+          <span className="section-title">Instance</span>
         </div>
-        <div className="settings-kv-grid">
-          <span className="settings-kv-key">Version</span><span className="settings-kv-val">v0.1.0</span>
-          <span className="settings-kv-key">Uptime</span><span className="settings-kv-val">—</span>
-          <span className="settings-kv-key">Go runtime</span><span className="settings-kv-val">go1.22</span>
-          <span className="settings-kv-key">Goroutines</span><span className="settings-kv-val">—</span>
-        </div>
-      </section>
-
-      <section className="settings-section">
-        <div className="section-header">
-          <span className="section-title">Database</span>
-        </div>
-        <div className="settings-kv-grid">
-          <span className="settings-kv-key">Engine</span><span className="settings-kv-val">SQLite</span>
-          <span className="settings-kv-key">File size</span><span className="settings-kv-val">—</span>
-          <span className="settings-kv-key">Last vacuum</span><span className="settings-kv-val">—</span>
-        </div>
-        <div className="settings-actions" style={{ marginTop: 12 }}>
-          <button className="settings-btn secondary">Run Vacuum</button>
-          <button className="settings-btn secondary">Export DB</button>
-        </div>
+        {loading ? (
+          <div className="settings-placeholder">Loading…</div>
+        ) : error ? (
+          <div className="settings-placeholder" style={{ color: 'var(--red)' }}>{error}</div>
+        ) : data ? (
+          <div className="settings-kv-grid">
+            <span className="settings-kv-key">DB size</span>
+            <span className="settings-kv-val">{formatBytes(data.db_size_bytes)}</span>
+            <span className="settings-kv-key">Events last 24h</span>
+            <span className="settings-kv-val">{data.events_last_24h.toLocaleString()}</span>
+            <span className="settings-kv-key">Uptime</span>
+            <span className="settings-kv-val">{formatUptime(data.uptime_seconds)}</span>
+          </div>
+        ) : null}
       </section>
 
       <section className="settings-section">
@@ -467,39 +528,185 @@ function MetricsTab() {
           <span className="section-title">Retention Policy</span>
         </div>
         <div className="settings-kv-grid">
-          <span className="settings-kv-key">Raw events</span><span className="settings-kv-val">7 days</span>
+          <span className="settings-kv-key">Debug events</span><span className="settings-kv-val">24 hours</span>
+          <span className="settings-kv-key">Info events</span><span className="settings-kv-val">7 days</span>
+          <span className="settings-kv-key">Warn events</span><span className="settings-kv-val">30 days</span>
+          <span className="settings-kv-key">Error / Critical</span><span className="settings-kv-val">90 days</span>
           <span className="settings-kv-key">Hourly rollups</span><span className="settings-kv-val">90 days</span>
           <span className="settings-kv-key">Daily rollups</span><span className="settings-kv-val">Forever</span>
-          <span className="settings-kv-key">Error events</span><span className="settings-kv-val">90 days</span>
         </div>
       </section>
 
       <section className="settings-section">
         <div className="section-header">
-          <span className="section-title">Resource Usage</span>
+          <span className="section-title">Events per App (last 24h)</span>
         </div>
-        <div className="settings-resource-bars">
-          <div className="settings-resource-row">
-            <span className="settings-resource-label">CPU</span>
-            <div className="settings-progress-track">
-              <div className="settings-progress-fill" style={{ width: '12%' }} />
-            </div>
-            <span className="settings-resource-pct">12%</span>
+        {loading ? (
+          <div className="settings-placeholder">Loading…</div>
+        ) : data && data.app_events_24h.length === 0 ? (
+          <div className="settings-placeholder">No events in the last 24 hours.</div>
+        ) : data ? (
+          <table className="settings-metrics-table">
+            <thead>
+              <tr>
+                <th>App</th>
+                <th className="settings-metrics-num">Events</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.app_events_24h.map(row => (
+                <tr key={row.app_id}>
+                  <td>{row.app_name}</td>
+                  <td className="settings-metrics-num">{row.count.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : null}
+      </section>
+    </div>
+  )
+}
+
+// ── Users tab ─────────────────────────────────────────────────────────────────
+
+function UsersTab() {
+  const [userList, setUserList] = useState<User[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  // Create form state
+  const [newEmail, setNewEmail] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [newRole, setNewRole] = useState<'admin' | 'member'>('member')
+  const [creating, setCreating] = useState(false)
+  const [createMsg, setCreateMsg] = useState('')
+
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  const load = () => {
+    setLoading(true)
+    users.list()
+      .then(res => setUserList(res.data ?? []))
+      .catch(e => setError(e instanceof Error ? e.message : 'Failed to load users'))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => { load() }, [])
+
+  const handleCreate = async () => {
+    if (!newEmail || !newPassword) {
+      setCreateMsg('Email and password are required.')
+      return
+    }
+    setCreating(true)
+    setCreateMsg('')
+    try {
+      await users.create({ email: newEmail, password: newPassword, role: newRole })
+      setNewEmail('')
+      setNewPassword('')
+      setNewRole('member')
+      setCreateMsg('User created.')
+      load()
+    } catch (e: unknown) {
+      setCreateMsg(e instanceof Error ? e.message : 'Create failed')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    setDeletingId(id)
+    try {
+      await users.delete(id)
+      setUserList(prev => prev.filter(u => u.id !== id))
+    } catch {
+      // ignore — keep list unchanged
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  return (
+    <div className="tab-content">
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title">Users</span>
+        </div>
+        {loading ? (
+          <div className="settings-placeholder">Loading…</div>
+        ) : error ? (
+          <div className="settings-placeholder" style={{ color: 'var(--red)' }}>{error}</div>
+        ) : userList.length === 0 ? (
+          <div className="settings-placeholder">No users yet.</div>
+        ) : (
+          <div className="apps-list">
+            {userList.map(u => (
+              <div key={u.id} className="app-row">
+                <div>
+                  <span className="app-row-name">{u.email}</span>
+                  <span className="app-pill-type" style={{ marginLeft: 8 }}>{u.role}</span>
+                </div>
+                <div className="app-row-actions">
+                  <span className="settings-kv-val" style={{ fontSize: '0.8em', marginRight: 8 }}>
+                    {new Date(u.created_at).toLocaleDateString()}
+                  </span>
+                  <button
+                    className="settings-btn danger settings-btn--sm"
+                    onClick={() => handleDelete(u.id)}
+                    disabled={deletingId === u.id}
+                  >
+                    {deletingId === u.id ? '…' : 'Remove'}
+                  </button>
+                </div>
+              </div>
+            ))}
           </div>
-          <div className="settings-resource-row">
-            <span className="settings-resource-label">MEM</span>
-            <div className="settings-progress-track">
-              <div className="settings-progress-fill" style={{ width: '34%' }} />
-            </div>
-            <span className="settings-resource-pct">34%</span>
+        )}
+      </section>
+
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title">Invite User</span>
+        </div>
+        <div className="settings-field-row">
+          <label className="settings-label">Email</label>
+          <input
+            className="settings-input"
+            placeholder="user@example.com"
+            value={newEmail}
+            onChange={e => setNewEmail(e.target.value)}
+          />
+        </div>
+        <div className="settings-field-row">
+          <label className="settings-label">Password</label>
+          <input
+            className="settings-input"
+            type="password"
+            placeholder="Initial password"
+            value={newPassword}
+            onChange={e => setNewPassword(e.target.value)}
+          />
+        </div>
+        <div className="settings-field-row">
+          <label className="settings-label">Role</label>
+          <div className="settings-segmented">
+            {(['member', 'admin'] as const).map(r => (
+              <button
+                key={r}
+                className={`settings-seg-btn${newRole === r ? ' active' : ''}`}
+                onClick={() => setNewRole(r)}
+              >
+                {r.charAt(0).toUpperCase() + r.slice(1)}
+              </button>
+            ))}
           </div>
-          <div className="settings-resource-row">
-            <span className="settings-resource-label">DISK</span>
-            <div className="settings-progress-track">
-              <div className="settings-progress-fill" style={{ width: '8%' }} />
-            </div>
-            <span className="settings-resource-pct">8%</span>
-          </div>
+        </div>
+        <div className="settings-actions">
+          <button className="settings-btn primary" onClick={handleCreate} disabled={creating}>
+            {creating ? 'Creating…' : 'Add User'}
+          </button>
+          {createMsg && <span className="settings-status-msg">{createMsg}</span>}
         </div>
       </section>
     </div>
@@ -530,6 +737,7 @@ export function Settings() {
         {activeTab === 'apps' && <AppsTab />}
         {activeTab === 'notifications' && <NotificationsTab />}
         {activeTab === 'metrics' && <MetricsTab />}
+        {activeTab === 'users' && <UsersTab />}
       </div>
     </>
   )

--- a/internal/api/digest_test.go
+++ b/internal/api/digest_test.go
@@ -31,6 +31,7 @@ func newDigestRouter(t *testing.T) (http.Handler, *repo.Store) {
 		repo.NewInfraRepo(db),
 		repo.NewSettingsRepo(db),
 		nil,
+		nil,
 	)
 	digestJob := jobs.NewDigestJob(store, &config.Config{})
 	h := api.NewDigestHandler(store, digestJob)
@@ -62,6 +63,7 @@ func newDigestRouterWithSMTP(t *testing.T) (http.Handler, *repo.Store) {
 		repo.NewDockerEngineRepo(db),
 		repo.NewInfraRepo(db),
 		repo.NewSettingsRepo(db),
+		nil,
 		nil,
 	)
 	digestJob2 := jobs.NewDigestJob(store2, cfg)

--- a/internal/api/ingest_test.go
+++ b/internal/api/ingest_test.go
@@ -21,7 +21,7 @@ func newIngestRouter(t *testing.T) (http.Handler, *repo.Store) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 	profiler := &apptemplate.NoopLoader{}
 
@@ -44,7 +44,7 @@ func TestHandleIngest_HappyPath(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()
@@ -131,7 +131,7 @@ func TestHandleIngest_RateLimit(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+)
+
+// MetricsHandler serves instance-wide and per-app metrics.
+type MetricsHandler struct {
+	events  repo.EventRepo
+	apps    repo.AppRepo
+	metrics repo.MetricsRepo
+	dbPath  string
+	started time.Time
+}
+
+// NewMetricsHandler creates a MetricsHandler.
+func NewMetricsHandler(events repo.EventRepo, apps repo.AppRepo, metrics repo.MetricsRepo, dbPath string, started time.Time) *MetricsHandler {
+	return &MetricsHandler{
+		events:  events,
+		apps:    apps,
+		metrics: metrics,
+		dbPath:  dbPath,
+		started: started,
+	}
+}
+
+// Routes registers metrics endpoints on r.
+func (h *MetricsHandler) Routes(r chi.Router) {
+	r.Get("/metrics", h.GetInstance)
+	r.Get("/apps/{id}/metrics", h.GetByApp)
+}
+
+// --- response types ---
+
+type topAppItem struct {
+	AppID         string `json:"app_id"`
+	AppName       string `json:"app_name"`
+	EventsPerHour int    `json:"events_per_hour"`
+}
+
+type appEventItem struct {
+	AppID   string `json:"app_id"`
+	AppName string `json:"app_name"`
+	Count   int    `json:"count"`
+}
+
+type instanceMetricsResponse struct {
+	DBSizeBytes   int64          `json:"db_size_bytes"`
+	EventsLast24h int            `json:"events_last_24h"`
+	UptimeSeconds int64          `json:"uptime_seconds"`
+	TopApps       []topAppItem   `json:"top_apps"`
+	AppEvents24h  []appEventItem `json:"app_events_24h"`
+}
+
+// GetInstance returns instance-wide metrics: GET /api/v1/metrics
+func (h *MetricsHandler) GetInstance(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// DB file size
+	var dbSize int64
+	if info, err := os.Stat(h.dbPath); err == nil {
+		dbSize = info.Size()
+	}
+
+	// Total events in last 24 hours
+	since24h := time.Now().Add(-24 * time.Hour)
+	perApp, err := h.events.CountPerApp(ctx, since24h)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var total24h int
+	appEvents := make([]appEventItem, 0, len(perApp))
+	for _, row := range perApp {
+		total24h += row.Count
+		appEvents = append(appEvents, appEventItem{
+			AppID:   row.AppID,
+			AppName: row.AppName,
+			Count:   row.Count,
+		})
+	}
+
+	// Top apps by most-recent hourly rate
+	tops, err := h.metrics.TopApps(ctx, 10)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	topItems := make([]topAppItem, 0, len(tops))
+	for _, t := range tops {
+		topItems = append(topItems, topAppItem{
+			AppID:         t.AppID,
+			AppName:       t.AppName,
+			EventsPerHour: t.EventsPerHour,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, instanceMetricsResponse{
+		DBSizeBytes:   dbSize,
+		EventsLast24h: total24h,
+		UptimeSeconds: int64(time.Since(h.started).Seconds()),
+		TopApps:       topItems,
+		AppEvents24h:  appEvents,
+	})
+}
+
+// appMetricItem is the per-app metric trend point returned by GetByApp.
+type appMetricItem struct {
+	AppID           string `json:"app_id"`
+	Period          string `json:"period"`
+	EventsPerHour   int    `json:"events_per_hour"`
+	AvgPayloadBytes int    `json:"avg_payload_bytes"`
+	PeakPerMinute   int    `json:"peak_per_minute"`
+}
+
+// GetByApp returns per-app metrics trend (last 24 points): GET /api/v1/apps/{id}/metrics
+func (h *MetricsHandler) GetByApp(w http.ResponseWriter, r *http.Request) {
+	appID := chi.URLParam(r, "id")
+	ctx := r.Context()
+
+	// Verify app exists.
+	if _, err := h.apps.Get(ctx, appID); err != nil {
+		writeError(w, http.StatusNotFound, "app not found")
+		return
+	}
+
+	rows, err := h.metrics.ListByApp(ctx, appID, 24)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	items := make([]appMetricItem, 0, len(rows))
+	for _, m := range rows {
+		items = append(items, appMetricItem{
+			AppID:           m.AppID,
+			Period:          m.Period.UTC().Format(time.RFC3339),
+			EventsPerHour:   m.EventsPerHour,
+			AvgPayloadBytes: m.AvgPayloadBytes,
+			PeakPerMinute:   m.PeakPerMinute,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, struct {
+		Data  []appMetricItem `json:"data"`
+		Total int             `json:"total"`
+	}{Data: items, Total: len(items)})
+}

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -1,0 +1,132 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/api"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+)
+
+func newMetricsRouter(t *testing.T) http.Handler {
+	t.Helper()
+	db := newTestDB(t)
+	eventRepo := repo.NewEventRepo(db)
+	appRepo := repo.NewAppRepo(db)
+	metricsRepo := repo.NewMetricsRepo(db)
+	h := api.NewMetricsHandler(eventRepo, appRepo, metricsRepo, ":memory:", time.Now())
+	r := chi.NewRouter()
+	h.Routes(r)
+	return r
+}
+
+// --- GET /metrics (instance-wide) ---
+
+func TestGetInstanceMetrics_Empty(t *testing.T) {
+	router := newMetricsRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		DBSizeBytes   int64 `json:"db_size_bytes"`
+		EventsLast24h int   `json:"events_last_24h"`
+		UptimeSeconds int64 `json:"uptime_seconds"`
+		TopApps       []any `json:"top_apps"`
+		AppEvents24h  []any `json:"app_events_24h"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.EventsLast24h != 0 {
+		t.Errorf("expected events_last_24h=0 got %d", resp.EventsLast24h)
+	}
+	if resp.TopApps == nil {
+		t.Error("expected top_apps to be a non-nil slice")
+	}
+	if resp.AppEvents24h == nil {
+		t.Error("expected app_events_24h to be a non-nil slice")
+	}
+}
+
+func TestGetInstanceMetrics_HasFields(t *testing.T) {
+	router := newMetricsRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+
+	var resp map[string]json.RawMessage
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, field := range []string{"db_size_bytes", "events_last_24h", "uptime_seconds", "top_apps", "app_events_24h"} {
+		if _, ok := resp[field]; !ok {
+			t.Errorf("missing field %q in response", field)
+		}
+	}
+}
+
+// --- GET /apps/{id}/metrics ---
+
+func TestGetAppMetrics_NotFound(t *testing.T) {
+	router := newMetricsRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/apps/does-not-exist/metrics", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}
+
+
+func TestGetAppMetrics_EmptyTrend(t *testing.T) {
+	// Create app via the apps handler, then call metrics on the same DB.
+	db := newTestDB(t)
+	appRepo := repo.NewAppRepo(db)
+	eventRepo := repo.NewEventRepo(db)
+	metricsRepo := repo.NewMetricsRepo(db)
+
+	appsHandler := api.NewAppsHandler(appRepo)
+	metricsHandler := api.NewMetricsHandler(eventRepo, appRepo, metricsRepo, ":memory:", time.Now())
+
+	r := chi.NewRouter()
+	appsHandler.Routes(r)
+	metricsHandler.Routes(r)
+
+	app := createApp(t, r, "MetricsApp")
+
+	req := httptest.NewRequest(http.MethodGet, "/apps/"+app.ID+"/metrics", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Data  []any `json:"data"`
+		Total int   `json:"total"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 0 {
+		t.Errorf("expected total=0 got %d", resp.Total)
+	}
+	if resp.Data == nil {
+		t.Error("expected data to be a non-nil slice")
+	}
+}

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/digitalcheffe/nora/internal/jobs"
 	"github.com/digitalcheffe/nora/internal/models"
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/go-chi/chi/v5"
@@ -26,6 +27,7 @@ func NewSettingsHandler(store *repo.Store) *SettingsHandler {
 func (h *SettingsHandler) Routes(r chi.Router) {
 	r.Get("/settings/smtp", h.GetSMTP)
 	r.Put("/settings/smtp", h.PutSMTP)
+	r.Post("/settings/smtp/test", h.TestSMTP)
 }
 
 // GetSMTP returns the stored SMTP config: GET /api/v1/settings/smtp
@@ -71,4 +73,36 @@ func (h *SettingsHandler) PutSMTP(w http.ResponseWriter, r *http.Request) {
 		resp.Pass = "••••••••"
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// TestSMTP sends a test email using the stored SMTP config: POST /api/v1/settings/smtp/test
+func (h *SettingsHandler) TestSMTP(w http.ResponseWriter, r *http.Request) {
+	var s models.SMTPSettings
+	err := h.store.Settings.GetJSON(r.Context(), smtpSettingsAPIKey, &s)
+	if errors.Is(err, repo.ErrNotFound) || s.Host == "" {
+		writeError(w, http.StatusBadRequest, "SMTP is not configured")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	to := s.From
+	if to == "" {
+		writeError(w, http.StatusBadRequest, "SMTP 'from' address is not configured")
+		return
+	}
+
+	if err := jobs.SendMail(
+		s.Host, s.Port, s.User, s.Pass, s.From,
+		[]string{to},
+		"NORA SMTP Test",
+		"<p>This is a test email from NORA. If you received this, your SMTP configuration is working correctly.</p>",
+	); err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "sent", "to": to})
 }

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// UsersHandler serves user management endpoints.
+type UsersHandler struct {
+	users repo.UserRepo
+}
+
+// NewUsersHandler creates a UsersHandler.
+func NewUsersHandler(users repo.UserRepo) *UsersHandler {
+	return &UsersHandler{users: users}
+}
+
+// Routes registers user endpoints on r.
+func (h *UsersHandler) Routes(r chi.Router) {
+	r.Get("/users", h.List)
+	r.Post("/users", h.Create)
+	r.Delete("/users/{id}", h.Delete)
+}
+
+// --- request / response types ---
+
+type createUserRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+	Role     string `json:"role"`
+}
+
+type listUsersResponse struct {
+	Data  []models.User `json:"data"`
+	Total int           `json:"total"`
+}
+
+// --- handlers ---
+
+// List returns all users: GET /api/v1/users
+func (h *UsersHandler) List(w http.ResponseWriter, r *http.Request) {
+	users, err := h.users.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, listUsersResponse{Data: users, Total: len(users)})
+}
+
+// Create adds a new user: POST /api/v1/users
+func (h *UsersHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var req createUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Email == "" {
+		writeError(w, http.StatusBadRequest, "email is required")
+		return
+	}
+	if req.Password == "" {
+		writeError(w, http.StatusBadRequest, "password is required")
+		return
+	}
+	role := req.Role
+	if role == "" {
+		role = "member"
+	}
+	if role != "admin" && role != "member" {
+		writeError(w, http.StatusBadRequest, "role must be admin or member")
+		return
+	}
+
+	u := &models.User{
+		ID:    uuid.NewString(),
+		Email: req.Email,
+		Role:  role,
+	}
+	// NOTE: SHA-256 is used as a placeholder until T-10 implements full auth with bcrypt.
+	hash := sha256.Sum256([]byte(req.Password))
+	passwordHash := fmt.Sprintf("%x", hash)
+
+	if err := h.users.Create(r.Context(), u, passwordHash); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Fetch the created user to get the DB-populated created_at.
+	created, err := h.users.GetByID(r.Context(), u.ID)
+	if err != nil {
+		writeJSON(w, http.StatusCreated, u)
+		return
+	}
+	writeJSON(w, http.StatusCreated, created)
+}
+
+// Delete removes a user: DELETE /api/v1/users/{id}
+func (h *UsersHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	err := h.users.Delete(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "user not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/users_test.go
+++ b/internal/api/users_test.go
@@ -1,0 +1,159 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/digitalcheffe/nora/internal/api"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+)
+
+func newUsersRouter(t *testing.T) http.Handler {
+	t.Helper()
+	db := newTestDB(t)
+	userRepo := repo.NewUserRepo(db)
+	h := api.NewUsersHandler(userRepo)
+	r := chi.NewRouter()
+	h.Routes(r)
+	return r
+}
+
+func createUser(t *testing.T, router http.Handler, email, password, role string) models.User {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{"email": email, "password": password, "role": role})
+	req := httptest.NewRequest(http.MethodPost, "/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("createUser: expected 201 got %d: %s", rr.Code, rr.Body.String())
+	}
+	var u models.User
+	if err := json.NewDecoder(rr.Body).Decode(&u); err != nil {
+		t.Fatalf("createUser decode: %v", err)
+	}
+	return u
+}
+
+// --- List ---
+
+func TestListUsers_Empty(t *testing.T) {
+	router := newUsersRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", rr.Code)
+	}
+	var resp struct {
+		Data  []models.User `json:"data"`
+		Total int           `json:"total"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.Total != 0 {
+		t.Errorf("expected total=0 got %d", resp.Total)
+	}
+}
+
+func TestListUsers_ReturnsAll(t *testing.T) {
+	router := newUsersRouter(t)
+	createUser(t, router, "alice@example.com", "pw1", "admin")
+	createUser(t, router, "bob@example.com", "pw2", "member")
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	var resp struct {
+		Data  []models.User `json:"data"`
+		Total int           `json:"total"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.Total != 2 {
+		t.Errorf("expected total=2 got %d", resp.Total)
+	}
+}
+
+// --- Create ---
+
+func TestCreateUser_HappyPath(t *testing.T) {
+	router := newUsersRouter(t)
+	u := createUser(t, router, "test@example.com", "secret", "member")
+
+	if u.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if u.Email != "test@example.com" {
+		t.Errorf("expected email got %q", u.Email)
+	}
+	if u.Role != "member" {
+		t.Errorf("expected role=member got %q", u.Role)
+	}
+}
+
+func TestCreateUser_MissingEmail(t *testing.T) {
+	router := newUsersRouter(t)
+	body := bytes.NewBufferString(`{"password":"pw"}`)
+	req := httptest.NewRequest(http.MethodPost, "/users", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+func TestCreateUser_MissingPassword(t *testing.T) {
+	router := newUsersRouter(t)
+	body := bytes.NewBufferString(`{"email":"a@b.com"}`)
+	req := httptest.NewRequest(http.MethodPost, "/users", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+func TestCreateUser_InvalidRole(t *testing.T) {
+	router := newUsersRouter(t)
+	body := bytes.NewBufferString(`{"email":"a@b.com","password":"pw","role":"superuser"}`)
+	req := httptest.NewRequest(http.MethodPost, "/users", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 got %d", rr.Code)
+	}
+}
+
+// --- Delete ---
+
+func TestDeleteUser_HappyPath(t *testing.T) {
+	router := newUsersRouter(t)
+	u := createUser(t, router, "del@example.com", "pw", "member")
+
+	req := httptest.NewRequest(http.MethodDelete, "/users/"+u.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("expected 204 got %d", rr.Code)
+	}
+}
+
+func TestDeleteUser_NotFound(t *testing.T) {
+	router := newUsersRouter(t)
+	req := httptest.NewRequest(http.MethodDelete, "/users/does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 got %d", rr.Code)
+	}
+}

--- a/internal/docker/resources_test.go
+++ b/internal/docker/resources_test.go
@@ -49,7 +49,7 @@ func (r *mockResourceReadingRepo) Create(_ context.Context, reading *models.Reso
 // --- helpers --------------------------------------------------------------
 
 func newTestResourcePoller(appRepo repo.AppRepo, eventRepo repo.EventRepo, resRepo repo.ResourceReadingRepo, cli resourcePollerAPI) *ResourcePoller {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo, nil, nil, nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo, nil, nil, nil, nil, nil, nil, nil, nil)
 	return newResourcePollerWithClient(store, cli)
 }
 

--- a/internal/docker/watcher_test.go
+++ b/internal/docker/watcher_test.go
@@ -83,11 +83,14 @@ func (r *mockEventRepo) GroupByTypeAndSeverity(_ context.Context, _ string, _, _
 func (r *mockEventRepo) MetricsForApp(_ context.Context, _ string, _, _ time.Time) (repo.EventMetrics, error) {
 	return repo.EventMetrics{}, nil
 }
+func (r *mockEventRepo) CountPerApp(_ context.Context, _ time.Time) ([]repo.AppEventCount, error) {
+	return nil, nil
+}
 
 // --- helpers -------------------------------------------------------------
 
 func newTestWatcher(appRepo repo.AppRepo, eventRepo repo.EventRepo, dc dockerAPI) *Watcher {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	return &Watcher{store: store, client: dc}
 }
 

--- a/internal/ingest/pipeline_test.go
+++ b/internal/ingest/pipeline_test.go
@@ -24,7 +24,7 @@ func newTestStore(t *testing.T) *repo.Store {
 	t.Cleanup(func() { db.Close() })
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil)
+	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func seedApp(t *testing.T, store *repo.Store, token string, rateLimit int) models.App {

--- a/internal/jobs/resource_rollup_test.go
+++ b/internal/jobs/resource_rollup_test.go
@@ -31,7 +31,7 @@ func newTestStore(t *testing.T) (*repo.Store, *sqlx.DB) {
 		repo.NewRollupRepo(db),
 		repo.NewResourceReadingRepo(db),
 		repo.NewResourceRollupRepo(db),
-		nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil,
 	)
 	return store, db
 }

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+// User represents an authenticated NORA user (no password hash — never expose it via API).
+type User struct {
+	ID        string    `db:"id"         json:"id"`
+	Email     string    `db:"email"      json:"email"`
+	Role      string    `db:"role"       json:"role"`
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
+}

--- a/internal/repo/events.go
+++ b/internal/repo/events.go
@@ -47,6 +47,13 @@ type EventMetrics struct {
 	PeakPerMinute   int
 }
 
+// AppEventCount is a per-app event count row returned by CountPerApp.
+type AppEventCount struct {
+	AppID   string `db:"app_id"`
+	AppName string `db:"app_name"`
+	Count   int    `db:"count"`
+}
+
 // EventRepo defines read/write operations for the events table.
 type EventRepo interface {
 	// Create persists a new event.
@@ -71,6 +78,9 @@ type EventRepo interface {
 	// MetricsForApp computes event count, average payload size, and peak
 	// per-minute rate for a single app over [since, until).
 	MetricsForApp(ctx context.Context, appID string, since, until time.Time) (EventMetrics, error)
+	// CountPerApp returns the event count grouped by app for the window [since, now].
+	// Results are ordered by count descending.
+	CountPerApp(ctx context.Context, since time.Time) ([]AppEventCount, error)
 }
 
 type sqliteEventRepo struct {
@@ -362,4 +372,25 @@ func (r *sqliteEventRepo) LatestPerApp(ctx context.Context, appIDs []string) (ma
 		result[events[i].AppID] = &events[i]
 	}
 	return result, nil
+}
+
+func (r *sqliteEventRepo) CountPerApp(ctx context.Context, since time.Time) ([]AppEventCount, error) {
+	var rows []AppEventCount
+	err := r.db.SelectContext(ctx, &rows, `
+		SELECT e.app_id, COALESCE(a.name, e.app_id) AS app_name, COUNT(*) AS count
+		FROM events e
+		LEFT JOIN apps a ON a.id = e.app_id
+		WHERE e.app_id IS NOT NULL
+		  AND datetime(e.received_at) >= datetime(?)
+		GROUP BY e.app_id
+		ORDER BY count DESC`,
+		since.UTC().Format(time.RFC3339),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("count per app: %w", err)
+	}
+	if rows == nil {
+		rows = []AppEventCount{}
+	}
+	return rows, nil
 }

--- a/internal/repo/metrics.go
+++ b/internal/repo/metrics.go
@@ -9,9 +9,21 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// MetricsRepo defines write operations for the metrics table.
+// AppTopEntry is a per-app summary row used in instance-wide metrics.
+type AppTopEntry struct {
+	AppID         string `db:"app_id"`
+	AppName       string `db:"app_name"`
+	EventsPerHour int    `db:"events_per_hour"`
+}
+
+// MetricsRepo defines write and read operations for the metrics table.
 type MetricsRepo interface {
 	Upsert(ctx context.Context, m *models.Metric) error
+	// ListByApp returns the most recent `limit` metric records for the given app,
+	// ordered newest-first.
+	ListByApp(ctx context.Context, appID string, limit int) ([]models.Metric, error)
+	// TopApps returns the top `limit` apps by most-recent events_per_hour.
+	TopApps(ctx context.Context, limit int) ([]AppTopEntry, error)
 }
 
 type sqliteMetricsRepo struct {
@@ -37,4 +49,51 @@ func (r *sqliteMetricsRepo) Upsert(ctx context.Context, m *models.Metric) error 
 		return fmt.Errorf("upsert metric: %w", err)
 	}
 	return nil
+}
+
+func (r *sqliteMetricsRepo) ListByApp(ctx context.Context, appID string, limit int) ([]models.Metric, error) {
+	if limit <= 0 {
+		limit = 24
+	}
+	var rows []models.Metric
+	err := r.db.SelectContext(ctx, &rows, `
+		SELECT app_id, period, events_per_hour, avg_payload_bytes, peak_per_minute
+		FROM metrics
+		WHERE app_id = ?
+		ORDER BY period DESC
+		LIMIT ?`,
+		appID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list metrics by app: %w", err)
+	}
+	if rows == nil {
+		rows = []models.Metric{}
+	}
+	return rows, nil
+}
+
+func (r *sqliteMetricsRepo) TopApps(ctx context.Context, limit int) ([]AppTopEntry, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	var rows []AppTopEntry
+	err := r.db.SelectContext(ctx, &rows, `
+		SELECT m.app_id, COALESCE(a.name, m.app_id) AS app_name, m.events_per_hour
+		FROM metrics m
+		JOIN apps a ON a.id = m.app_id
+		WHERE m.period = (
+			SELECT MAX(m2.period) FROM metrics m2 WHERE m2.app_id = m.app_id
+		)
+		ORDER BY m.events_per_hour DESC
+		LIMIT ?`,
+		limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("top apps: %w", err)
+	}
+	if rows == nil {
+		rows = []AppTopEntry{}
+	}
+	return rows, nil
 }

--- a/internal/repo/store.go
+++ b/internal/repo/store.go
@@ -14,10 +14,11 @@ type Store struct {
 	Infra           InfraRepo
 	Settings        SettingsRepo
 	Metrics         MetricsRepo
+	Users           UserRepo
 }
 
 // NewStore creates a Store backed by the given repositories.
-func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRepo, resources ResourceReadingRepo, resourceRollups ResourceRollupRepo, physicalHosts PhysicalHostRepo, virtualHosts VirtualHostRepo, dockerEngines DockerEngineRepo, infra InfraRepo, settings SettingsRepo, metrics MetricsRepo) *Store {
+func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRepo, resources ResourceReadingRepo, resourceRollups ResourceRollupRepo, physicalHosts PhysicalHostRepo, virtualHosts VirtualHostRepo, dockerEngines DockerEngineRepo, infra InfraRepo, settings SettingsRepo, metrics MetricsRepo, users UserRepo) *Store {
 	return &Store{
 		Apps:            apps,
 		Events:          events,
@@ -31,5 +32,6 @@ func NewStore(apps AppRepo, events EventRepo, checks CheckRepo, rollups RollupRe
 		Infra:           infra,
 		Settings:        settings,
 		Metrics:         metrics,
+		Users:           users,
 	}
 }

--- a/internal/repo/users.go
+++ b/internal/repo/users.go
@@ -1,0 +1,79 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/jmoiron/sqlx"
+)
+
+// UserRepo defines read/write operations for the users table.
+type UserRepo interface {
+	List(ctx context.Context) ([]models.User, error)
+	// Create inserts a new user. passwordHash must be a pre-hashed value.
+	Create(ctx context.Context, u *models.User, passwordHash string) error
+	Delete(ctx context.Context, id string) error
+	GetByID(ctx context.Context, id string) (*models.User, error)
+}
+
+type sqliteUserRepo struct {
+	db *sqlx.DB
+}
+
+// NewUserRepo returns a UserRepo backed by the given SQLite database.
+func NewUserRepo(db *sqlx.DB) UserRepo {
+	return &sqliteUserRepo{db: db}
+}
+
+func (r *sqliteUserRepo) List(ctx context.Context) ([]models.User, error) {
+	var users []models.User
+	err := r.db.SelectContext(ctx, &users, `
+		SELECT id, email, role, created_at
+		FROM users ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("list users: %w", err)
+	}
+	if users == nil {
+		users = []models.User{}
+	}
+	return users, nil
+}
+
+func (r *sqliteUserRepo) Create(ctx context.Context, u *models.User, passwordHash string) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO users (id, email, password_hash, role)
+		VALUES (?, ?, ?, ?)`,
+		u.ID, u.Email, passwordHash, u.Role)
+	if err != nil {
+		return fmt.Errorf("create user: %w", err)
+	}
+	return nil
+}
+
+func (r *sqliteUserRepo) Delete(ctx context.Context, id string) error {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM users WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete user: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sqliteUserRepo) GetByID(ctx context.Context, id string) (*models.User, error) {
+	var u models.User
+	err := r.db.GetContext(ctx, &u, `
+		SELECT id, email, role, created_at FROM users WHERE id = ?`, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get user: %w", err)
+	}
+	return &u, nil
+}


### PR DESCRIPTION
## What
Implements T-27: metrics collection API, user management, SMTP test endpoint, and a significantly expanded Settings screen.

## Why
Closes #27. Provides instance observability (DB size, event throughput per app) and basic user management so admins can invite/remove users from the UI.

## How

**Backend:**
- `GET /api/v1/metrics` — instance-wide: DB size, events last 24h, uptime, top apps by hourly rate, per-app 24h event table
- `GET /api/v1/apps/{id}/metrics` — per-app trend (last 24 hourly records)
- `GET/POST/DELETE /api/v1/users` — list, create (SHA-256 hashed password as T-10 placeholder), delete users
- `POST /api/v1/settings/smtp/test` — fires a test email to the configured `from` address
- Extended `MetricsRepo` with `ListByApp` + `TopApps` query methods
- Added `CountPerApp` to `EventRepo` for per-app 24h event counts
- New `UserRepo` + `models.User` (no password hash in API responses)

**Frontend:**
- Settings → **Users tab**: list all users (email, role, created), invite new user form, remove button
- Settings → **Notifications tab**: added SMTP "Send test email" button + Web Push stub section
- Settings → **Instance Metrics tab**: fetches real data from `/api/v1/metrics` — DB size, uptime, events last 24h, per-app events table

## Test coverage
- `go test ./...` — all packages pass
- `TestGetInstanceMetrics_*` — happy path + field presence
- `TestGetAppMetrics_*` — not found + empty trend
- `TestListUsers_*`, `TestCreateUser_*`, `TestDeleteUser_*` — full CRUD coverage
- `npm run build` — zero TypeScript errors

## Closes
Closes #27