### PR TITLE
feat: Synology DSM API poller (Infra-3)

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -102,6 +102,11 @@ func main() {
 	defer proxmoxCancel()
 	go jobs.StartProxmoxPollers(proxmoxCtx, store)
 
+	// Synology pollers — polls all enabled synology components every 5 minutes.
+	synologyCtx, synologyCancel := context.WithCancel(context.Background())
+	defer synologyCancel()
+	go jobs.StartSynologyPollers(synologyCtx, store)
+
 	// Docker socket watcher and resource poller — optional; skipped if the socket is not available.
 	dockerCtx, dockerCancel := context.WithCancel(context.Background())
 	defer dockerCancel()

--- a/internal/infra/synology.go
+++ b/internal/infra/synology.go
@@ -1,0 +1,437 @@
+package infra
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+// SynologyCredentials is the JSON shape stored in infrastructure_components.credentials.
+type SynologyCredentials struct {
+	BaseURL   string `json:"base_url"`
+	Username  string `json:"username"`
+	Password  string `json:"password"`
+	VerifyTLS bool   `json:"verify_tls"`
+}
+
+// SynologyPoller polls a single Synology DSM instance, writing resource_readings
+// and generating events for degraded disk health. The session ID is reused across
+// poll cycles; a re-login occurs automatically on session expiry (error code 119).
+type SynologyPoller struct {
+	componentID string
+	creds       SynologyCredentials
+	client      *http.Client
+
+	mu  sync.Mutex
+	sid string // empty means not yet authenticated
+}
+
+// NewSynologyPoller creates a SynologyPoller from a component ID and credentials JSON.
+func NewSynologyPoller(componentID, credJSON string) (*SynologyPoller, error) {
+	var creds SynologyCredentials
+	if err := json.Unmarshal([]byte(credJSON), &creds); err != nil {
+		return nil, fmt.Errorf("parse synology credentials: %w", err)
+	}
+
+	transport := &http.Transport{}
+	if !creds.VerifyTLS {
+		log.Printf("synology poller %s: TLS verification disabled (verify_tls=false)", componentID)
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	}
+
+	return &SynologyPoller{
+		componentID: componentID,
+		creds:       creds,
+		client: &http.Client{
+			Transport: transport,
+			Timeout:   15 * time.Second,
+		},
+	}, nil
+}
+
+// ── API response shapes ───────────────────────────────────────────────────────
+
+type synoEnvelope struct {
+	Success bool            `json:"success"`
+	Data    json.RawMessage `json:"data"`
+	Error   *synoAPIError   `json:"error,omitempty"`
+}
+
+type synoAPIError struct {
+	Code int `json:"code"`
+}
+
+type synoAuthData struct {
+	SID string `json:"sid"`
+}
+
+type synoSystemInfo struct {
+	CPUUserLoad float64 `json:"cpu_user_load"`
+	RAMTotal    float64 `json:"ram_total"`
+	RAMUsed     float64 `json:"ram_used"`
+}
+
+type synoStorageData struct {
+	Volumes []synoVolume `json:"volumes"`
+}
+
+// synoVolume holds per-volume storage info. DSM returns byte counts as decimal
+// strings (e.g. "1073741824000") to avoid JSON integer-overflow on large arrays.
+type synoVolume struct {
+	VolPath       string `json:"vol_path"`
+	SizeTotalByte string `json:"size_total_byte"`
+	SizeUsedByte  string `json:"size_used_byte"`
+}
+
+type synoDiskHealthData struct {
+	Disks []synoDisk `json:"disks"`
+}
+
+type synoDisk struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+// ── Authentication ────────────────────────────────────────────────────────────
+
+// login authenticates with DSM and stores the returned session ID.
+func (p *SynologyPoller) login(ctx context.Context) error {
+	u, err := url.Parse(p.creds.BaseURL + "/webapi/auth.cgi")
+	if err != nil {
+		return fmt.Errorf("parse base URL: %w", err)
+	}
+	q := url.Values{}
+	q.Set("api", "SYNO.API.Auth")
+	q.Set("version", "3")
+	q.Set("method", "login")
+	q.Set("account", p.creds.Username)
+	q.Set("passwd", p.creds.Password)
+	q.Set("session", "NORA")
+	q.Set("format", "cookie")
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("build login request: %w", err)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("login request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var env synoEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return fmt.Errorf("decode login response: %w", err)
+	}
+	if !env.Success {
+		code := 0
+		if env.Error != nil {
+			code = env.Error.Code
+		}
+		return fmt.Errorf("login failed (error code %d)", code)
+	}
+
+	var authData synoAuthData
+	if err := json.Unmarshal(env.Data, &authData); err != nil {
+		return fmt.Errorf("decode auth data: %w", err)
+	}
+	if authData.SID == "" {
+		return fmt.Errorf("login returned empty session ID")
+	}
+
+	p.mu.Lock()
+	p.sid = authData.SID
+	p.mu.Unlock()
+	return nil
+}
+
+// Shutdown logs out of the active DSM session. Call this when stopping the poller.
+func (p *SynologyPoller) Shutdown(ctx context.Context) {
+	p.mu.Lock()
+	sid := p.sid
+	p.mu.Unlock()
+	if sid == "" {
+		return
+	}
+
+	u, err := url.Parse(p.creds.BaseURL + "/webapi/auth.cgi")
+	if err != nil {
+		log.Printf("synology poller %s: logout: parse URL: %v", p.componentID, err)
+		return
+	}
+	q := url.Values{}
+	q.Set("api", "SYNO.API.Auth")
+	q.Set("version", "3")
+	q.Set("method", "logout")
+	q.Set("session", "NORA")
+	q.Set("_sid", sid)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		log.Printf("synology poller %s: logout: build request: %v", p.componentID, err)
+		return
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		log.Printf("synology poller %s: logout: %v", p.componentID, err)
+		return
+	}
+	resp.Body.Close()
+	log.Printf("synology poller %s: logged out", p.componentID)
+}
+
+// ── HTTP helper ───────────────────────────────────────────────────────────────
+
+// get performs an authenticated GET to entry.cgi and decodes the response data
+// into out. It automatically re-authenticates once on session expiry (code 119).
+func (p *SynologyPoller) get(ctx context.Context, params url.Values, out interface{}) error {
+	p.mu.Lock()
+	sid := p.sid
+	p.mu.Unlock()
+
+	if sid == "" {
+		if err := p.login(ctx); err != nil {
+			return fmt.Errorf("authenticate: %w", err)
+		}
+		p.mu.Lock()
+		sid = p.sid
+		p.mu.Unlock()
+	}
+
+	env, err := p.doGet(ctx, sid, params)
+	if err != nil {
+		return err
+	}
+
+	// Re-authenticate on session expiry and retry once.
+	if !env.Success && env.Error != nil && env.Error.Code == 119 {
+		log.Printf("synology poller %s: session expired, re-authenticating", p.componentID)
+		if authErr := p.login(ctx); authErr != nil {
+			return fmt.Errorf("re-authenticate: %w", authErr)
+		}
+		p.mu.Lock()
+		sid = p.sid
+		p.mu.Unlock()
+
+		env, err = p.doGet(ctx, sid, params)
+		if err != nil {
+			return err
+		}
+	}
+
+	if !env.Success {
+		code := 0
+		if env.Error != nil {
+			code = env.Error.Code
+		}
+		return fmt.Errorf("API call failed (error code %d)", code)
+	}
+
+	return json.Unmarshal(env.Data, out)
+}
+
+func (p *SynologyPoller) doGet(ctx context.Context, sid string, params url.Values) (*synoEnvelope, error) {
+	u, err := url.Parse(p.creds.BaseURL + "/webapi/entry.cgi")
+	if err != nil {
+		return nil, fmt.Errorf("parse entry URL: %w", err)
+	}
+	params.Set("_sid", sid)
+	u.RawQuery = params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET entry.cgi: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var env synoEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &env, nil
+}
+
+// ── Poll ──────────────────────────────────────────────────────────────────────
+
+// Poll runs one full cycle: system resources, volume usage, and disk health.
+// Returns an error if the system-resources call fails (indicating the host is
+// unreachable). Partial failures on subsequent calls set status="degraded".
+func (p *SynologyPoller) Poll(ctx context.Context, store *repo.Store) error {
+	now := time.Now().UTC()
+
+	// System resources is the primary reachability test.
+	if err := p.pollSystemResources(ctx, store, now); err != nil {
+		return fmt.Errorf("system resources: %w", err)
+	}
+
+	degraded := false
+
+	if err := p.pollVolumeUsage(ctx, store, now); err != nil {
+		log.Printf("synology poller %s: volume usage: %v", p.componentID, err)
+		degraded = true
+	}
+
+	diskDegraded, err := p.pollDiskHealth(ctx, store, now)
+	if err != nil {
+		log.Printf("synology poller %s: disk health: %v", p.componentID, err)
+		degraded = true
+	}
+
+	status := "online"
+	if degraded || diskDegraded {
+		status = "degraded"
+	}
+	polledAt := now.Format(time.RFC3339Nano)
+	if err := store.InfraComponents.UpdateStatus(ctx, p.componentID, status, polledAt); err != nil {
+		log.Printf("synology poller %s: update status: %v", p.componentID, err)
+	}
+	return nil
+}
+
+func (p *SynologyPoller) pollSystemResources(ctx context.Context, store *repo.Store, now time.Time) error {
+	params := url.Values{}
+	params.Set("api", "SYNO.Core.System")
+	params.Set("version", "1")
+	params.Set("method", "info")
+
+	var info synoSystemInfo
+	if err := p.get(ctx, params, &info); err != nil {
+		return err
+	}
+
+	var memPercent float64
+	if info.RAMTotal > 0 {
+		memPercent = (info.RAMUsed / info.RAMTotal) * 100
+	}
+
+	for _, m := range []struct {
+		metric string
+		value  float64
+	}{
+		{"cpu_percent", info.CPUUserLoad},
+		{"mem_percent", memPercent},
+	} {
+		reading := &models.ResourceReading{
+			ID:         uuid.New().String(),
+			SourceID:   p.componentID,
+			SourceType: "synology",
+			Metric:     m.metric,
+			Value:      m.value,
+			RecordedAt: now,
+		}
+		if err := store.Resources.Create(ctx, reading); err != nil {
+			log.Printf("synology poller %s: write %s: %v", p.componentID, m.metric, err)
+		}
+	}
+	return nil
+}
+
+func (p *SynologyPoller) pollVolumeUsage(ctx context.Context, store *repo.Store, now time.Time) error {
+	params := url.Values{}
+	params.Set("api", "SYNO.Storage.CGI.Storage")
+	params.Set("version", "1")
+	params.Set("method", "load_info")
+
+	var storageData synoStorageData
+	if err := p.get(ctx, params, &storageData); err != nil {
+		return err
+	}
+
+	for _, vol := range storageData.Volumes {
+		total, err := strconv.ParseInt(vol.SizeTotalByte, 10, 64)
+		if err != nil || total == 0 {
+			continue
+		}
+		used, err := strconv.ParseInt(vol.SizeUsedByte, 10, 64)
+		if err != nil {
+			continue
+		}
+
+		diskPercent := (float64(used) / float64(total)) * 100
+		// Sanitise vol_path to a metric-safe key: "/volume1" → "volume1".
+		volKey := strings.TrimLeft(vol.VolPath, "/")
+		if volKey == "" {
+			volKey = "unknown"
+		}
+
+		reading := &models.ResourceReading{
+			ID:         uuid.New().String(),
+			SourceID:   p.componentID,
+			SourceType: "synology",
+			Metric:     "disk_percent_" + volKey,
+			Value:      diskPercent,
+			RecordedAt: now,
+		}
+		if err := store.Resources.Create(ctx, reading); err != nil {
+			log.Printf("synology poller %s: write disk_percent_%s: %v", p.componentID, volKey, err)
+		}
+	}
+	return nil
+}
+
+// pollDiskHealth checks disk status and fires events for non-normal disks.
+// Returns (degraded, error) — degraded is true if any disk is not "normal".
+func (p *SynologyPoller) pollDiskHealth(ctx context.Context, store *repo.Store, now time.Time) (bool, error) {
+	params := url.Values{}
+	params.Set("api", "SYNO.Storage.CGI.DiskHealth")
+	params.Set("version", "1")
+	params.Set("method", "load_info")
+
+	var healthData synoDiskHealthData
+	if err := p.get(ctx, params, &healthData); err != nil {
+		return false, err
+	}
+
+	degraded := false
+	for _, disk := range healthData.Disks {
+		if disk.Status == "normal" {
+			continue
+		}
+		degraded = true
+
+		severity := "warn"
+		if disk.Status == "critical" || disk.Status == "failing" {
+			severity = "error"
+		}
+
+		rawPayload, _ := json.Marshal(disk)
+		event := &models.Event{
+			ID:          uuid.New().String(),
+			AppID:       "",
+			ReceivedAt:  now,
+			Severity:    severity,
+			DisplayText: fmt.Sprintf("Synology disk %s status: %s", disk.ID, disk.Status),
+			RawPayload:  string(rawPayload),
+			Fields:      fmt.Sprintf(`{"source":"synology","disk_id":%q,"status":%q}`, disk.ID, disk.Status),
+		}
+		if err := store.Events.Create(ctx, event); err != nil {
+			log.Printf("synology poller %s: create disk health event for %s: %v",
+				p.componentID, disk.ID, err)
+		}
+	}
+	return degraded, nil
+}

--- a/internal/infra/synology_test.go
+++ b/internal/infra/synology_test.go
@@ -1,0 +1,506 @@
+package infra
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/config"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/migrations"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func newSynologyTestStore(t *testing.T) *repo.Store {
+	t.Helper()
+	cfg := &config.Config{DBPath: ":memory:", DevMode: true}
+	db, err := repo.Open(cfg, migrations.Files)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	return repo.NewStore(
+		repo.NewAppRepo(db),
+		repo.NewEventRepo(db),
+		repo.NewCheckRepo(db),
+		repo.NewRollupRepo(db),
+		repo.NewResourceReadingRepo(db),
+		repo.NewResourceRollupRepo(db),
+		repo.NewInfraComponentRepo(db),
+		repo.NewDockerEngineRepo(db),
+		repo.NewInfraRepo(db),
+		repo.NewSettingsRepo(db),
+		repo.NewMetricsRepo(db),
+		repo.NewUserRepo(db),
+	)
+}
+
+func createSynologyTestComponent(t *testing.T, store *repo.Store, id string) {
+	t.Helper()
+	c := &models.InfrastructureComponent{
+		ID:               id,
+		Name:             "syn-" + id,
+		Type:             "synology",
+		CollectionMethod: "synology_api",
+		Enabled:          true,
+		LastStatus:       "unknown",
+		CreatedAt:        "2026-01-01T00:00:00Z",
+	}
+	if err := store.InfraComponents.Create(context.Background(), c); err != nil {
+		t.Fatalf("create synology test component: %v", err)
+	}
+}
+
+// synologyFakeServer handles DSM API requests.
+type synologyFakeServer struct {
+	sidToReturn     string
+	loginShouldFail bool
+
+	// expireFirstN causes the first N entry.cgi calls to return code 119.
+	expireFirstN int
+	callCount    int
+
+	systemInfo synoSystemInfo
+	volumes    []synoVolume
+	disks      []synoDisk
+}
+
+func newSynologyFakeServer(t *testing.T) (*httptest.Server, *synologyFakeServer) {
+	t.Helper()
+	fs := &synologyFakeServer{
+		sidToReturn: "test-session-id",
+		systemInfo: synoSystemInfo{
+			CPUUserLoad: 25.0,
+			RAMTotal:    8192,
+			RAMUsed:     4096,
+		},
+		volumes: []synoVolume{
+			{VolPath: "/volume1", SizeTotalByte: "1000000000", SizeUsedByte: "500000000"},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(fs.handle))
+	t.Cleanup(srv.Close)
+	return srv, fs
+}
+
+func (fs *synologyFakeServer) ok(w http.ResponseWriter, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	b, _ := json.Marshal(map[string]interface{}{"success": true, "data": data})
+	w.Write(b) //nolint:errcheck
+}
+
+func (fs *synologyFakeServer) apiError(w http.ResponseWriter, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	b, _ := json.Marshal(map[string]interface{}{
+		"success": false,
+		"error":   map[string]interface{}{"code": code},
+	})
+	w.Write(b) //nolint:errcheck
+}
+
+func (fs *synologyFakeServer) handle(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	if r.URL.Path == "/webapi/auth.cgi" {
+		switch q.Get("method") {
+		case "login":
+			if fs.loginShouldFail {
+				fs.apiError(w, 400)
+				return
+			}
+			fs.ok(w, map[string]string{"sid": fs.sidToReturn})
+		case "logout":
+			fs.ok(w, nil)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+		return
+	}
+
+	if r.URL.Path == "/webapi/entry.cgi" {
+		// Simulate session expiry on the first N calls.
+		if fs.expireFirstN > 0 && fs.callCount < fs.expireFirstN {
+			fs.callCount++
+			fs.apiError(w, 119)
+			return
+		}
+		fs.callCount++
+
+		switch q.Get("api") {
+		case "SYNO.Core.System":
+			fs.ok(w, fs.systemInfo)
+		case "SYNO.Storage.CGI.Storage":
+			fs.ok(w, map[string]interface{}{"volumes": fs.volumes})
+		case "SYNO.Storage.CGI.DiskHealth":
+			fs.ok(w, map[string]interface{}{"disks": fs.disks})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusNotFound)
+}
+
+func makeSynologyCredentials(baseURL string) string {
+	b, _ := json.Marshal(SynologyCredentials{
+		BaseURL:   baseURL,
+		Username:  "nora",
+		Password:  "secret",
+		VerifyTLS: true,
+	})
+	return string(b)
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+func TestSynologyPoller_NewPoller_InvalidJSON(t *testing.T) {
+	_, err := NewSynologyPoller("id1", "not-json")
+	if err == nil {
+		t.Error("expected error for invalid credentials JSON, got nil")
+	}
+}
+
+func TestSynologyPoller_Poll_WritesResourceReadingsAndSetsOnline(t *testing.T) {
+	srv, _ := newSynologyFakeServer(t)
+
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-readings"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, err := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
+	if err != nil {
+		t.Fatalf("NewSynologyPoller: %v", err)
+	}
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	comp, err := store.InfraComponents.Get(ctx, compID)
+	if err != nil {
+		t.Fatalf("Get component: %v", err)
+	}
+	if comp.LastStatus != "online" {
+		t.Errorf("last_status: got %q, want %q", comp.LastStatus, "online")
+	}
+	if comp.LastPolledAt == nil {
+		t.Error("last_polled_at should be set after a successful poll")
+	}
+
+	from := time.Now().UTC().Add(-time.Minute)
+	to := time.Now().UTC().Add(time.Minute)
+	aggs, err := store.ResourceRollups.AggregateReadings(ctx, from, to)
+	if err != nil {
+		t.Fatalf("AggregateReadings: %v", err)
+	}
+	metrics := make(map[string]bool)
+	for _, a := range aggs {
+		if a.SourceID == compID {
+			metrics[a.Metric] = true
+		}
+	}
+	for _, want := range []string{"cpu_percent", "mem_percent", "disk_percent_volume1"} {
+		if !metrics[want] {
+			t.Errorf("expected resource reading for metric %q, not found", want)
+		}
+	}
+}
+
+func TestSynologyPoller_Poll_CPUMemValues(t *testing.T) {
+	srv, fs := newSynologyFakeServer(t)
+	fs.systemInfo = synoSystemInfo{
+		CPUUserLoad: 50.0,
+		RAMTotal:    8192,
+		RAMUsed:     4096, // 50%
+	}
+	fs.volumes = []synoVolume{
+		{VolPath: "/volume1", SizeTotalByte: "1000000000", SizeUsedByte: "500000000"}, // 50%
+	}
+
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-values"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, _ := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	from := time.Now().UTC().Add(-time.Minute)
+	to := time.Now().UTC().Add(time.Minute)
+	aggs, _ := store.ResourceRollups.AggregateReadings(ctx, from, to)
+
+	for _, a := range aggs {
+		if a.SourceID != compID {
+			continue
+		}
+		if a.Avg < 49 || a.Avg > 51 {
+			t.Errorf("metric %s: avg=%v, want ~50", a.Metric, a.Avg)
+		}
+	}
+}
+
+func TestSynologyPoller_Poll_MultipleVolumes(t *testing.T) {
+	srv, fs := newSynologyFakeServer(t)
+	fs.volumes = []synoVolume{
+		{VolPath: "/volume1", SizeTotalByte: "1000000000", SizeUsedByte: "250000000"},  // 25%
+		{VolPath: "/volume2", SizeTotalByte: "2000000000", SizeUsedByte: "1000000000"}, // 50%
+	}
+
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-multivol"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, _ := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	from := time.Now().UTC().Add(-time.Minute)
+	to := time.Now().UTC().Add(time.Minute)
+	aggs, _ := store.ResourceRollups.AggregateReadings(ctx, from, to)
+
+	metrics := make(map[string]float64)
+	for _, a := range aggs {
+		if a.SourceID == compID {
+			metrics[a.Metric] = a.Avg
+		}
+	}
+	if _, ok := metrics["disk_percent_volume1"]; !ok {
+		t.Error("expected disk_percent_volume1 reading")
+	}
+	if _, ok := metrics["disk_percent_volume2"]; !ok {
+		t.Error("expected disk_percent_volume2 reading")
+	}
+}
+
+func TestSynologyPoller_Poll_DiskWarningFiresWarnEvent(t *testing.T) {
+	srv, fs := newSynologyFakeServer(t)
+	fs.disks = []synoDisk{{ID: "sda", Status: "warning"}}
+
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-disk-warn"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, _ := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	comp, _ := store.InfraComponents.Get(ctx, compID)
+	if comp.LastStatus != "degraded" {
+		t.Errorf("last_status: got %q, want \"degraded\"", comp.LastStatus)
+	}
+
+	events, total, err := store.Events.List(ctx, repo.ListFilter{Limit: 50})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if total == 0 {
+		t.Fatal("expected at least one event, got none")
+	}
+	found := false
+	for _, ev := range events {
+		if ev.Severity == "warn" && ev.DisplayText == "Synology disk sda status: warning" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warn event for sda warning; events: %v", events)
+	}
+}
+
+func TestSynologyPoller_Poll_DiskCriticalFiresErrorEvent(t *testing.T) {
+	srv, fs := newSynologyFakeServer(t)
+	fs.disks = []synoDisk{{ID: "sdb", Status: "critical"}}
+
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-disk-crit"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, _ := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	events, _, _ := store.Events.List(ctx, repo.ListFilter{Limit: 50})
+	found := false
+	for _, ev := range events {
+		if ev.Severity == "error" && ev.DisplayText == "Synology disk sdb status: critical" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error event for sdb critical; events: %v", events)
+	}
+}
+
+func TestSynologyPoller_Poll_DiskFailingFiresErrorEvent(t *testing.T) {
+	srv, fs := newSynologyFakeServer(t)
+	fs.disks = []synoDisk{{ID: "sdc", Status: "failing"}}
+
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-disk-fail"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, _ := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	events, _, _ := store.Events.List(ctx, repo.ListFilter{Limit: 50})
+	found := false
+	for _, ev := range events {
+		if ev.Severity == "error" && ev.DisplayText == "Synology disk sdc status: failing" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error event for sdc failing; events: %v", events)
+	}
+}
+
+func TestSynologyPoller_Poll_AllDisksNormal_NoEvent(t *testing.T) {
+	srv, fs := newSynologyFakeServer(t)
+	fs.disks = []synoDisk{
+		{ID: "sda", Status: "normal"},
+		{ID: "sdb", Status: "normal"},
+	}
+
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-disk-ok"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, _ := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	_, total, _ := store.Events.List(ctx, repo.ListFilter{Limit: 50})
+	if total != 0 {
+		t.Errorf("expected 0 events for normal disks, got %d", total)
+	}
+
+	comp, _ := store.InfraComponents.Get(ctx, compID)
+	if comp.LastStatus != "online" {
+		t.Errorf("last_status: got %q, want \"online\"", comp.LastStatus)
+	}
+}
+
+func TestSynologyPoller_Poll_SessionExpiryTriggersReauth(t *testing.T) {
+	srv, fs := newSynologyFakeServer(t)
+	// First entry.cgi call returns session-expired; poller should re-auth and retry.
+	fs.expireFirstN = 1
+
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-reauth"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, _ := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll after session expiry: %v", err)
+	}
+
+	comp, _ := store.InfraComponents.Get(ctx, compID)
+	if comp.LastStatus != "online" {
+		t.Errorf("last_status after reauth: got %q, want \"online\"", comp.LastStatus)
+	}
+}
+
+func TestSynologyPoller_Poll_SessionReusedAcrossCycles(t *testing.T) {
+	loginCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/webapi/auth.cgi" && q.Get("method") == "login" {
+			loginCount++
+			b, _ := json.Marshal(map[string]interface{}{
+				"success": true,
+				"data":    map[string]string{"sid": "reused-sid"},
+			})
+			w.Write(b) //nolint:errcheck
+			return
+		}
+
+		if r.URL.Path == "/webapi/entry.cgi" {
+			var data interface{}
+			switch q.Get("api") {
+			case "SYNO.Core.System":
+				data = synoSystemInfo{CPUUserLoad: 10, RAMTotal: 1024, RAMUsed: 512}
+			case "SYNO.Storage.CGI.Storage":
+				data = map[string]interface{}{"volumes": []interface{}{}}
+			case "SYNO.Storage.CGI.DiskHealth":
+				data = map[string]interface{}{"disks": []interface{}{}}
+			}
+			b, _ := json.Marshal(map[string]interface{}{"success": true, "data": data})
+			w.Write(b) //nolint:errcheck
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-session-reuse"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, _ := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
+
+	// Two poll cycles — login should only be called once.
+	for i := 0; i < 2; i++ {
+		if err := poller.Poll(ctx, store); err != nil {
+			t.Fatalf("Poll cycle %d: %v", i+1, err)
+		}
+	}
+
+	if loginCount != 1 {
+		t.Errorf("login called %d times across 2 poll cycles, want 1", loginCount)
+	}
+}
+
+func TestSynologyPoller_Poll_LoginFailure_ReturnsError(t *testing.T) {
+	srv, fs := newSynologyFakeServer(t)
+	fs.loginShouldFail = true
+
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-login-fail"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, _ := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
+	if err := poller.Poll(ctx, store); err == nil {
+		t.Error("expected error when login fails, got nil")
+	}
+}
+
+func TestSynologyPoller_Poll_ConnectionRefused_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-offline"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, err := NewSynologyPoller(compID, makeSynologyCredentials("http://127.0.0.1:1"))
+	if err != nil {
+		t.Fatalf("NewSynologyPoller: %v", err)
+	}
+	if err := poller.Poll(ctx, store); err == nil {
+		t.Error("expected error for unreachable host, got nil")
+	}
+}

--- a/internal/jobs/synology.go
+++ b/internal/jobs/synology.go
@@ -1,0 +1,81 @@
+package jobs
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/infra"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// RunSynologyPollers iterates all enabled synology infrastructure components,
+// reusing existing poller instances (and their sessions) across calls.
+// Errors per-component are logged; the process never crashes.
+func RunSynologyPollers(ctx context.Context, store *repo.Store, pollers map[string]*infra.SynologyPoller) {
+	components, err := store.InfraComponents.List(ctx)
+	if err != nil {
+		log.Printf("synology scheduler: list components: %v", err)
+		return
+	}
+
+	for _, c := range components {
+		if c.Type != "synology" || !c.Enabled {
+			continue
+		}
+		if c.Credentials == nil || *c.Credentials == "" {
+			log.Printf("synology scheduler: component %s (%s) has no credentials, skipping", c.Name, c.ID)
+			continue
+		}
+
+		// Get or create the poller for this component.
+		poller, ok := pollers[c.ID]
+		if !ok {
+			var newErr error
+			poller, newErr = infra.NewSynologyPoller(c.ID, *c.Credentials)
+			if newErr != nil {
+				log.Printf("synology scheduler: component %s (%s): invalid credentials: %v", c.Name, c.ID, newErr)
+				continue
+			}
+			pollers[c.ID] = poller
+		}
+
+		log.Printf("synology scheduler: polling %s (%s)", c.Name, c.ID)
+		if err := poller.Poll(ctx, store); err != nil {
+			log.Printf("synology scheduler: poll %s (%s): %v", c.Name, c.ID, err)
+			// Connection failure → mark offline.
+			polledAt := time.Now().UTC().Format(time.RFC3339Nano)
+			if updateErr := store.InfraComponents.UpdateStatus(ctx, c.ID, "offline", polledAt); updateErr != nil {
+				log.Printf("synology scheduler: update status %s: %v", c.ID, updateErr)
+			}
+		} else {
+			log.Printf("synology scheduler: poll %s (%s): complete", c.Name, c.ID)
+		}
+	}
+}
+
+// StartSynologyPollers runs RunSynologyPollers immediately on startup and then
+// every 5 minutes until ctx is cancelled. Poller instances are retained across
+// ticks so sessions are reused. All pollers are logged out on shutdown.
+func StartSynologyPollers(ctx context.Context, store *repo.Store) {
+	pollers := make(map[string]*infra.SynologyPoller)
+
+	log.Printf("synology scheduler: started (interval=5m)")
+	RunSynologyPollers(ctx, store, pollers)
+
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("synology scheduler: stopped, logging out sessions")
+			for _, p := range pollers {
+				p.Shutdown(context.Background())
+			}
+			return
+		case <-ticker.C:
+			RunSynologyPollers(ctx, store, pollers)
+		}
+	}
+}


### PR DESCRIPTION
## What
Adds the Synology DSM API poller — session-based auth, CPU/mem/volume metrics, and disk health events.

## Why
Closes #86 (Infra-3). Depends on Infra-1 (infrastructure_components schema) and Infra-2 (poller pattern).

## How
- `internal/infra/synology.go` — `SynologyPoller` struct with login/logout, `get()` with automatic session-expiry retry (error code 119), and three poll sub-methods
- `internal/jobs/synology.go` — `StartSynologyPollers` maintains a `map[string]*SynologyPoller` so sessions are reused across ticks; logs out all pollers on shutdown
- `cmd/nora/main.go` — starts Synology scheduler goroutine alongside Proxmox
- Volume byte sizes handled as decimal strings (DSM returns them this way to avoid int overflow); sanitised to `disk_percent_{vol}` metric names
- Poll returns error only on system-resources failure (→ scheduler marks "offline"); disk-health degradation sets status "degraded" within Poll

## Test coverage
- 11 tests with mocked httptest.Server covering: invalid credentials, resource readings written + component marked online, CPU/mem value accuracy, multi-volume metrics, warn/error/failing disk events, no events for normal disks, session expiry re-auth, session reuse across cycles, login failure, connection refused

## Closes
Closes #86