### PR TITLE
feat: Proxmox API poller (Infra-2)

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -97,6 +97,11 @@ func main() {
 	syncWorker := infra.NewSyncWorker(store)
 	go syncWorker.Start(infraCtx)
 
+	// Proxmox pollers — polls all enabled proxmox_node components every 5 minutes.
+	proxmoxCtx, proxmoxCancel := context.WithCancel(context.Background())
+	defer proxmoxCancel()
+	go jobs.StartProxmoxPollers(proxmoxCtx, store)
+
 	// Docker socket watcher and resource poller — optional; skipped if the socket is not available.
 	dockerCtx, dockerCancel := context.WithCancel(context.Background())
 	defer dockerCancel()

--- a/internal/api/infra_components.go
+++ b/internal/api/infra_components.go
@@ -279,11 +279,23 @@ func (h *InfraComponentHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// infraResourcesResponse is the response shape for GET /infrastructure/{id}/resources.
+type infraResourcesResponse struct {
+	ComponentID string  `json:"component_id"`
+	Period      string  `json:"period"`
+	CPUPercent  float64 `json:"cpu_percent"`
+	MemPercent  float64 `json:"mem_percent"`
+	DiskPercent float64 `json:"disk_percent"`
+	RecordedAt  string  `json:"recorded_at,omitempty"`
+	NoData      bool    `json:"no_data,omitempty"`
+}
+
 // GetResources returns the latest resource rollup values for an infrastructure component.
 // GET /api/v1/infrastructure/{id}/resources?period=hour|day
 func (h *InfraComponentHandler) GetResources(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	if _, err := h.components.Get(r.Context(), id); errors.Is(err, repo.ErrNotFound) {
+	comp, err := h.components.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "component not found")
 		return
 	} else if err != nil {
@@ -300,21 +312,33 @@ func (h *InfraComponentHandler) GetResources(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	rollups, err := h.rollups.LatestForSource(r.Context(), id, "host", period)
+	rollups, err := h.rollups.LatestForSource(r.Context(), id, comp.Type, period)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	resp := hostResourcesResponse{}
+	resp := infraResourcesResponse{
+		ComponentID: id,
+		Period:      period,
+	}
+	if len(rollups) == 0 {
+		resp.NoData = true
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
 	for _, rr := range rollups {
 		switch rr.Metric {
 		case "cpu_percent":
-			resp.CPU = rr.Avg
+			resp.CPUPercent = rr.Avg
+			if resp.RecordedAt == "" {
+				resp.RecordedAt = rr.PeriodStart.UTC().Format(time.RFC3339)
+			}
 		case "mem_percent":
-			resp.Mem = rr.Avg
+			resp.MemPercent = rr.Avg
 		case "disk_percent":
-			resp.Disk = rr.Avg
+			resp.DiskPercent = rr.Avg
 		}
 	}
 	writeJSON(w, http.StatusOK, resp)

--- a/internal/infra/proxmox.go
+++ b/internal/infra/proxmox.go
@@ -1,0 +1,281 @@
+package infra
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+// ProxmoxCredentials is the JSON shape stored in infrastructure_components.credentials.
+type ProxmoxCredentials struct {
+	BaseURL     string `json:"base_url"`
+	TokenID     string `json:"token_id"`
+	TokenSecret string `json:"token_secret"`
+	VerifyTLS   bool   `json:"verify_tls"`
+}
+
+// ProxmoxPoller polls a single Proxmox VE instance, writing resource_readings
+// and generating events for VM/LXC state changes.
+type ProxmoxPoller struct {
+	componentID string
+	creds       ProxmoxCredentials
+	client      *http.Client
+
+	mu          sync.Mutex
+	lastVMState map[string]string // key: "node/vmid", value: last known status
+}
+
+// NewProxmoxPoller creates a ProxmoxPoller from a component ID and credentials JSON.
+// Logs a warning when verify_tls is false.
+func NewProxmoxPoller(componentID, credJSON string) (*ProxmoxPoller, error) {
+	var creds ProxmoxCredentials
+	if err := json.Unmarshal([]byte(credJSON), &creds); err != nil {
+		return nil, fmt.Errorf("parse proxmox credentials: %w", err)
+	}
+
+	transport := &http.Transport{}
+	if !creds.VerifyTLS {
+		log.Printf("proxmox poller %s: TLS verification disabled (verify_tls=false)", componentID)
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	}
+
+	return &ProxmoxPoller{
+		componentID: componentID,
+		creds:       creds,
+		client: &http.Client{
+			Transport: transport,
+			Timeout:   15 * time.Second,
+		},
+		lastVMState: make(map[string]string),
+	}, nil
+}
+
+// ── API response shapes ───────────────────────────────────────────────────────
+
+type proxmoxEnvelope struct {
+	Data json.RawMessage `json:"data"`
+}
+
+type proxmoxNode struct {
+	Node   string `json:"node"`
+	Status string `json:"status"`
+}
+
+type proxmoxNodeStatus struct {
+	CPU    float64 `json:"cpu"`
+	Memory struct {
+		Used  float64 `json:"used"`
+		Total float64 `json:"total"`
+	} `json:"memory"`
+}
+
+type proxmoxStorage struct {
+	Storage string  `json:"storage"`
+	Used    float64 `json:"used"`
+	Total   float64 `json:"total"`
+	Active  int     `json:"active"`
+}
+
+type proxmoxVM struct {
+	VMID   int    `json:"vmid"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+func (p *ProxmoxPoller) get(ctx context.Context, path string, out interface{}) error {
+	url := p.creds.BaseURL + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build request %s: %w", path, err)
+	}
+	req.Header.Set("Authorization",
+		fmt.Sprintf("PVEAPIToken=%s=%s", p.creds.TokenID, p.creds.TokenSecret))
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: unexpected status %d", path, resp.StatusCode)
+	}
+
+	var env proxmoxEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return fmt.Errorf("decode response %s: %w", path, err)
+	}
+	return json.Unmarshal(env.Data, out)
+}
+
+// ── Poll ──────────────────────────────────────────────────────────────────────
+
+// Poll runs one full poll cycle: fetches all nodes, records metrics, and fires
+// VM/LXC state-change events. Returns an error only if the cluster is unreachable.
+// Partial failures (single-node errors) result in status="degraded".
+func (p *ProxmoxPoller) Poll(ctx context.Context, store *repo.Store) error {
+	var nodes []proxmoxNode
+	if err := p.get(ctx, "/api2/json/nodes", &nodes); err != nil {
+		return fmt.Errorf("list nodes: %w", err)
+	}
+
+	partial := false
+	now := time.Now().UTC()
+
+	for _, node := range nodes {
+		if err := p.pollNode(ctx, store, node.Node, now); err != nil {
+			log.Printf("proxmox poller %s: node %s: %v", p.componentID, node.Node, err)
+			partial = true
+		}
+	}
+
+	status := "online"
+	if partial {
+		status = "degraded"
+	}
+	polledAt := now.Format(time.RFC3339Nano)
+	if err := store.InfraComponents.UpdateStatus(ctx, p.componentID, status, polledAt); err != nil {
+		log.Printf("proxmox poller %s: update status: %v", p.componentID, err)
+	}
+
+	return nil
+}
+
+func (p *ProxmoxPoller) pollNode(ctx context.Context, store *repo.Store, node string, now time.Time) error {
+	// ── Node status (CPU + memory) ────────────────────────────────────────────
+	var status proxmoxNodeStatus
+	if err := p.get(ctx, fmt.Sprintf("/api2/json/nodes/%s/status", node), &status); err != nil {
+		return fmt.Errorf("node status: %w", err)
+	}
+
+	cpuPercent := status.CPU * 100
+	var memPercent float64
+	if status.Memory.Total > 0 {
+		memPercent = (status.Memory.Used / status.Memory.Total) * 100
+	}
+
+	for _, m := range []struct {
+		metric string
+		value  float64
+	}{
+		{"cpu_percent", cpuPercent},
+		{"mem_percent", memPercent},
+	} {
+		reading := &models.ResourceReading{
+			ID:         uuid.New().String(),
+			SourceID:   p.componentID,
+			SourceType: "proxmox_node",
+			Metric:     m.metric,
+			Value:      m.value,
+			RecordedAt: now,
+		}
+		if err := store.Resources.Create(ctx, reading); err != nil {
+			log.Printf("proxmox poller %s: write %s: %v", p.componentID, m.metric, err)
+		}
+	}
+
+	// ── Storage (disk) ────────────────────────────────────────────────────────
+	var storages []proxmoxStorage
+	if err := p.get(ctx, fmt.Sprintf("/api2/json/nodes/%s/storage", node), &storages); err != nil {
+		return fmt.Errorf("node storage: %w", err)
+	}
+
+	var usedTotal, sizeTotal float64
+	for _, s := range storages {
+		if s.Active == 0 {
+			continue
+		}
+		usedTotal += s.Used
+		sizeTotal += s.Total
+	}
+	var diskPercent float64
+	if sizeTotal > 0 {
+		diskPercent = (usedTotal / sizeTotal) * 100
+	}
+	diskReading := &models.ResourceReading{
+		ID:         uuid.New().String(),
+		SourceID:   p.componentID,
+		SourceType: "proxmox_node",
+		Metric:     "disk_percent",
+		Value:      diskPercent,
+		RecordedAt: now,
+	}
+	if err := store.Resources.Create(ctx, diskReading); err != nil {
+		log.Printf("proxmox poller %s: write disk_percent: %v", p.componentID, err)
+	}
+
+	// ── VM inventory ──────────────────────────────────────────────────────────
+	var vms []proxmoxVM
+	if err := p.get(ctx, fmt.Sprintf("/api2/json/nodes/%s/qemu", node), &vms); err != nil {
+		log.Printf("proxmox poller %s: list qemu on %s: %v", p.componentID, node, err)
+	} else {
+		p.checkStateChanges(ctx, store, node, "VM", vms)
+	}
+
+	var ctrs []proxmoxVM
+	if err := p.get(ctx, fmt.Sprintf("/api2/json/nodes/%s/lxc", node), &ctrs); err != nil {
+		log.Printf("proxmox poller %s: list lxc on %s: %v", p.componentID, node, err)
+	} else {
+		p.checkStateChanges(ctx, store, node, "LXC", ctrs)
+	}
+
+	return nil
+}
+
+// checkStateChanges compares current VM/LXC statuses against the last known
+// state and fires events for running↔stopped transitions.
+func (p *ProxmoxPoller) checkStateChanges(ctx context.Context, store *repo.Store, node, kind string, vms []proxmoxVM) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for _, vm := range vms {
+		key := fmt.Sprintf("%s/%d", node, vm.VMID)
+		prev, seen := p.lastVMState[key]
+		p.lastVMState[key] = vm.Status
+
+		if !seen {
+			continue
+		}
+		if prev == vm.Status {
+			continue
+		}
+
+		// Fire events only on running↔stopped transitions.
+		if !((prev == "running" && vm.Status == "stopped") ||
+			(prev == "stopped" && vm.Status == "running")) {
+			continue
+		}
+
+		severity := "info"
+		if vm.Status == "stopped" {
+			severity = "warn"
+		}
+
+		rawPayload, _ := json.Marshal(vm)
+
+		event := &models.Event{
+			ID:          uuid.New().String(),
+			AppID:       "",
+			ReceivedAt:  time.Now().UTC(),
+			Severity:    severity,
+			DisplayText: fmt.Sprintf("%s %s is now %s on %s", kind, vm.Name, vm.Status, node),
+			RawPayload:  string(rawPayload),
+			Fields:      fmt.Sprintf(`{"source":"proxmox","node":%q,"vmid":%d,"kind":%q}`, node, vm.VMID, kind),
+		}
+		if err := store.Events.Create(ctx, event); err != nil {
+			log.Printf("proxmox poller %s: create state-change event for %s %s: %v",
+				p.componentID, kind, vm.Name, err)
+		}
+	}
+}

--- a/internal/infra/proxmox_test.go
+++ b/internal/infra/proxmox_test.go
@@ -1,0 +1,424 @@
+package infra
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/config"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/migrations"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func newProxmoxTestStore(t *testing.T) *repo.Store {
+	t.Helper()
+	cfg := &config.Config{DBPath: ":memory:", DevMode: true}
+	db, err := repo.Open(cfg, migrations.Files)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	return repo.NewStore(
+		repo.NewAppRepo(db),
+		repo.NewEventRepo(db),
+		repo.NewCheckRepo(db),
+		repo.NewRollupRepo(db),
+		repo.NewResourceReadingRepo(db),
+		repo.NewResourceRollupRepo(db),
+		repo.NewInfraComponentRepo(db),
+		repo.NewDockerEngineRepo(db),
+		repo.NewInfraRepo(db),
+		repo.NewSettingsRepo(db),
+		repo.NewMetricsRepo(db),
+		repo.NewUserRepo(db),
+	)
+}
+
+// createTestComponent inserts a minimal proxmox_node component with the given ID.
+func createTestComponent(t *testing.T, store *repo.Store, id string) {
+	t.Helper()
+	c := &models.InfrastructureComponent{
+		ID:               id,
+		Name:             "test-" + id,
+		Type:             "proxmox_node",
+		CollectionMethod: "proxmox_api",
+		Enabled:          true,
+		LastStatus:       "unknown",
+		CreatedAt:        "2026-01-01T00:00:00Z",
+	}
+	if err := store.InfraComponents.Create(context.Background(), c); err != nil {
+		t.Fatalf("create test component: %v", err)
+	}
+}
+
+// proxmoxFakeServer builds an httptest.Server that responds with the supplied
+// fixture data, keyed by node name.
+type proxmoxFakeServer struct {
+	nodes         []proxmoxNode
+	statusByNode  map[string]proxmoxNodeStatus
+	storageByNode map[string][]proxmoxStorage
+	qemuByNode    map[string][]proxmoxVM
+	lxcByNode     map[string][]proxmoxVM
+}
+
+func newFakeServer(t *testing.T) (*httptest.Server, *proxmoxFakeServer) {
+	t.Helper()
+	fs := &proxmoxFakeServer{
+		statusByNode:  make(map[string]proxmoxNodeStatus),
+		storageByNode: make(map[string][]proxmoxStorage),
+		qemuByNode:    make(map[string][]proxmoxVM),
+		lxcByNode:     make(map[string][]proxmoxVM),
+	}
+	srv := httptest.NewServer(http.HandlerFunc(fs.handle))
+	t.Cleanup(srv.Close)
+	return srv, fs
+}
+
+func (fs *proxmoxFakeServer) handle(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	respond := func(v any) {
+		b, _ := json.Marshal(map[string]any{"data": v})
+		w.Write(b) //nolint:errcheck
+	}
+
+	if r.URL.Path == "/api2/json/nodes" {
+		respond(fs.nodes)
+		return
+	}
+	for _, n := range fs.nodes {
+		base := "/api2/json/nodes/" + n.Node
+		switch r.URL.Path {
+		case base + "/status":
+			respond(fs.statusByNode[n.Node])
+			return
+		case base + "/storage":
+			respond(fs.storageByNode[n.Node])
+			return
+		case base + "/qemu":
+			respond(fs.qemuByNode[n.Node])
+			return
+		case base + "/lxc":
+			respond(fs.lxcByNode[n.Node])
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNotFound)
+}
+
+func makeCredentials(baseURL string) string {
+	b, _ := json.Marshal(ProxmoxCredentials{
+		BaseURL:     baseURL,
+		TokenID:     "nora@pam!token",
+		TokenSecret: "secret",
+		VerifyTLS:   true,
+	})
+	return string(b)
+}
+
+func defaultNodeStatus() proxmoxNodeStatus {
+	var ns proxmoxNodeStatus
+	ns.CPU = 0.25
+	ns.Memory.Used = 2e9
+	ns.Memory.Total = 8e9
+	return ns
+}
+
+func defaultStorage() []proxmoxStorage {
+	return []proxmoxStorage{{Storage: "local", Used: 50e9, Total: 200e9, Active: 1}}
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+func TestProxmoxPoller_NewPoller_InvalidJSON(t *testing.T) {
+	_, err := NewProxmoxPoller("id1", "not-json")
+	if err == nil {
+		t.Error("expected error for invalid credentials JSON, got nil")
+	}
+}
+
+func TestProxmoxPoller_Poll_WritesResourceReadingsAndSetsOnline(t *testing.T) {
+	srv, fs := newFakeServer(t)
+	fs.nodes = []proxmoxNode{{Node: "pve", Status: "online"}}
+	fs.statusByNode["pve"] = defaultNodeStatus()
+	fs.storageByNode["pve"] = defaultStorage()
+
+	ctx := context.Background()
+	store := newProxmoxTestStore(t)
+	compID := "comp-readings"
+	createTestComponent(t, store, compID)
+
+	poller, err := NewProxmoxPoller(compID, makeCredentials(srv.URL))
+	if err != nil {
+		t.Fatalf("NewProxmoxPoller: %v", err)
+	}
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	// Component should now be "online" with last_polled_at set.
+	comp, err := store.InfraComponents.Get(ctx, compID)
+	if err != nil {
+		t.Fatalf("Get component: %v", err)
+	}
+	if comp.LastStatus != "online" {
+		t.Errorf("last_status: got %q, want %q", comp.LastStatus, "online")
+	}
+	if comp.LastPolledAt == nil {
+		t.Error("last_polled_at should be set after a successful poll")
+	}
+
+	// Verify resource_readings via aggregation: 3 metrics (cpu, mem, disk) expected.
+	from := time.Now().UTC().Add(-time.Minute)
+	to := time.Now().UTC().Add(time.Minute)
+	aggs, err := store.ResourceRollups.AggregateReadings(ctx, from, to)
+	if err != nil {
+		t.Fatalf("AggregateReadings: %v", err)
+	}
+	metrics := make(map[string]bool)
+	for _, a := range aggs {
+		if a.SourceID == compID {
+			metrics[a.Metric] = true
+		}
+	}
+	for _, want := range []string{"cpu_percent", "mem_percent", "disk_percent"} {
+		if !metrics[want] {
+			t.Errorf("expected resource reading for metric %q, not found", want)
+		}
+	}
+}
+
+func TestProxmoxPoller_Poll_CPUMemValues(t *testing.T) {
+	srv, fs := newFakeServer(t)
+	fs.nodes = []proxmoxNode{{Node: "pve", Status: "online"}}
+
+	var ns proxmoxNodeStatus
+	ns.CPU = 0.50            // 50%
+	ns.Memory.Used = 4e9     // 4 GiB
+	ns.Memory.Total = 8e9    // 8 GiB → 50%
+	fs.statusByNode["pve"] = ns
+	fs.storageByNode["pve"] = []proxmoxStorage{{Storage: "local", Used: 100e9, Total: 200e9, Active: 1}} // 50%
+
+	ctx := context.Background()
+	store := newProxmoxTestStore(t)
+	compID := "comp-values"
+	createTestComponent(t, store, compID)
+
+	poller, _ := NewProxmoxPoller(compID, makeCredentials(srv.URL))
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	from := time.Now().UTC().Add(-time.Minute)
+	to := time.Now().UTC().Add(time.Minute)
+	aggs, _ := store.ResourceRollups.AggregateReadings(ctx, from, to)
+
+	for _, a := range aggs {
+		if a.SourceID != compID {
+			continue
+		}
+		// All three metrics should be ~50.
+		if a.Avg < 49 || a.Avg > 51 {
+			t.Errorf("metric %s: avg=%v, want ~50", a.Metric, a.Avg)
+		}
+	}
+}
+
+func TestProxmoxPoller_Poll_VMStoppedFiresWarnEvent(t *testing.T) {
+	srv, fs := newFakeServer(t)
+	fs.nodes = []proxmoxNode{{Node: "pve", Status: "online"}}
+	fs.statusByNode["pve"] = defaultNodeStatus()
+	fs.storageByNode["pve"] = defaultStorage()
+	fs.qemuByNode["pve"] = []proxmoxVM{{VMID: 100, Name: "ubuntu", Status: "running"}}
+
+	ctx := context.Background()
+	store := newProxmoxTestStore(t)
+	compID := "comp-vm-stop"
+	createTestComponent(t, store, compID)
+
+	poller, _ := NewProxmoxPoller(compID, makeCredentials(srv.URL))
+
+	// First poll: seeds state, no event.
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("first Poll: %v", err)
+	}
+
+	// VM transitions to stopped.
+	fs.qemuByNode["pve"] = []proxmoxVM{{VMID: 100, Name: "ubuntu", Status: "stopped"}}
+
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("second Poll: %v", err)
+	}
+
+	events, total, err := store.Events.List(ctx, repo.ListFilter{Limit: 50})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if total == 0 {
+		t.Fatal("expected at least one event, got none")
+	}
+	found := false
+	for _, ev := range events {
+		if ev.Severity == "warn" && ev.DisplayText == "VM ubuntu is now stopped on pve" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warn event for VM ubuntu stopped; events: %v", events)
+	}
+}
+
+func TestProxmoxPoller_Poll_VMStartedFiresInfoEvent(t *testing.T) {
+	srv, fs := newFakeServer(t)
+	fs.nodes = []proxmoxNode{{Node: "pve", Status: "online"}}
+	fs.statusByNode["pve"] = defaultNodeStatus()
+	fs.storageByNode["pve"] = defaultStorage()
+	fs.qemuByNode["pve"] = []proxmoxVM{{VMID: 101, Name: "win11", Status: "stopped"}}
+
+	ctx := context.Background()
+	store := newProxmoxTestStore(t)
+	compID := "comp-vm-start"
+	createTestComponent(t, store, compID)
+
+	poller, _ := NewProxmoxPoller(compID, makeCredentials(srv.URL))
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("first Poll: %v", err)
+	}
+
+	fs.qemuByNode["pve"] = []proxmoxVM{{VMID: 101, Name: "win11", Status: "running"}}
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("second Poll: %v", err)
+	}
+
+	events, _, _ := store.Events.List(ctx, repo.ListFilter{Limit: 50})
+	found := false
+	for _, ev := range events {
+		if ev.Severity == "info" && ev.DisplayText == "VM win11 is now running on pve" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected info event for VM win11 started; events: %v", events)
+	}
+}
+
+func TestProxmoxPoller_Poll_LXCStateChangeFiresEvent(t *testing.T) {
+	srv, fs := newFakeServer(t)
+	fs.nodes = []proxmoxNode{{Node: "pve", Status: "online"}}
+	fs.statusByNode["pve"] = defaultNodeStatus()
+	fs.storageByNode["pve"] = defaultStorage()
+	fs.lxcByNode["pve"] = []proxmoxVM{{VMID: 200, Name: "debian-ct", Status: "stopped"}}
+
+	ctx := context.Background()
+	store := newProxmoxTestStore(t)
+	compID := "comp-lxc"
+	createTestComponent(t, store, compID)
+
+	poller, _ := NewProxmoxPoller(compID, makeCredentials(srv.URL))
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("first Poll: %v", err)
+	}
+
+	fs.lxcByNode["pve"] = []proxmoxVM{{VMID: 200, Name: "debian-ct", Status: "running"}}
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("second Poll: %v", err)
+	}
+
+	events, _, _ := store.Events.List(ctx, repo.ListFilter{Limit: 50})
+	found := false
+	for _, ev := range events {
+		if ev.Severity == "info" && ev.DisplayText == "LXC debian-ct is now running on pve" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected info event for LXC debian-ct started; events: %v", events)
+	}
+}
+
+func TestProxmoxPoller_Poll_NoStateChangeNoEvent(t *testing.T) {
+	srv, fs := newFakeServer(t)
+	fs.nodes = []proxmoxNode{{Node: "pve", Status: "online"}}
+	fs.statusByNode["pve"] = defaultNodeStatus()
+	fs.storageByNode["pve"] = defaultStorage()
+	fs.qemuByNode["pve"] = []proxmoxVM{{VMID: 100, Name: "ubuntu", Status: "running"}}
+
+	ctx := context.Background()
+	store := newProxmoxTestStore(t)
+	compID := "comp-no-change"
+	createTestComponent(t, store, compID)
+
+	poller, _ := NewProxmoxPoller(compID, makeCredentials(srv.URL))
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("first Poll: %v", err)
+	}
+	// State unchanged on second poll.
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("second Poll: %v", err)
+	}
+
+	_, total, _ := store.Events.List(ctx, repo.ListFilter{Limit: 50})
+	if total != 0 {
+		t.Errorf("expected 0 events for no state change, got %d", total)
+	}
+}
+
+func TestProxmoxPoller_Poll_ConnectionRefused_ReturnsError(t *testing.T) {
+	creds := makeCredentials("http://127.0.0.1:1") // nothing listening
+
+	ctx := context.Background()
+	store := newProxmoxTestStore(t)
+	compID := "comp-offline"
+	createTestComponent(t, store, compID)
+
+	poller, err := NewProxmoxPoller(compID, creds)
+	if err != nil {
+		t.Fatalf("NewProxmoxPoller: %v", err)
+	}
+
+	pollErr := poller.Poll(ctx, store)
+	if pollErr == nil {
+		t.Error("expected error for unreachable host, got nil")
+	}
+	// Process should not have panicked. If we reach here, it didn't.
+}
+
+func TestProxmoxPoller_AuthHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[]}`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	creds, _ := json.Marshal(ProxmoxCredentials{
+		BaseURL:     srv.URL,
+		TokenID:     "nora@pam!mytoken",
+		TokenSecret: "abc123",
+		VerifyTLS:   true,
+	})
+
+	ctx := context.Background()
+	store := newProxmoxTestStore(t)
+	createTestComponent(t, store, "id-auth")
+
+	poller, err := NewProxmoxPoller("id-auth", string(creds))
+	if err != nil {
+		t.Fatalf("NewProxmoxPoller: %v", err)
+	}
+
+	// Poll — returns nil because there are no nodes; auth header is still captured.
+	_ = poller.Poll(ctx, store)
+
+	want := "PVEAPIToken=nora@pam!mytoken=abc123"
+	if gotAuth != want {
+		t.Errorf("Authorization header: got %q, want %q", gotAuth, want)
+	}
+}

--- a/internal/jobs/proxmox.go
+++ b/internal/jobs/proxmox.go
@@ -1,0 +1,69 @@
+package jobs
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/infra"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// RunProxmoxPollers iterates all enabled proxmox_node infrastructure components
+// and runs a poll cycle for each. Errors per-component are logged; the process
+// never crashes.
+func RunProxmoxPollers(ctx context.Context, store *repo.Store) {
+	components, err := store.InfraComponents.List(ctx)
+	if err != nil {
+		log.Printf("proxmox scheduler: list components: %v", err)
+		return
+	}
+
+	for _, c := range components {
+		if c.Type != "proxmox_node" || !c.Enabled {
+			continue
+		}
+		if c.Credentials == nil || *c.Credentials == "" {
+			log.Printf("proxmox scheduler: component %s (%s) has no credentials, skipping", c.Name, c.ID)
+			continue
+		}
+
+		poller, err := infra.NewProxmoxPoller(c.ID, *c.Credentials)
+		if err != nil {
+			log.Printf("proxmox scheduler: component %s (%s): invalid credentials: %v", c.Name, c.ID, err)
+			continue
+		}
+
+		log.Printf("proxmox scheduler: polling %s (%s)", c.Name, c.ID)
+		if err := poller.Poll(ctx, store); err != nil {
+			log.Printf("proxmox scheduler: poll %s (%s): %v", c.Name, c.ID, err)
+			// Connection failure → mark offline.
+			polledAt := time.Now().UTC().Format(time.RFC3339Nano)
+			if updateErr := store.InfraComponents.UpdateStatus(ctx, c.ID, "offline", polledAt); updateErr != nil {
+				log.Printf("proxmox scheduler: update status %s: %v", c.ID, updateErr)
+			}
+		} else {
+			log.Printf("proxmox scheduler: poll %s (%s): complete", c.Name, c.ID)
+		}
+	}
+}
+
+// StartProxmoxPollers runs RunProxmoxPollers immediately on startup and then
+// every 5 minutes until ctx is cancelled.
+func StartProxmoxPollers(ctx context.Context, store *repo.Store) {
+	log.Printf("proxmox scheduler: started (interval=5m)")
+	RunProxmoxPollers(ctx, store)
+
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("proxmox scheduler: stopped")
+			return
+		case <-ticker.C:
+			RunProxmoxPollers(ctx, store)
+		}
+	}
+}

--- a/internal/repo/infrastructure.go
+++ b/internal/repo/infrastructure.go
@@ -22,6 +22,8 @@ type InfraComponentRepo interface {
 	Create(ctx context.Context, c *models.InfrastructureComponent) error
 	Update(ctx context.Context, c *models.InfrastructureComponent) error
 	Delete(ctx context.Context, id string) error
+	// UpdateStatus sets last_polled_at and last_status without touching other fields.
+	UpdateStatus(ctx context.Context, id, status, lastPolledAt string) error
 }
 
 type sqliteInfraComponentRepo struct{ db *sqlx.DB }
@@ -105,6 +107,21 @@ func (r *sqliteInfraComponentRepo) Delete(ctx context.Context, id string) error 
 	res, err := r.db.ExecContext(ctx, `DELETE FROM infrastructure_components WHERE id = ?`, id)
 	if err != nil {
 		return fmt.Errorf("delete infrastructure_component: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sqliteInfraComponentRepo) UpdateStatus(ctx context.Context, id, status, lastPolledAt string) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE infrastructure_components
+		SET last_status = ?, last_polled_at = ?
+		WHERE id = ?`,
+		status, lastPolledAt, id)
+	if err != nil {
+		return fmt.Errorf("update component status: %w", err)
 	}
 	if n, _ := res.RowsAffected(); n == 0 {
 		return ErrNotFound

--- a/migrations/010_resource_readings_proxmox_type.sql
+++ b/migrations/010_resource_readings_proxmox_type.sql
@@ -1,0 +1,46 @@
+-- 010_resource_readings_proxmox_type.sql
+-- Extend source_type CHECK constraints in resource_readings and resource_rollups
+-- to include 'proxmox_node' and 'synology' (for future Synology poller).
+-- SQLite does not support ALTER COLUMN, so we recreate both tables.
+
+-- ── resource_readings ─────────────────────────────────────────────────────────
+
+CREATE TABLE resource_readings_new (
+    id          TEXT      PRIMARY KEY,
+    source_id   TEXT      NOT NULL,
+    source_type TEXT      NOT NULL CHECK (source_type IN (
+                              'docker_container', 'host', 'vm',
+                              'proxmox_node', 'synology'
+                          )),
+    metric      TEXT      NOT NULL,
+    value       REAL      NOT NULL,
+    recorded_at TIMESTAMP NOT NULL
+);
+
+INSERT INTO resource_readings_new SELECT * FROM resource_readings;
+DROP TABLE resource_readings;
+ALTER TABLE resource_readings_new RENAME TO resource_readings;
+
+CREATE INDEX IF NOT EXISTS idx_resource_readings_source      ON resource_readings(source_id, recorded_at);
+CREATE INDEX IF NOT EXISTS idx_resource_readings_recorded_at ON resource_readings(recorded_at);
+
+-- ── resource_rollups ──────────────────────────────────────────────────────────
+
+CREATE TABLE resource_rollups_new (
+    source_id    TEXT      NOT NULL,
+    source_type  TEXT      NOT NULL CHECK (source_type IN (
+                               'docker_container', 'host', 'vm',
+                               'proxmox_node', 'synology'
+                           )),
+    metric       TEXT      NOT NULL,
+    period_type  TEXT      NOT NULL CHECK (period_type IN ('hour', 'day')),
+    period_start TIMESTAMP NOT NULL,
+    avg          REAL      NOT NULL,
+    min          REAL      NOT NULL,
+    max          REAL      NOT NULL,
+    PRIMARY KEY (source_id, metric, period_type, period_start)
+);
+
+INSERT INTO resource_rollups_new SELECT * FROM resource_rollups;
+DROP TABLE resource_rollups;
+ALTER TABLE resource_rollups_new RENAME TO resource_rollups;


### PR DESCRIPTION
## What
Builds the Proxmox VE API poller that authenticates with token auth, polls all nodes in a cluster every 5 minutes, and writes CPU/memory/disk resource readings. Fires events on VM and LXC state changes (running↔stopped).

## Why
Closes #85 (Infra-2). Depends on Infra-1 (infrastructure_components table).

## How
- **`internal/infra/proxmox.go`** — `ProxmoxPoller` struct with token-based auth (`PVEAPIToken={id}={secret}`). Logs a warning when `verify_tls=false` and configures `InsecureSkipVerify`. Poll cycle: `GET /nodes` → per-node status + storage + qemu + lxc. Disk % is computed by summing active storage volumes. VM/LXC state changes (running↔stopped) trigger events with `severity=warn` (stopped) or `info` (started). First poll seeds the state map; events only fire on subsequent transitions.
- **`internal/jobs/proxmox.go`** — `StartProxmoxPollers` / `RunProxmoxPollers`: iterates enabled `proxmox_node` components, creates a poller per component, runs the poll cycle. Connection failures mark the component `offline`; partial node failures mark it `degraded`; full success marks `online`. Never crashes — errors logged only.
- **`internal/repo/infrastructure.go`** — added `UpdateStatus(ctx, id, status, lastPolledAt)` to `InfraComponentRepo` interface and `sqliteInfraComponentRepo`. Lets the poller update `last_polled_at` + `last_status` without touching credentials or other config fields.
- **`internal/api/infra_components.go`** — fixed `GetResources` to query rollups using the component's actual `type` as `source_type` (was hardcoded `"host"`). Updated response shape to match spec: `component_id`, `period`, `cpu_percent`, `mem_percent`, `disk_percent`, `recorded_at`, `no_data`.
- **`migrations/010_resource_readings_proxmox_type.sql`** — extends the `source_type` CHECK constraint in `resource_readings` and `resource_rollups` to include `proxmox_node` and `synology` (future Synology poller). Recreates both tables (SQLite doesn't support ALTER COLUMN).
- **`cmd/nora/main.go`** — wires `StartProxmoxPollers` as a goroutine on startup with its own context.

## Test coverage
- 9 tests in `internal/infra/proxmox_test.go` using `httptest.Server` mocks:
  - Invalid credentials JSON returns error
  - Successful poll writes cpu/mem/disk readings and sets `last_status=online`
  - CPU/mem/disk values computed correctly (0.50 cpu → 50%, etc.)
  - VM stopped → `warn` event; VM started → `info` event
  - LXC state change fires event
  - No state change → no event
  - Connection refused → returns error (no panic)
  - `Authorization` header is `PVEAPIToken={id}={secret}`
- `go test ./...` passes, `go vet ./...` clean, `npm run build` succeeds

## Closes
Closes #85