### PR TITLE
feat: active checks page redesign + self-signed cert support + check history

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -178,6 +178,9 @@ export const checks = {
 
   run: (id: string) =>
     request<MonitorCheck>('POST', `/checks/${id}/run`),
+
+  listEvents: (id: string) =>
+    request<ListResponse<Event>>('GET', `/checks/${id}/events`),
 }
 
 // ── Topology ──────────────────────────────────────────────────────────────────

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -101,7 +101,7 @@ export interface TimeseriesFilter {
 // ── Monitor Checks ──────────────────────────────────────────────────────────
 
 export type CheckType = 'ping' | 'url' | 'ssl'
-export type CheckStatus = 'up' | 'warn' | 'down'
+export type CheckStatus = 'up' | 'warn' | 'down' | 'critical'
 export type SSLSource = 'traefik' | 'standalone'
 
 export interface MonitorCheck {
@@ -116,6 +116,7 @@ export interface MonitorCheck {
   ssl_crit_days: number
   ssl_source: SSLSource | null
   integration_id: string | null
+  skip_tls_verify: boolean
   enabled: boolean
   last_checked_at: string | null
   last_status: CheckStatus | null
@@ -134,6 +135,7 @@ export interface CreateCheckInput {
   ssl_crit_days?: number
   ssl_source?: SSLSource
   integration_id?: string
+  skip_tls_verify?: boolean
   enabled?: boolean
 }
 

--- a/frontend/src/pages/Checks.css
+++ b/frontend/src/pages/Checks.css
@@ -55,18 +55,18 @@
 
 .section-action:hover { opacity: 1; }
 
-/* ── MONITOR WIDGET (shared styles) ── */
+/* ── MONITOR STATUS BLOCK ── */
 .monitor-status-block {
-  width: 36px;
-  height: 36px;
-  border-radius: 6px;
+  width: 44px;
+  height: 44px;
+  border-radius: 8px;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
   font-family: var(--mono);
   font-size: 9px;
-  font-weight: 600;
+  font-weight: 700;
   letter-spacing: 0.05em;
 }
 
@@ -75,66 +75,179 @@
 .monitor-status-block.down    { background: var(--red-dim);    color: var(--red);    border: 1px solid #991b1b; }
 .monitor-status-block.unknown { background: var(--bg4);        color: var(--text3);  border: 1px solid var(--border); }
 
-.monitor-info    { flex: 1; min-width: 0; }
-.monitor-name    { font-size: 13px; font-weight: 500; color: var(--text); }
-.monitor-target  { font-family: var(--mono); font-size: 10px; color: var(--text3); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-
-.monitor-meta    { text-align: right; flex-shrink: 0; }
-.monitor-uptime  { font-family: var(--mono); font-size: 12px; font-weight: 600; color: var(--green); }
-.monitor-uptime.warn { color: var(--yellow); }
-.monitor-uptime.down { color: var(--red); }
-.monitor-last    { font-family: var(--mono); font-size: 10px; color: var(--text3); }
-
-/* ── CHECKS LIST ── */
-.checks-list {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+/* ── CHECKS GRID ── */
+.checks-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 10px;
+  align-items: start;
 }
 
-/* ── CHECK ROW ── */
-.check-row {
+/* ── CHECK CARD WRAPPER ── */
+.check-card-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.check-card-wrapper.expanded {
+  grid-column: 1 / -1;  /* span full width when expanded */
+}
+
+/* ── CHECK CARD ── */
+.check-card {
   background: var(--bg2);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 12px 14px;
+  padding: 14px;
   cursor: pointer;
   transition: all 0.15s;
   display: flex;
-  align-items: center;
-  gap: 12px;
+  flex-direction: column;
+  gap: 8px;
+  position: relative;
+  animation: fadeUp 0.2s ease both;
 }
 
-.check-row:hover { border-color: var(--border2); }
+.check-card:hover { border-color: var(--border2); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(0,0,0,0.25); }
+.check-card.expanded { border-radius: 8px 8px 0 0; border-bottom-color: var(--bg3); }
 
-.check-row-wrapper.expanded .check-row {
+/* Disabled styling */
+.check-card-wrapper.disabled .check-card {
+  opacity: 0.55;
+}
+
+/* Status bar at top of card */
+.check-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 2px;
   border-radius: 8px 8px 0 0;
+  background: var(--border);
+  transition: background 0.15s;
 }
 
-/* ── EXPAND PANEL ── */
-.check-expand {
+.check-card-wrapper:not(.disabled) .check-card.expanded::before,
+.check-card-wrapper:not(.disabled) .check-card:hover::before { background: var(--accent); opacity: 0.5; }
+
+/* Status-specific top bar colors */
+.check-card-wrapper:not(.disabled) .check-card:has(.monitor-status-block.up)::before   { background: var(--green); opacity: 0.6; }
+.check-card-wrapper:not(.disabled) .check-card:has(.monitor-status-block.warn)::before { background: var(--yellow); opacity: 0.6; }
+.check-card-wrapper:not(.disabled) .check-card:has(.monitor-status-block.down)::before { background: var(--red); opacity: 0.6; }
+
+.check-card-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.check-card-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  line-height: 1.3;
+}
+
+.check-card-target {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.check-card-target-tag {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 600;
+  color: var(--text3);
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 4px;
+  flex-shrink: 0;
+}
+
+.check-card-target-tag.warn {
+  color: var(--yellow);
+  background: var(--yellow-dim);
+  border-color: #854d0e;
+}
+
+.check-card-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.check-card-interval {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  flex: 1;
+}
+
+.check-card-last {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+}
+
+/* ── TYPE BADGE ── */
+.check-type-badge {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 700;
+  border-radius: 3px;
+  padding: 2px 5px;
+  flex-shrink: 0;
+  letter-spacing: 0.04em;
+}
+
+.check-type-ping { background: var(--accent-dim); color: var(--accent); border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent); }
+.check-type-url  { background: var(--bg4);        color: var(--text2);  border: 1px solid var(--border); }
+.check-type-ssl  { background: var(--green-dim);  color: var(--green);  border: 1px solid #166534; }
+
+/* ── PAUSED BADGE ── */
+.check-paused-badge {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 700;
+  color: var(--text3);
+  background: var(--bg4);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 2px 5px;
+  letter-spacing: 0.04em;
+  margin-left: auto;
+}
+
+/* ── TOGGLE BUTTON ── */
+.check-toggle-btn {
+  width: 24px;
+  height: 24px;
+  border-radius: 5px;
   background: var(--bg3);
   border: 1px solid var(--border);
-  border-top: none;
-  border-radius: 0 0 8px 8px;
-  padding: 14px 16px;
+  color: var(--text3);
+  font-size: 10px;
+  cursor: pointer;
   display: flex;
-  flex-direction: column;
-  gap: 14px;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: all 0.15s;
 }
 
-.check-expand-details {
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--text2);
-  white-space: pre-wrap;
-  word-break: break-all;
-  background: var(--bg2);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 10px 12px;
-  line-height: 1.6;
-}
+.check-toggle-btn:hover { border-color: var(--border2); color: var(--text); }
+.check-toggle-btn.enabled:hover { border-color: var(--yellow); color: var(--yellow); }
+.check-toggle-btn.paused { color: var(--green); border-color: #166534; background: var(--green-dim); }
+.check-toggle-btn.paused:hover { opacity: 0.85; }
 
 /* ── RUN BUTTON ── */
 .check-run-btn {
@@ -153,11 +266,7 @@
   transition: all 0.15s;
 }
 
-.check-run-btn:hover:not(:disabled) {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-
+.check-run-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
 .check-run-btn:disabled { cursor: default; opacity: 0.6; }
 .check-run-btn.running  { border-color: var(--accent-dim); }
 
@@ -171,9 +280,186 @@
   animation: spin 0.8s linear infinite;
 }
 
-@keyframes spin {
-  to { transform: rotate(360deg); }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── DETAIL PANEL ── */
+.check-detail-panel {
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-top: none;
+  border-radius: 0 0 8px 8px;
 }
+
+.check-detail-tabs {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 10px 14px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.check-detail-tab {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  background: none;
+  border: none;
+  padding: 6px 12px;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: all 0.15s;
+}
+
+.check-detail-tab:hover { color: var(--text2); }
+.check-detail-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+.check-detail-tab-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-bottom: 2px;
+}
+
+.check-detail-close {
+  width: 24px;
+  height: 24px;
+  background: none;
+  border: none;
+  color: var(--text3);
+  font-size: 12px;
+  cursor: pointer;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+}
+
+.check-detail-close:hover { background: var(--bg4); color: var(--text); }
+
+.check-detail-content {
+  padding: 16px;
+}
+
+/* ── RESULT DISPLAY ── */
+.check-result-box {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px 14px;
+  margin-bottom: 10px;
+}
+
+.check-result-grid {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 6px 12px;
+  align-items: center;
+}
+
+.check-result-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.check-result-value {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text);
+}
+
+.check-result-error { color: var(--red); }
+
+.check-result-empty {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  font-style: italic;
+}
+
+.check-result-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.check-result-meta-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.check-result-meta-value {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+}
+
+/* ── HISTORY ── */
+.check-history-empty {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  padding: 16px 0;
+}
+
+.check-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.check-history-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.check-history-text {
+  flex: 1;
+  font-size: 12px;
+  color: var(--text2);
+  font-family: var(--mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.check-history-time {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  flex-shrink: 0;
+}
+
+/* ── EVENT SEVERITY BADGE ── */
+.event-severity-badge {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 700;
+  border-radius: 3px;
+  padding: 2px 5px;
+  flex-shrink: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.event-severity-badge.info     { background: var(--bg4);         color: var(--text2);  border: 1px solid var(--border); }
+.event-severity-badge.warn     { background: var(--yellow-dim);  color: var(--yellow); border: 1px solid #854d0e; }
+.event-severity-badge.error    { background: var(--red-dim);     color: var(--red);    border: 1px solid #991b1b; }
+.event-severity-badge.critical { background: var(--red-dim);     color: var(--red);    border: 1px solid #991b1b; }
+.event-severity-badge.debug    { background: var(--bg4);         color: var(--text3);  border: 1px solid var(--border); }
 
 /* ── ADD / EDIT FORM ── */
 .add-form {
@@ -227,6 +513,10 @@
   gap: 5px;
 }
 
+.form-field-full {
+  grid-column: 1 / -1;
+}
+
 .form-label {
   font-family: var(--mono);
   font-size: 10px;
@@ -248,6 +538,36 @@
 }
 
 .form-input:focus { border-color: var(--accent); }
+
+/* ── CHECKBOX ── */
+.form-checkbox-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  cursor: pointer;
+  padding: 6px 0;
+}
+
+.form-checkbox {
+  width: 14px;
+  height: 14px;
+  margin-top: 1px;
+  flex-shrink: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.form-checkbox-text {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text2);
+  line-height: 1.4;
+}
+
+.form-checkbox-hint {
+  color: var(--text3);
+  font-size: 11px;
+}
 
 .form-error {
   font-family: var(--mono);
@@ -344,4 +664,10 @@
   font-size: 11px;
   color: var(--text3);
   padding: 4px 0;
+}
+
+/* ── ANIMATIONS ── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
 }

--- a/frontend/src/pages/Checks.tsx
+++ b/frontend/src/pages/Checks.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react'
 import { Topbar } from '../components/Topbar'
 import { SSLRow } from '../components/SSLRow'
 import { checks as checksApi, integrations as integrationsApi } from '../api/client'
-import type { MonitorCheck, CreateCheckInput, CheckType, SSLCert, InfraIntegration, TraefikCert, SSLSource } from '../api/types'
+import type { MonitorCheck, CreateCheckInput, CheckType, SSLCert, InfraIntegration, TraefikCert, SSLSource, Event } from '../api/types'
 import './Checks.css'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -18,7 +18,8 @@ type FormFields = {
   ssl_crit_days: string
   ssl_source: SSLSource
   integration_id: string
-  traefik_domain: string   // domain selection when ssl_source === 'traefik'
+  traefik_domain: string
+  skip_tls_verify: string  // 'true' | 'false'
 }
 
 const defaultForm: FormFields = {
@@ -32,23 +33,37 @@ const defaultForm: FormFields = {
   ssl_source: 'standalone',
   integration_id: '',
   traefik_domain: '',
+  skip_tls_verify: 'false',
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+function sslDaysFromResult(lastResult: string | null): number | null {
+  if (!lastResult) return null
+  try {
+    const r = JSON.parse(lastResult) as { days_remaining?: number }
+    return r.days_remaining ?? null
+  } catch {
+    return null
+  }
+}
+
 function statusLabel(check: MonitorCheck): string {
-  if (check.type === 'ssl') return 'SSL'
+  if (check.type === 'ssl') {
+    const days = sslDaysFromResult(check.last_result)
+    if (days != null) return `${days}d`
+    return 'SSL'
+  }
   if (check.last_status === 'up') return 'UP'
   if (check.last_status === 'down') return 'DOWN'
   if (check.last_status === 'warn') return 'WARN'
-  return '?'
+  return '—'
 }
 
-function statusClass(status: string | null, type: string): string {
-  if (type === 'ssl' && status === 'warn') return 'monitor-status-block warn'
+function statusClass(status: string | null): string {
   if (status === 'up') return 'monitor-status-block up'
   if (status === 'warn') return 'monitor-status-block warn'
-  if (status === 'down') return 'monitor-status-block down'
+  if (status === 'down' || status === 'critical') return 'monitor-status-block down'
   return 'monitor-status-block unknown'
 }
 
@@ -87,15 +102,6 @@ function extractSSLCerts(checkList: MonitorCheck[]): SSLCert[] {
       }
     })
     .sort((a, b) => a.days_remaining - b.days_remaining)
-}
-
-function formatResult(lastResult: string | null): string {
-  if (!lastResult) return 'No result yet'
-  try {
-    return JSON.stringify(JSON.parse(lastResult), null, 2)
-  } catch {
-    return lastResult
-  }
 }
 
 function validateForm(form: FormFields): string | null {
@@ -138,6 +144,7 @@ function checkToForm(check: MonitorCheck): FormFields {
     ssl_source: (check.ssl_source as SSLSource) ?? 'standalone',
     integration_id: check.integration_id ?? '',
     traefik_domain: check.ssl_source === 'traefik' ? check.target : '',
+    skip_tls_verify: check.skip_tls_verify ? 'true' : 'false',
   }
 }
 
@@ -152,6 +159,7 @@ function formToInput(form: FormFields, integrationID?: string): CreateCheckInput
   }
   if (form.type === 'url') {
     input.expected_status = parseInt(form.expected_status, 10)
+    input.skip_tls_verify = form.skip_tls_verify === 'true'
   }
   if (form.type === 'ssl') {
     input.ssl_warn_days = parseInt(form.ssl_warn_days, 10)
@@ -162,6 +170,71 @@ function formToInput(form: FormFields, integrationID?: string): CreateCheckInput
     }
   }
   return input
+}
+
+// ── Result display ────────────────────────────────────────────────────────────
+
+function renderCheckResult(check: MonitorCheck): ReactNode {
+  if (!check.last_result) return <span className="check-result-empty">No result recorded yet</span>
+  try {
+    const r = JSON.parse(check.last_result) as Record<string, unknown>
+    if (check.type === 'ping') {
+      return (
+        <div className="check-result-grid">
+          <span className="check-result-label">Latency</span>
+          <span className="check-result-value">{r.latency_ms != null ? `${r.latency_ms}ms` : '—'}</span>
+        </div>
+      )
+    }
+    if (check.type === 'url') {
+      return (
+        <div className="check-result-grid">
+          <span className="check-result-label">HTTP Status</span>
+          <span className="check-result-value">{r.status_code != null ? String(r.status_code) : '—'}</span>
+          <span className="check-result-label">Latency</span>
+          <span className="check-result-value">{r.latency_ms != null ? `${r.latency_ms}ms` : '—'}</span>
+          {!!r.error && <>
+            <span className="check-result-label">Error</span>
+            <span className="check-result-value check-result-error">{String(r.error)}</span>
+          </>}
+        </div>
+      )
+    }
+    if (check.type === 'ssl') {
+      if (r.error) return (
+        <div className="check-result-grid">
+          <span className="check-result-label">Error</span>
+          <span className="check-result-value check-result-error">{String(r.error)}</span>
+        </div>
+      )
+      const expiresStr = r.expires_at
+        ? new Date(r.expires_at as string).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+        : '—'
+      return (
+        <div className="check-result-grid">
+          <span className="check-result-label">Days remaining</span>
+          <span className="check-result-value">{r.days_remaining != null ? String(r.days_remaining) : '—'}</span>
+          <span className="check-result-label">Expires</span>
+          <span className="check-result-value">{expiresStr}</span>
+          {!!r.issuer && <>
+            <span className="check-result-label">Issuer</span>
+            <span className="check-result-value">{String(r.issuer)}</span>
+          </>}
+          {!!r.subject && <>
+            <span className="check-result-label">Subject</span>
+            <span className="check-result-value">{String(r.subject)}</span>
+          </>}
+        </div>
+      )
+    }
+  } catch { /* fall through */ }
+  return <span className="check-result-empty">{check.last_result}</span>
+}
+
+// ── Severity badge ────────────────────────────────────────────────────────────
+
+function severityBadge(severity: string) {
+  return <span className={`event-severity-badge ${severity}`}>{severity}</span>
 }
 
 // ── CheckForm component ───────────────────────────────────────────────────────
@@ -176,7 +249,6 @@ interface CheckFormProps {
   title: string
   submitLabel: string
   extraAction?: ReactNode
-  // Traefik context
   traefikIntegrations: InfraIntegration[]
   traefikCerts: TraefikCert[]
   onIntegrationChange: (integrationId: string) => void
@@ -327,18 +399,36 @@ function CheckForm({
             onChange={e => onChange('interval_secs', e.target.value)}
           />
         </div>
+
         {form.type === 'url' && (
-          <div className="form-field">
-            <div className="form-label">Expected Status</div>
-            <input
-              className="form-input"
-              type="number"
-              value={form.expected_status}
-              onChange={e => onChange('expected_status', e.target.value)}
-              placeholder="200"
-            />
-          </div>
+          <>
+            <div className="form-field">
+              <div className="form-label">Expected Status</div>
+              <input
+                className="form-input"
+                type="number"
+                value={form.expected_status}
+                onChange={e => onChange('expected_status', e.target.value)}
+                placeholder="200"
+              />
+            </div>
+            <div className="form-field form-field-full">
+              <label className="form-checkbox-label">
+                <input
+                  type="checkbox"
+                  className="form-checkbox"
+                  checked={form.skip_tls_verify === 'true'}
+                  onChange={e => onChange('skip_tls_verify', e.target.checked ? 'true' : 'false')}
+                />
+                <span className="form-checkbox-text">
+                  Accept self-signed certificates
+                  <span className="form-checkbox-hint"> — skips TLS verification; use for internal services only</span>
+                </span>
+              </label>
+            </div>
+          </>
         )}
+
         {form.type === 'ssl' && (
           <>
             <div className="form-field">
@@ -380,13 +470,263 @@ function CheckForm({
   )
 }
 
+// ── Check card expand panel ───────────────────────────────────────────────────
+
+interface CheckDetailProps {
+  check: MonitorCheck
+  editForm: FormFields
+  editError: string | null
+  editSubmitting: boolean
+  deletingIds: Set<string>
+  runningIds: Set<string>
+  events: Event[]
+  eventsLoading: boolean
+  traefikIntegrations: InfraIntegration[]
+  traefikCerts: TraefikCert[]
+  onEditChange: (field: keyof FormFields, value: string) => void
+  onEditSubmit: () => void
+  onClose: () => void
+  onDelete: () => void
+  onRun: () => void
+  onIntegrationChange: (id: string) => void
+}
+
+function CheckDetail({
+  check,
+  editForm,
+  editError,
+  editSubmitting,
+  deletingIds,
+  runningIds,
+  events,
+  eventsLoading,
+  traefikIntegrations,
+  traefikCerts,
+  onEditChange,
+  onEditSubmit,
+  onClose,
+  onDelete,
+  onRun,
+  onIntegrationChange,
+}: CheckDetailProps) {
+  const [tab, setTab] = useState<'result' | 'history' | 'edit'>('result')
+
+  return (
+    <div className="check-detail-panel">
+      <div className="check-detail-tabs">
+        <button
+          className={`check-detail-tab${tab === 'result' ? ' active' : ''}`}
+          onClick={() => setTab('result')}
+        >
+          Last Result
+        </button>
+        <button
+          className={`check-detail-tab${tab === 'history' ? ' active' : ''}`}
+          onClick={() => setTab('history')}
+        >
+          History
+        </button>
+        <button
+          className={`check-detail-tab${tab === 'edit' ? ' active' : ''}`}
+          onClick={() => setTab('edit')}
+        >
+          Edit
+        </button>
+        <div className="check-detail-tab-actions">
+          <button
+            className={`check-run-btn${runningIds.has(check.id) ? ' running' : ''}`}
+            title="Run now"
+            onClick={e => { e.stopPropagation(); onRun() }}
+            disabled={runningIds.has(check.id)}
+          >
+            {runningIds.has(check.id) ? <span className="check-spinner" /> : '▶'}
+          </button>
+          <button className="check-detail-close" onClick={onClose} title="Close">✕</button>
+        </div>
+      </div>
+
+      {tab === 'result' && (
+        <div className="check-detail-content">
+          <div className="check-result-box">
+            {renderCheckResult(check)}
+          </div>
+          <div className="check-result-meta">
+            <span className="check-result-meta-label">Last checked</span>
+            <span className="check-result-meta-value">{check.last_checked_at
+              ? new Date(check.last_checked_at).toLocaleString()
+              : 'Never'}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {tab === 'history' && (
+        <div className="check-detail-content">
+          {eventsLoading ? (
+            <div className="check-history-empty">Loading…</div>
+          ) : events.length === 0 ? (
+            <div className="check-history-empty">
+              No status-change events recorded yet. Events are created on first status transition.
+            </div>
+          ) : (
+            <div className="check-history-list">
+              {events.map(ev => (
+                <div key={ev.id} className="check-history-row">
+                  {severityBadge(ev.severity)}
+                  <span className="check-history-text">{ev.display_text}</span>
+                  <span className="check-history-time">{formatTimeAgo(ev.received_at)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {tab === 'edit' && (
+        <div className="check-detail-content">
+          <CheckForm
+            form={editForm}
+            onChange={onEditChange}
+            onSubmit={onEditSubmit}
+            onCancel={onClose}
+            error={editError}
+            submitting={editSubmitting}
+            title="Edit Check"
+            submitLabel="Save"
+            traefikIntegrations={traefikIntegrations}
+            traefikCerts={traefikCerts}
+            onIntegrationChange={onIntegrationChange}
+            extraAction={
+              <button
+                className="form-btn danger"
+                onClick={onDelete}
+                disabled={deletingIds.has(check.id)}
+                style={{ marginLeft: 'auto' }}
+              >
+                {deletingIds.has(check.id) ? 'Deleting…' : 'Delete'}
+              </button>
+            }
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Check card ────────────────────────────────────────────────────────────────
+
+interface CheckCardProps {
+  check: MonitorCheck
+  expanded: boolean
+  editForm: FormFields
+  editError: string | null
+  editSubmitting: boolean
+  deletingIds: Set<string>
+  runningIds: Set<string>
+  checkEvents: Event[]
+  checkEventsLoading: boolean
+  traefikIntegrations: InfraIntegration[]
+  traefikCerts: TraefikCert[]
+  onToggleExpand: () => void
+  onToggleEnabled: () => void
+  onEditChange: (field: keyof FormFields, value: string) => void
+  onEditSubmit: () => void
+  onDelete: () => void
+  onRun: () => void
+  onIntegrationChange: (id: string) => void
+}
+
+function CheckCard({
+  check,
+  expanded,
+  editForm,
+  editError,
+  editSubmitting,
+  deletingIds,
+  runningIds,
+  checkEvents,
+  checkEventsLoading,
+  traefikIntegrations,
+  traefikCerts,
+  onToggleExpand,
+  onToggleEnabled,
+  onEditChange,
+  onEditSubmit,
+  onDelete,
+  onRun,
+  onIntegrationChange,
+}: CheckCardProps) {
+  const disabled = !check.enabled
+
+  return (
+    <div className={`check-card-wrapper${expanded ? ' expanded' : ''}${disabled ? ' disabled' : ''}`}>
+      <div className={`check-card${expanded ? ' expanded' : ''}`} onClick={onToggleExpand}>
+
+        {/* Top row: status block + type badge */}
+        <div className="check-card-top">
+          <div className={statusClass(check.last_status)}>
+            {statusLabel(check)}
+          </div>
+          <span className={`check-type-badge check-type-${check.type}`}>
+            {check.type.toUpperCase()}
+          </span>
+          {disabled && <span className="check-paused-badge">PAUSED</span>}
+        </div>
+
+        {/* Name */}
+        <div className="check-card-name">{check.name}</div>
+
+        {/* Target */}
+        <div className="check-card-target" title={check.target}>
+          {check.target}
+          {check.ssl_source === 'traefik' && <span className="check-card-target-tag">Traefik</span>}
+          {check.skip_tls_verify && <span className="check-card-target-tag warn">self-signed</span>}
+        </div>
+
+        {/* Footer: interval + last checked + toggle */}
+        <div className="check-card-footer">
+          <span className="check-card-interval">every {check.interval_secs}s</span>
+          <span className="check-card-last">{formatTimeAgo(check.last_checked_at)}</span>
+          <button
+            className={`check-toggle-btn${check.enabled ? ' enabled' : ' paused'}`}
+            title={check.enabled ? 'Pause check' : 'Resume check'}
+            onClick={e => { e.stopPropagation(); onToggleEnabled() }}
+          >
+            {check.enabled ? '⏸' : '▶'}
+          </button>
+        </div>
+      </div>
+
+      {expanded && (
+        <CheckDetail
+          check={check}
+          editForm={editForm}
+          editError={editError}
+          editSubmitting={editSubmitting}
+          deletingIds={deletingIds}
+          runningIds={runningIds}
+          events={checkEvents}
+          eventsLoading={checkEventsLoading}
+          traefikIntegrations={traefikIntegrations}
+          traefikCerts={traefikCerts}
+          onEditChange={onEditChange}
+          onEditSubmit={onEditSubmit}
+          onClose={onToggleExpand}
+          onDelete={onDelete}
+          onRun={onRun}
+          onIntegrationChange={onIntegrationChange}
+        />
+      )}
+    </div>
+  )
+}
+
 // ── Main page ─────────────────────────────────────────────────────────────────
 
 export function Checks() {
   const [checkList, setCheckList] = useState<MonitorCheck[]>([])
   const [loading, setLoading] = useState(true)
 
-  // Traefik integrations for SSL source toggle
   const [traefikIntegrations, setTraefikIntegrations] = useState<InfraIntegration[]>([])
   const [traefikCerts, setTraefikCerts] = useState<TraefikCert[]>([])
 
@@ -402,10 +742,12 @@ export function Checks() {
   const [editError, setEditError] = useState<string | null>(null)
   const [editSubmitting, setEditSubmitting] = useState(false)
 
-  // Run
-  const [runningIds, setRunningIds] = useState<Set<string>>(new Set())
+  // Per-check events (for history tab)
+  const [checkEvents, setCheckEvents] = useState<Event[]>([])
+  const [checkEventsLoading, setCheckEventsLoading] = useState(false)
 
-  // Delete
+  // Action state
+  const [runningIds, setRunningIds] = useState<Set<string>>(new Set())
   const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set())
 
   useEffect(() => {
@@ -429,7 +771,7 @@ export function Checks() {
 
   const sslCerts = extractSSLCerts(checkList)
 
-  // ── Integration change (reload certs) ──
+  // ── Integration change ──
 
   function handleIntegrationChange(integrationId: string) {
     if (!integrationId) return
@@ -443,7 +785,6 @@ export function Checks() {
   function handleAddChange(field: keyof FormFields, value: string) {
     setAddForm(prev => {
       const next = { ...prev, [field]: value }
-      // When switching to traefik ssl, auto-set first integration
       if (field === 'ssl_source' && value === 'traefik' && traefikIntegrations.length > 0 && !next.integration_id) {
         next.integration_id = traefikIntegrations[0].id
       }
@@ -469,21 +810,30 @@ export function Checks() {
     }
   }
 
-  // ── Expand / edit ──
+  // ── Expand ──
 
   function handleToggleExpand(check: MonitorCheck) {
     if (expandedId === check.id) {
       setExpandedId(null)
-    } else {
-      setExpandedId(check.id)
-      setEditForm(checkToForm(check))
-      setEditError(null)
-      // Load certs for the check's integration if it's traefik
-      if (check.ssl_source === 'traefik' && check.integration_id) {
-        handleIntegrationChange(check.integration_id)
-      }
+      setCheckEvents([])
+      return
     }
+    setExpandedId(check.id)
+    setEditForm(checkToForm(check))
+    setEditError(null)
+    if (check.ssl_source === 'traefik' && check.integration_id) {
+      handleIntegrationChange(check.integration_id)
+    }
+    // Load events for history tab
+    setCheckEventsLoading(true)
+    setCheckEvents([])
+    checksApi.listEvents(check.id)
+      .then(res => setCheckEvents(res.data))
+      .catch(() => {})
+      .finally(() => setCheckEventsLoading(false))
   }
+
+  // ── Edit ──
 
   function handleEditChange(field: keyof FormFields, value: string) {
     setEditForm(prev => ({ ...prev, [field]: value }))
@@ -506,6 +856,23 @@ export function Checks() {
     }
   }
 
+  // ── Toggle enabled ──
+
+  async function handleToggleEnabled(check: MonitorCheck) {
+    const newEnabled = !check.enabled
+    // Optimistic update
+    setCheckList(prev => prev.map(c => c.id === check.id ? { ...c, enabled: newEnabled } : c))
+    try {
+      const updated = await checksApi.update(check.id, { enabled: newEnabled })
+      setCheckList(prev => prev.map(c => c.id === check.id ? updated : c))
+    } catch {
+      // Revert on failure
+      setCheckList(prev => prev.map(c => c.id === check.id ? check : c))
+    }
+  }
+
+  // ── Delete ──
+
   async function handleDelete(id: string) {
     setDeletingIds(prev => new Set(prev).add(id))
     try {
@@ -515,11 +882,7 @@ export function Checks() {
     } catch {
       // keep in list if delete fails
     } finally {
-      setDeletingIds(prev => {
-        const next = new Set(prev)
-        next.delete(id)
-        return next
-      })
+      setDeletingIds(prev => { const next = new Set(prev); next.delete(id); return next })
     }
   }
 
@@ -531,14 +894,16 @@ export function Checks() {
       await checksApi.run(id)
       const updated = await checksApi.get(id)
       setCheckList(prev => prev.map(c => c.id === id ? updated : c))
+      // Refresh events for expanded check
+      if (expandedId === id) {
+        checksApi.listEvents(id)
+          .then(res => setCheckEvents(res.data))
+          .catch(() => {})
+      }
     } catch {
-      // noop — status update visible on next poll
+      // noop
     } finally {
-      setRunningIds(prev => {
-        const next = new Set(prev)
-        next.delete(id)
-        return next
-      })
+      setRunningIds(prev => { const next = new Set(prev); next.delete(id); return next })
     }
   }
 
@@ -575,68 +940,29 @@ export function Checks() {
         ) : checkList.length === 0 ? (
           <div className="checks-empty"><span>No monitor checks configured yet.</span></div>
         ) : (
-          <div className="checks-list">
+          <div className="checks-grid">
             {checkList.map(check => (
-              <div
+              <CheckCard
                 key={check.id}
-                className={`check-row-wrapper${expandedId === check.id ? ' expanded' : ''}`}
-              >
-                <div className="check-row" onClick={() => handleToggleExpand(check)}>
-                  <div className={statusClass(check.last_status, check.type)}>
-                    {statusLabel(check)}
-                  </div>
-                  <div className="monitor-info">
-                    <div className="monitor-name">{check.name}</div>
-                    <div className="monitor-target">
-                      {check.target} · {check.type}
-                      {check.ssl_source === 'traefik' && ' (Traefik)'}
-                      {' '}· every {check.interval_secs}s
-                    </div>
-                  </div>
-                  <div className="monitor-meta">
-                    <div className="monitor-last">{formatTimeAgo(check.last_checked_at)}</div>
-                  </div>
-                  <button
-                    className={`check-run-btn${runningIds.has(check.id) ? ' running' : ''}`}
-                    title="Run now"
-                    onClick={e => { e.stopPropagation(); void handleRun(check.id) }}
-                    disabled={runningIds.has(check.id)}
-                  >
-                    {runningIds.has(check.id) ? <span className="check-spinner" /> : '▶'}
-                  </button>
-                </div>
-
-                {expandedId === check.id && (
-                  <div className="check-expand">
-                    <div className="check-expand-details">
-                      {formatResult(check.last_result)}
-                    </div>
-                    <CheckForm
-                      form={editForm}
-                      onChange={handleEditChange}
-                      onSubmit={() => void handleEditSubmit(check.id)}
-                      onCancel={() => setExpandedId(null)}
-                      error={editError}
-                      submitting={editSubmitting}
-                      title="Edit Check"
-                      submitLabel="Save"
-                      traefikIntegrations={traefikIntegrations}
-                      traefikCerts={traefikCerts}
-                      onIntegrationChange={handleIntegrationChange}
-                      extraAction={
-                        <button
-                          className="form-btn danger"
-                          onClick={() => void handleDelete(check.id)}
-                          disabled={deletingIds.has(check.id)}
-                          style={{ marginLeft: 'auto' }}
-                        >
-                          {deletingIds.has(check.id) ? 'Deleting…' : 'Delete'}
-                        </button>
-                      }
-                    />
-                  </div>
-                )}
-              </div>
+                check={check}
+                expanded={expandedId === check.id}
+                editForm={editForm}
+                editError={editError}
+                editSubmitting={editSubmitting}
+                deletingIds={deletingIds}
+                runningIds={runningIds}
+                checkEvents={checkEvents}
+                checkEventsLoading={checkEventsLoading}
+                traefikIntegrations={traefikIntegrations}
+                traefikCerts={traefikCerts}
+                onToggleExpand={() => handleToggleExpand(check)}
+                onToggleEnabled={() => void handleToggleEnabled(check)}
+                onEditChange={handleEditChange}
+                onEditSubmit={() => void handleEditSubmit(check.id)}
+                onDelete={() => void handleDelete(check.id)}
+                onRun={() => void handleRun(check.id)}
+                onIntegrationChange={handleIntegrationChange}
+              />
             ))}
           </div>
         )}

--- a/internal/api/checks.go
+++ b/internal/api/checks.go
@@ -34,6 +34,7 @@ func (h *ChecksHandler) Routes(r chi.Router) {
 	r.Put("/checks/{id}", h.Update)
 	r.Delete("/checks/{id}", h.Delete)
 	r.Post("/checks/{id}/run", h.Run)
+	r.Get("/checks/{id}/events", h.ListEvents)
 }
 
 // --- request / response types ---
@@ -47,8 +48,10 @@ type checkRequest struct {
 	ExpectedStatus int     `json:"expected_status"`
 	SSLWarnDays    int     `json:"ssl_warn_days"`
 	SSLCritDays    int     `json:"ssl_crit_days"`
-	SSLSource      *string `json:"ssl_source"`       // "traefik" | "standalone" | nil
-	IntegrationID  *string `json:"integration_id"`   // required when ssl_source == "traefik"
+	SSLSource      *string `json:"ssl_source"`     // "traefik" | "standalone" | nil
+	IntegrationID  *string `json:"integration_id"` // required when ssl_source == "traefik"
+	Enabled        *bool   `json:"enabled"`         // nil = no change, false = disable, true = enable
+	SkipTLSVerify  *bool   `json:"skip_tls_verify"` // nil = no change; for url checks only
 }
 
 type listChecksResponse struct {
@@ -130,6 +133,8 @@ func (h *ChecksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		critDays = 7
 	}
 
+	skipTLS := req.SkipTLSVerify != nil && *req.SkipTLSVerify
+
 	check := &models.MonitorCheck{
 		ID:             uuid.New().String(),
 		AppID:          req.AppID,
@@ -142,6 +147,7 @@ func (h *ChecksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		SSLCritDays:    critDays,
 		SSLSource:      req.SSLSource,
 		IntegrationID:  req.IntegrationID,
+		SkipTLSVerify:  skipTLS,
 		Enabled:        true,
 		CreatedAt:      time.Now().UTC(),
 	}
@@ -219,13 +225,21 @@ func (h *ChecksHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if req.IntegrationID != nil {
 		existing.IntegrationID = req.IntegrationID
 	}
+	if req.Enabled != nil {
+		existing.Enabled = *req.Enabled
+	}
+	if req.SkipTLSVerify != nil {
+		existing.SkipTLSVerify = *req.SkipTLSVerify
+	}
 
-	// Re-validate the merged state.
+	// Re-validate the merged state. Include SSLSource so Traefik-mode checks
+	// are not incorrectly rejected for using a bare domain target.
 	merged := checkRequest{
 		Name:         existing.Name,
 		Type:         existing.Type,
 		Target:       existing.Target,
 		IntervalSecs: existing.IntervalSecs,
+		SSLSource:    existing.SSLSource,
 	}
 	if msg := validateCheck(merged); msg != "" {
 		writeError(w, http.StatusBadRequest, msg)
@@ -271,7 +285,7 @@ func (h *ChecksHandler) Run(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	result, runErr := monitor.Run(ctx, check.Type, check.Target, check.ExpectedStatus, check.SSLWarnDays, check.SSLCritDays)
+	result, runErr := monitor.Run(ctx, check.Type, check.Target, check.ExpectedStatus, check.SSLWarnDays, check.SSLCritDays, check.SkipTLSVerify)
 	if runErr != nil {
 		writeError(w, http.StatusInternalServerError, runErr.Error())
 		return
@@ -285,8 +299,8 @@ func (h *ChecksHandler) Run(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create an event if the status changed to non-up and check is associated with an app.
-	if result.Status != "up" && result.Status != prevStatus && check.AppID != "" {
+	// Create an event on status change (always — app_id is optional).
+	if result.Status != prevStatus {
 		h.createStatusEvent(r.Context(), check, result)
 	}
 
@@ -297,13 +311,42 @@ func (h *ChecksHandler) Run(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// createStatusEvent records a monitor check failure as an app event.
+// ListEvents returns recent status-change events for a specific check: GET /api/v1/checks/{id}/events
+func (h *ChecksHandler) ListEvents(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if _, err := h.checks.Get(r.Context(), id); err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "check not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	events, _, err := h.events.List(r.Context(), repo.ListFilter{
+		CheckID: id,
+		Limit:   50,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"data":  events,
+		"total": len(events),
+	})
+}
+
+// createStatusEvent records a monitor check status change as an event.
+// app_id is optional — checks not linked to an app still generate events.
 func (h *ChecksHandler) createStatusEvent(ctx context.Context, check *models.MonitorCheck, result monitor.Result) {
-	severity := "error"
-	if result.Status == "warn" {
+	severity := "info"
+	if result.Status == "down" || result.Status == "critical" {
+		severity = "error"
+	} else if result.Status == "warn" {
 		severity = "warn"
 	}
-	displayText := check.Name + " check status: " + result.Status
+	displayText := check.Name + " — " + result.Status
 
 	event := &models.Event{
 		ID:          uuid.New().String(),
@@ -312,7 +355,7 @@ func (h *ChecksHandler) createStatusEvent(ctx context.Context, check *models.Mon
 		Severity:    severity,
 		DisplayText: displayText,
 		RawPayload:  string(result.Details),
-		Fields:      `{"source":"monitor","check_id":"` + check.ID + `","status":"` + result.Status + `"}`,
+		Fields:      `{"source":"monitor","check_id":"` + check.ID + `","check_type":"` + check.Type + `","status":"` + result.Status + `"}`,
 	}
 	// Log failure but don't fail the response.
 	_ = h.events.Create(ctx, event)

--- a/internal/models/monitor_check.go
+++ b/internal/models/monitor_check.go
@@ -15,9 +15,12 @@ type MonitorCheck struct {
 	SSLCritDays    int        `db:"ssl_crit_days"   json:"ssl_crit_days"`
 	// SSLSource distinguishes Traefik-mode SSL checks (cert read from cache)
 	// from standalone checks (direct TLS handshake). Nil means standalone.
-	SSLSource     *string `db:"ssl_source"     json:"ssl_source,omitempty"`
-	IntegrationID *string `db:"integration_id" json:"integration_id,omitempty"`
-	Enabled        bool       `db:"enabled"         json:"enabled"`
+	SSLSource     *string `db:"ssl_source"      json:"ssl_source,omitempty"`
+	IntegrationID *string `db:"integration_id"  json:"integration_id,omitempty"`
+	// SkipTLSVerify disables certificate validation for URL checks.
+	// Use for internal services with self-signed certificates.
+	SkipTLSVerify  bool    `db:"skip_tls_verify" json:"skip_tls_verify"`
+	Enabled        bool    `db:"enabled"         json:"enabled"`
 	LastCheckedAt  *time.Time `db:"last_checked_at" json:"last_checked_at,omitempty"`
 	LastStatus     string     `db:"last_status"     json:"last_status,omitempty"`
 	LastResult     string     `db:"last_result"     json:"last_result,omitempty"`

--- a/internal/monitor/ping.go
+++ b/internal/monitor/ping.go
@@ -34,9 +34,8 @@ func NewPingChecker(store *repo.Store) *PingChecker {
 //
 // It sends up to 3 pings with a 5-second timeout each. The check is considered
 // down only if all 3 pings fail, reducing false positives from transient packet
-// loss. On a status transition (up→down or down→up), an event is created —
-// but only when the check is associated with an app, because the events table
-// requires a valid app_id foreign key.
+// loss. On a status transition (up→down or down→up), an event is created.
+// app_id is optional — standalone checks still generate events queryable by check_id.
 func (p *PingChecker) Run(ctx context.Context, check *models.MonitorCheck) error {
 	const attempts = 3
 
@@ -68,11 +67,10 @@ func (p *PingChecker) Run(ctx context.Context, check *models.MonitorCheck) error
 		detailsBytes, _ = json.Marshal(pingDetails{LatencyMs: latencyMs})
 	}
 
-	// Emit a status-change event when there is a known previous state and the
-	// check is linked to an app. Checks without an app_id are tracked in
-	// last_status only — the events table requires a valid app_id reference.
+	// Emit a status-change event on any transition. app_id is optional —
+	// checks not linked to an app still generate events queryable by check_id.
 	prevStatus := check.LastStatus
-	if prevStatus != "" && prevStatus != newStatus && check.AppID != "" {
+	if prevStatus != "" && prevStatus != newStatus {
 		if err := p.createStatusEvent(ctx, check, newStatus, now); err != nil {
 			log.Printf("ping checker: create event for check %s: %v", check.ID, err)
 		}

--- a/internal/monitor/ping_test.go
+++ b/internal/monitor/ping_test.go
@@ -140,20 +140,23 @@ func TestPingChecker_Recovery(t *testing.T) {
 	}
 }
 
-// TestPingChecker_NoEventWithoutApp verifies that no event is created for checks
-// not linked to an app (the events table requires a valid app_id).
-func TestPingChecker_NoEventWithoutApp(t *testing.T) {
+// TestPingChecker_EventWithoutApp verifies that a status-change event IS created
+// for checks not linked to an app (app_id nullable; events queryable by check_id).
+func TestPingChecker_EventWithoutApp(t *testing.T) {
 	checks := &mockCheckRepo{}
 	events := &mockEventRepo{}
 	checker := &PingChecker{store: newTestStore(checks, events), pinger: alwaysDown}
 
-	check := makeCheck("up", "") // AppID is empty
+	check := makeCheck("up", "") // AppID empty — status changes up→down
 	if err := checker.Run(context.Background(), check); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(events.created) != 0 {
-		t.Errorf("expected no events for check without app, got %d", len(events.created))
+	if len(events.created) != 1 {
+		t.Errorf("expected 1 event for check without app on status change, got %d", len(events.created))
+	}
+	if events.created[0].AppID != "" {
+		t.Errorf("expected empty app_id on event, got %s", events.created[0].AppID)
 	}
 }
 

--- a/internal/monitor/runner.go
+++ b/internal/monitor/runner.go
@@ -12,6 +12,16 @@ import (
 	"time"
 )
 
+// tlsTransport returns an http.Transport with optional InsecureSkipVerify.
+func tlsTransport(skipVerify bool) *http.Transport {
+	if !skipVerify {
+		return &http.Transport{}
+	}
+	return &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+	}
+}
+
 // Result is the outcome of a single check execution.
 type Result struct {
 	Status    string          `json:"status"`     // up | warn | down
@@ -62,14 +72,16 @@ func RunPing(ctx context.Context, target string) Result {
 }
 
 // RunURL executes an HTTP check against target, verifying the response status code.
-func RunURL(ctx context.Context, target string, expectedStatus int) Result {
+// Set skipTLSVerify to true for services using self-signed certificates.
+func RunURL(ctx context.Context, target string, expectedStatus int, skipTLSVerify bool) Result {
 	now := time.Now().UTC()
 	if expectedStatus == 0 {
 		expectedStatus = 200
 	}
 
 	client := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout:   10 * time.Second,
+		Transport: tlsTransport(skipTLSVerify),
 		// Don't follow redirects — check the actual status code returned.
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
@@ -173,12 +185,13 @@ func RunSSL(ctx context.Context, target string, warnDays, critDays int) Result {
 // Run dispatches a check by type and returns the result.
 // checkType must be one of "ping", "url", "ssl".
 // expectedStatus is used for url checks; warnDays/critDays for ssl checks.
-func Run(ctx context.Context, checkType, target string, expectedStatus, warnDays, critDays int) (Result, error) {
+// skipTLSVerify applies only to url checks (ignore self-signed cert errors).
+func Run(ctx context.Context, checkType, target string, expectedStatus, warnDays, critDays int, skipTLSVerify bool) (Result, error) {
 	switch checkType {
 	case "ping":
 		return RunPing(ctx, target), nil
 	case "url":
-		return RunURL(ctx, target, expectedStatus), nil
+		return RunURL(ctx, target, expectedStatus, skipTLSVerify), nil
 	case "ssl":
 		return RunSSL(ctx, target, warnDays, critDays), nil
 	default:

--- a/internal/monitor/ssl.go
+++ b/internal/monitor/ssl.go
@@ -30,8 +30,7 @@ func NewSSLChecker(store *repo.Store) *SSLChecker {
 // cache — no outbound TLS connection is made. Otherwise the existing standalone
 // mode dials the target and reads the cert off the TLS handshake.
 //
-// On a status transition an event is created, but only when the check is
-// linked to an app (events require a valid app_id).
+// On a status transition an event is always created. app_id is optional.
 func (s *SSLChecker) Run(ctx context.Context, check *models.MonitorCheck) error {
 	if check.SSLSource != nil && *check.SSLSource == "traefik" {
 		return s.runTraefikSSL(ctx, check)
@@ -103,7 +102,7 @@ func (s *SSLChecker) runTraefikSSL(ctx context.Context, check *models.MonitorChe
 	}
 
 	prevStatus := check.LastStatus
-	if prevStatus != "" && prevStatus != newStatus && check.AppID != "" {
+	if prevStatus != "" && prevStatus != newStatus {
 		if evErr := s.createStatusEvent(ctx, check, newStatus, domain, daysRemaining, now); evErr != nil {
 			log.Printf("ssl checker (traefik): create event for check %s: %v", check.ID, evErr)
 		}
@@ -142,7 +141,7 @@ func (s *SSLChecker) runStandaloneSSL(ctx context.Context, check *models.Monitor
 	prevStatus := check.LastStatus
 	newStatus := result.Status
 
-	if prevStatus != "" && prevStatus != newStatus && check.AppID != "" {
+	if prevStatus != "" && prevStatus != newStatus {
 		if evErr := s.createStatusEvent(ctx, check, newStatus, domain, days, now); evErr != nil {
 			log.Printf("ssl checker: create event for check %s: %v", check.ID, evErr)
 		}

--- a/internal/monitor/ssl_test.go
+++ b/internal/monitor/ssl_test.go
@@ -168,19 +168,23 @@ func TestSSLChecker_Recovery(t *testing.T) {
 	}
 }
 
-// TestSSLChecker_NoEventWithoutApp verifies no event is created for checks not linked to an app.
-func TestSSLChecker_NoEventWithoutApp(t *testing.T) {
+// TestSSLChecker_EventWithoutApp verifies a status-change event IS created for
+// checks not linked to an app (app_id nullable; events queryable by check_id).
+func TestSSLChecker_EventWithoutApp(t *testing.T) {
 	checks := &mockCheckRepo{}
 	events := &mockEventRepo{}
 	checker := newSSLChecker(checks, events, fakeSSLRunner("warn", 20, ""))
 
-	check := makeSSLCheck("https://example.com", "up", "", 30, 7) // no AppID
+	check := makeSSLCheck("https://example.com", "up", "", 30, 7) // no AppID, up→warn transition
 	if err := checker.Run(context.Background(), check); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(events.created) != 0 {
-		t.Errorf("expected no events for check without app, got %d", len(events.created))
+	if len(events.created) != 1 {
+		t.Errorf("expected 1 event for check without app on status change, got %d", len(events.created))
+	}
+	if events.created[0].AppID != "" {
+		t.Errorf("expected empty app_id on event, got %s", events.created[0].AppID)
 	}
 }
 

--- a/internal/monitor/url.go
+++ b/internal/monitor/url.go
@@ -13,6 +13,22 @@ import (
 	"github.com/google/uuid"
 )
 
+// clientForCheck returns an http.Client appropriate for check.
+// When SkipTLSVerify is set a fresh client with InsecureSkipVerify is returned;
+// otherwise the shared URLChecker client is reused.
+func (u *URLChecker) clientForCheck(check *models.MonitorCheck) *http.Client {
+	if !check.SkipTLSVerify {
+		return u.client
+	}
+	return &http.Client{
+		Timeout:   u.client.Timeout,
+		Transport: tlsTransport(true),
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
 // URLChecker executes HTTP GET health checks and persists results via the store.
 type URLChecker struct {
 	store  *repo.Store
@@ -72,7 +88,7 @@ func (u *URLChecker) Run(ctx context.Context, check *models.MonitorCheck) error 
 	}
 
 	start := time.Now()
-	resp, err := u.client.Do(req)
+	resp, err := u.clientForCheck(check).Do(req)
 	latencyMs := time.Since(start).Milliseconds()
 
 	now := time.Now().UTC()
@@ -98,7 +114,7 @@ func (u *URLChecker) Run(ctx context.Context, check *models.MonitorCheck) error 
 	// Emit a status-change event when there is a known previous state and the
 	// check is linked to an app.
 	prevStatus := check.LastStatus
-	if prevStatus != "" && prevStatus != newStatus && check.AppID != "" {
+	if prevStatus != "" && prevStatus != newStatus {
 		if evErr := u.createStatusEvent(ctx, check, newStatus, resp.StatusCode, expected, now); evErr != nil {
 			log.Printf("url checker: create event for check %s: %v", check.ID, evErr)
 		}
@@ -126,7 +142,7 @@ func (u *URLChecker) recordError(ctx context.Context, check *models.MonitorCheck
 	}
 
 	prevStatus := check.LastStatus
-	if prevStatus != "" && prevStatus != newStatus && check.AppID != "" {
+	if prevStatus != "" && prevStatus != newStatus {
 		if evErr := u.createStatusEvent(ctx, check, newStatus, 0, expected, now); evErr != nil {
 			log.Printf("url checker: create event for check %s: %v", check.ID, evErr)
 		}

--- a/internal/monitor/url_test.go
+++ b/internal/monitor/url_test.go
@@ -233,8 +233,9 @@ func TestURLChecker_DefaultExpected200(t *testing.T) {
 	}
 }
 
-// TestURLChecker_NoEventWithoutApp verifies no event is created for app-less checks.
-func TestURLChecker_NoEventWithoutApp(t *testing.T) {
+// TestURLChecker_EventWithoutApp verifies a status-change event IS created for
+// app-less checks (app_id nullable; events queryable by check_id).
+func TestURLChecker_EventWithoutApp(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -244,13 +245,16 @@ func TestURLChecker_NoEventWithoutApp(t *testing.T) {
 	events := &mockEventRepo{}
 	checker := newURLChecker(checks, events)
 
-	check := makeURLCheck(srv.URL, "up", "", 200) // no AppID
+	check := makeURLCheck(srv.URL, "up", "", 200) // no AppID, up→down transition
 	if err := checker.Run(context.Background(), check); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(events.created) != 0 {
-		t.Errorf("expected no events for check without app, got %d", len(events.created))
+	if len(events.created) != 1 {
+		t.Errorf("expected 1 event for check without app on status change, got %d", len(events.created))
+	}
+	if events.created[0].AppID != "" {
+		t.Errorf("expected empty app_id on event, got %s", events.created[0].AppID)
 	}
 }
 

--- a/internal/repo/checks.go
+++ b/internal/repo/checks.go
@@ -33,7 +33,8 @@ func NewCheckRepo(db *sqlx.DB) CheckRepo {
 const selectCheckCols = `
 	SELECT id, COALESCE(app_id,'') AS app_id, name, type, target,
 	       interval_secs, COALESCE(expected_status,0) AS expected_status,
-	       ssl_warn_days, ssl_crit_days, ssl_source, integration_id, enabled,
+	       ssl_warn_days, ssl_crit_days, ssl_source, integration_id,
+	       COALESCE(skip_tls_verify,0) AS skip_tls_verify, enabled,
 	       last_checked_at, COALESCE(last_status,'') AS last_status,
 	       COALESCE(last_result,'') AS last_result, created_at
 	FROM monitor_checks`
@@ -54,13 +55,14 @@ func (r *sqliteCheckRepo) Create(ctx context.Context, check *models.MonitorCheck
 	_, err := r.db.ExecContext(ctx, `
 		INSERT INTO monitor_checks
 		  (id, app_id, name, type, target, interval_secs, expected_status,
-		   ssl_warn_days, ssl_crit_days, ssl_source, integration_id, enabled)
-		VALUES (?, NULLIF(?,?), ?, ?, ?, ?, NULLIF(?,0), ?, ?, ?, ?, ?)`,
+		   ssl_warn_days, ssl_crit_days, ssl_source, integration_id, skip_tls_verify, enabled)
+		VALUES (?, NULLIF(?,?), ?, ?, ?, ?, NULLIF(?,0), ?, ?, ?, ?, ?, ?)`,
 		check.ID, check.AppID, check.AppID,
 		check.Name, check.Type, check.Target, check.IntervalSecs,
 		check.ExpectedStatus,
 		check.SSLWarnDays, check.SSLCritDays,
 		check.SSLSource, check.IntegrationID,
+		check.SkipTLSVerify,
 		check.Enabled)
 	if err != nil {
 		return fmt.Errorf("create check: %w", err)
@@ -85,13 +87,14 @@ func (r *sqliteCheckRepo) Update(ctx context.Context, check *models.MonitorCheck
 		UPDATE monitor_checks
 		SET app_id=NULLIF(?,?), name=?, type=?, target=?, interval_secs=?,
 		    expected_status=NULLIF(?,0), ssl_warn_days=?, ssl_crit_days=?,
-		    ssl_source=?, integration_id=?, enabled=?
+		    ssl_source=?, integration_id=?, skip_tls_verify=?, enabled=?
 		WHERE id=?`,
 		check.AppID, check.AppID,
 		check.Name, check.Type, check.Target, check.IntervalSecs,
 		check.ExpectedStatus,
 		check.SSLWarnDays, check.SSLCritDays,
 		check.SSLSource, check.IntegrationID,
+		check.SkipTLSVerify,
 		check.Enabled,
 		check.ID)
 	if err != nil {

--- a/internal/repo/events.go
+++ b/internal/repo/events.go
@@ -15,6 +15,7 @@ import (
 // ListFilter constrains an event list query. Zero values mean "no filter".
 type ListFilter struct {
 	AppID    string
+	CheckID  string   // filter by json_extract(fields, '$.check_id')
 	Severity []string
 	Since    *time.Time
 	Until    *time.Time
@@ -123,6 +124,11 @@ func buildWhere(f ListFilter) (clause string, args []interface{}) {
 	if f.AppID != "" {
 		parts = append(parts, "e.app_id = ?")
 		args = append(args, f.AppID)
+	}
+
+	if f.CheckID != "" {
+		parts = append(parts, "json_extract(e.fields, '$.check_id') = ?")
+		args = append(args, f.CheckID)
 	}
 
 	if len(f.Severity) > 0 {

--- a/migrations/008_checks_skip_tls_verify.sql
+++ b/migrations/008_checks_skip_tls_verify.sql
@@ -1,0 +1,5 @@
+-- Add skip_tls_verify column to monitor_checks.
+-- When true, URL checks skip TLS certificate validation.
+-- Useful for self-signed certificates on internal services.
+
+ALTER TABLE monitor_checks ADD COLUMN skip_tls_verify INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## What
Complete redesign of the Monitor Checks page with new capabilities.

## Why
- Cards are more scannable than rows (matches the apps page pattern)
- Self-signed certificates are common in homelabs — URL checks needed opt-in TLS skip
- Check failures are operational events and should be visible in the event stream and queryable as history

## How

**Checks page — card grid:**
- Each check renders as a card (same grid pattern as apps)
- Status block: SSL checks show days remaining (e.g. `89d`) instead of `SSL`
- Type badge (PING / URL / SSL) on every card
- Enable/disable toggle per card (optimistic update)
- Disabled cards dimmed with PAUSED badge
- Click to expand → tabbed detail: **Last Result** / **History** / **Edit**

**Last Result tab:**
- Structured display per type: ping shows latency, URL shows status code + latency + error, SSL shows days/expiry/issuer

**History tab:**
- Pulls from new `GET /checks/{id}/events` endpoint
- Shows status-change events with severity badge, display text, time ago

**Self-signed cert support:**
- New `skip_tls_verify` boolean field on `monitor_checks` (migration 008)
- Checkbox in URL check form: "Accept self-signed certificates"
- Propagated through scheduler (`url.go`) and manual run (`runner.go`)

**Backend:**
- `PUT /checks/{id}` now accepts `enabled` and `skip_tls_verify`
- Fixed re-validation bug for Traefik SSL checks (SSLSource was missing from merged validation struct)
- Check status-change events now always fire (app_id optional — events queryable by `check_id` in fields JSON)
- `GET /checks/{id}/events` endpoint (uses new `CheckID` filter on `repo.ListFilter`)

## Test coverage
- `go test ./...` passes
- Updated `NoEventWithoutApp` tests to `EventWithoutApp` — reflects the new intentional behavior
- `npm run build` clean

## Closes
N/A — new feature work on `feat/active-checks-improvements`