### PR TITLE
feat: Infrastructure network map view (Infra-6)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@codemirror/lang-yaml": "^6.1.3",
+        "@xyflow/react": "^12.10.2",
         "codemirror": "^6.0.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -2382,6 +2383,55 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2758,6 +2808,38 @@
         }
       }
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3097,6 +3179,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/codemirror": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
@@ -3221,6 +3309,111 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -6630,6 +6823,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
@@ -7136,6 +7338,34 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@codemirror/lang-yaml": "^6.1.3",
+    "@xyflow/react": "^12.10.2",
     "codemirror": "^6.0.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/frontend/src/components/InfraNetworkMap.tsx
+++ b/frontend/src/components/InfraNetworkMap.tsx
@@ -1,0 +1,429 @@
+import { memo, useCallback, useContext, createContext, useEffect, useRef } from 'react'
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  Controls,
+  MiniMap,
+  useNodesState,
+  useEdgesState,
+  useReactFlow,
+  Handle,
+  Position,
+  BackgroundVariant,
+  MarkerType,
+  type Node,
+  type Edge,
+  type NodeProps,
+  type OnNodeDrag,
+  type NodeTypes,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import type { InfrastructureComponent, ComponentType } from '../api/types'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const POSITIONS_KEY = 'nora-infra-map-positions'
+
+const TYPE_COLOR: Record<ComponentType, string> = {
+  proxmox_node:  '#3b82f6',
+  synology:      '#a855f7',
+  vm:            '#6b7280',
+  lxc:           '#6b7280',
+  bare_metal:    '#6b7280',
+  windows_host:  '#6b7280',
+  docker_engine: '#14b8a6',
+}
+
+const TYPE_LABEL: Record<ComponentType, string> = {
+  proxmox_node:  'Proxmox Node',
+  synology:      'Synology NAS',
+  vm:            'VM',
+  lxc:           'LXC',
+  bare_metal:    'Bare Metal',
+  windows_host:  'Windows Host',
+  docker_engine: 'Docker Engine',
+}
+
+const STATUS_COLOR: Record<string, string> = {
+  online:   '#22c55e',
+  degraded: '#eab308',
+  offline:  '#ef4444',
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  online:   'Online',
+  degraded: 'Degraded',
+  offline:  'Offline',
+}
+
+// ── Context ───────────────────────────────────────────────────────────────────
+
+const EditContext = createContext<(c: InfrastructureComponent) => void>(() => {})
+
+// ── Layout ────────────────────────────────────────────────────────────────────
+
+const NODE_W = 240
+const NODE_H = 180
+
+function computeAutoLayout(components: InfrastructureComponent[]): Record<string, { x: number; y: number }> {
+  if (components.length === 0) return {}
+
+  const idSet = new Set(components.map(c => c.id))
+  const childrenOf = new Map<string, string[]>()
+  const roots: string[] = []
+
+  for (const c of components) {
+    if (!c.parent_id || !idSet.has(c.parent_id)) {
+      roots.push(c.id)
+    } else {
+      const arr = childrenOf.get(c.parent_id) ?? []
+      arr.push(c.id)
+      childrenOf.set(c.parent_id, arr)
+    }
+  }
+
+  const positions: Record<string, { x: number; y: number }> = {}
+  const seen = new Set<string>()
+  let layer = roots
+  let y = 0
+
+  while (layer.length > 0) {
+    const totalW = layer.length * NODE_W
+    layer.forEach((id, i) => {
+      if (seen.has(id)) return
+      seen.add(id)
+      positions[id] = {
+        x: i * NODE_W - totalW / 2 + NODE_W / 2,
+        y,
+      }
+    })
+    const next: string[] = []
+    for (const id of layer) {
+      next.push(...(childrenOf.get(id) ?? []))
+    }
+    layer = next
+    y += NODE_H
+  }
+
+  return positions
+}
+
+// ── Persistence ───────────────────────────────────────────────────────────────
+
+function loadPositions(): Record<string, { x: number; y: number }> {
+  try {
+    return JSON.parse(localStorage.getItem(POSITIONS_KEY) ?? '{}') as Record<string, { x: number; y: number }>
+  } catch {
+    return {}
+  }
+}
+
+function savePositions(p: Record<string, { x: number; y: number }>) {
+  localStorage.setItem(POSITIONS_KEY, JSON.stringify(p))
+}
+
+// ── Node icons ────────────────────────────────────────────────────────────────
+
+function TypeIcon({ type, color }: { type: ComponentType; color: string }) {
+  switch (type) {
+    case 'proxmox_node':
+    case 'bare_metal':
+      return (
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <rect x="2" y="4" width="16" height="12" rx="2" stroke={color} strokeWidth="1.5" />
+          <rect x="4" y="7" width="3" height="2" rx="0.5" fill={color} />
+          <line x1="9" y1="8" x2="14" y2="8" stroke={color} strokeWidth="1" />
+          <line x1="9" y1="10.5" x2="14" y2="10.5" stroke={color} strokeWidth="1" />
+        </svg>
+      )
+    case 'synology':
+      return (
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <rect x="3" y="3" width="14" height="14" rx="2" stroke={color} strokeWidth="1.5" />
+          <circle cx="10" cy="7.5" r="2" stroke={color} strokeWidth="1" />
+          <circle cx="10" cy="12.5" r="2" stroke={color} strokeWidth="1" />
+          <circle cx="14.5" cy="7.5" r="0.8" fill={color} />
+          <circle cx="14.5" cy="12.5" r="0.8" fill={color} />
+        </svg>
+      )
+    case 'vm':
+    case 'lxc':
+      return (
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <rect x="3" y="4" width="14" height="12" rx="2" stroke={color} strokeWidth="1.5" />
+          <polyline points="7,9 10,6 13,9" stroke={color} strokeWidth="1" fill="none" />
+          <polyline points="7,11 10,14 13,11" stroke={color} strokeWidth="1" fill="none" />
+        </svg>
+      )
+    case 'windows_host':
+      return (
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <rect x="2"  y="3"  width="7.5" height="6.5" rx="0.5" fill={color} opacity="0.8" />
+          <rect x="10.5" y="3"  width="7.5" height="6.5" rx="0.5" fill={color} opacity="0.8" />
+          <rect x="2"  y="10.5" width="7.5" height="6.5" rx="0.5" fill={color} opacity="0.8" />
+          <rect x="10.5" y="10.5" width="7.5" height="6.5" rx="0.5" fill={color} opacity="0.8" />
+        </svg>
+      )
+    case 'docker_engine':
+      return (
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <rect x="2"  y="9" width="3" height="3" rx="0.5" stroke={color} strokeWidth="1.2" />
+          <rect x="6"  y="9" width="3" height="3" rx="0.5" stroke={color} strokeWidth="1.2" />
+          <rect x="10" y="9" width="3" height="3" rx="0.5" stroke={color} strokeWidth="1.2" />
+          <rect x="6"  y="5" width="3" height="3" rx="0.5" stroke={color} strokeWidth="1.2" />
+          <rect x="10" y="5" width="3" height="3" rx="0.5" stroke={color} strokeWidth="1.2" />
+          <path d="M14.5 10.5 Q18 8.5 16.5 5.5" stroke={color} strokeWidth="1.2" fill="none" />
+        </svg>
+      )
+  }
+}
+
+// ── Custom node ───────────────────────────────────────────────────────────────
+
+type InfraNodeData = { component: InfrastructureComponent }
+
+const InfraNode = memo(function InfraNode({ data }: NodeProps) {
+  const onEdit = useContext(EditContext)
+  const { component } = data as InfraNodeData
+  const borderColor = TYPE_COLOR[component.type]
+  const statusColor = STATUS_COLOR[component.last_status] ?? '#445566'
+  const statusText  = STATUS_LABEL[component.last_status]  ?? 'Unknown'
+
+  return (
+    <div
+      style={{
+        background: '#0f1215',
+        border: `1.5px solid ${borderColor}`,
+        borderRadius: 8,
+        padding: '10px 12px',
+        minWidth: 160,
+        fontFamily: '"JetBrains Mono", monospace',
+        cursor: 'default',
+        userSelect: 'none',
+      }}
+      onDoubleClick={() => onEdit(component)}
+    >
+      <Handle
+        type="target"
+        position={Position.Top}
+        style={{ background: '#1e2530', border: '1px solid #252d38', width: 8, height: 8 }}
+      />
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <TypeIcon type={component.type} color={borderColor} />
+        <div style={{ overflow: 'hidden' }}>
+          <div style={{
+            fontSize: 12,
+            fontWeight: 500,
+            color: '#c8d4e0',
+            lineHeight: 1.2,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            maxWidth: 120,
+          }}>
+            {component.name}
+          </div>
+          <div style={{ fontSize: 10, color: '#7a8fa8', marginTop: 2 }}>
+            {TYPE_LABEL[component.type]}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ fontSize: 10, color: '#7a8fa8', marginBottom: 8, fontFamily: 'monospace' }}>
+        {component.ip || '—'}
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+        <div style={{
+          width: 7,
+          height: 7,
+          borderRadius: '50%',
+          background: statusColor,
+          flexShrink: 0,
+          boxShadow: `0 0 4px ${statusColor}44`,
+        }} />
+        <span style={{ fontSize: 10, color: statusColor }}>{statusText}</span>
+      </div>
+
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        style={{ background: '#1e2530', border: '1px solid #252d38', width: 8, height: 8 }}
+      />
+    </div>
+  )
+})
+
+const nodeTypes: NodeTypes = { infraNode: InfraNode }
+
+// ── Inner flow component ──────────────────────────────────────────────────────
+
+interface InnerProps {
+  components: InfrastructureComponent[]
+  onEditComponent: (c: InfrastructureComponent) => void
+}
+
+function InfraNetworkMapInner({ components, onEditComponent }: InnerProps) {
+  const { fitView } = useReactFlow()
+  const savedPositions = useRef<Record<string, { x: number; y: number }>>(loadPositions())
+  const prevIdsRef = useRef('')
+  const onEditRef = useRef(onEditComponent)
+  onEditRef.current = onEditComponent
+  const didFitView = useRef(false)
+
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([])
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
+
+  const componentIds = components.map(c => c.id).sort().join(',')
+
+  useEffect(() => {
+    if (components.length === 0) {
+      setNodes([])
+      setEdges([])
+      prevIdsRef.current = ''
+      didFitView.current = false
+      return
+    }
+
+    if (componentIds === prevIdsRef.current) {
+      // Status-only update — patch data without moving nodes
+      setNodes(prev =>
+        prev.map(node => {
+          const c = components.find(c => c.id === node.id)
+          return c ? { ...node, data: { component: c } } : node
+        })
+      )
+      return
+    }
+
+    // Structural change — rebuild nodes and edges
+    prevIdsRef.current = componentIds
+    const auto = computeAutoLayout(components)
+
+    const newNodes: Node[] = components.map(c => ({
+      id: c.id,
+      type: 'infraNode',
+      position: savedPositions.current[c.id] ?? auto[c.id] ?? { x: 0, y: 0 },
+      data: { component: c } as InfraNodeData,
+      draggable: true,
+    }))
+
+    const newEdges: Edge[] = components
+      .filter(c => c.parent_id)
+      .map(c => ({
+        id: `e-${c.parent_id}-${c.id}`,
+        source: c.parent_id!,
+        target: c.id,
+        style: {
+          stroke: '#252d38',
+          strokeDasharray: '5 5',
+          strokeWidth: 1.5,
+          opacity: 0.7,
+        },
+        markerEnd: {
+          type: MarkerType.Arrow,
+          color: '#252d38',
+          width: 12,
+          height: 12,
+        },
+      }))
+
+    setNodes(newNodes)
+    setEdges(newEdges)
+    didFitView.current = false
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [componentIds, components])
+
+  // Fit view after initial layout
+  useEffect(() => {
+    if (!didFitView.current && nodes.length > 0) {
+      didFitView.current = true
+      requestAnimationFrame(() => {
+        fitView({ padding: 0.2, duration: 400 })
+      })
+    }
+  }, [nodes, fitView])
+
+  const onNodeDragStop: OnNodeDrag = useCallback((_: React.MouseEvent, node: Node) => {
+    savedPositions.current[node.id] = node.position
+    savePositions(savedPositions.current)
+  }, [])
+
+  const onNodeDoubleClick = useCallback((_event: React.MouseEvent, node: Node) => {
+    const c = components.find(c => c.id === node.id)
+    if (c) onEditRef.current(c)
+  }, [components])
+
+  return (
+    <EditContext.Provider value={(c) => onEditRef.current(c)}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onNodeDragStop={onNodeDragStop}
+        onNodeDoubleClick={onNodeDoubleClick}
+        nodeTypes={nodeTypes}
+        nodesConnectable={false}
+        deleteKeyCode={null}
+        style={{ background: '#0f1215' }}
+        fitView
+      >
+        <Background
+          variant={BackgroundVariant.Dots}
+          gap={20}
+          size={1}
+          color="#1e2530"
+        />
+        <Controls
+          position="bottom-right"
+          style={{
+            background: '#151920',
+            border: '1px solid #1e2530',
+            borderRadius: 6,
+          }}
+        />
+        <MiniMap
+          position="bottom-left"
+          style={{
+            background: '#0a0c0f',
+            border: '1px solid #1e2530',
+            borderRadius: 6,
+          }}
+          nodeColor={(node) => {
+            const d = node.data as InfraNodeData | undefined
+            return d ? TYPE_COLOR[d.component.type] : '#445566'
+          }}
+          maskColor="#0a0c0f99"
+        />
+      </ReactFlow>
+    </EditContext.Provider>
+  )
+}
+
+// ── Exported component ────────────────────────────────────────────────────────
+
+export interface InfraNetworkMapProps {
+  components: InfrastructureComponent[]
+  onEditComponent: (c: InfrastructureComponent) => void
+}
+
+export function InfraNetworkMap({ components, onEditComponent }: InfraNetworkMapProps) {
+  if (components.length < 2) {
+    return (
+      <div className="infra-map-empty">
+        Add more components to see the network map.
+      </div>
+    )
+  }
+
+  return (
+    <div className="infra-map-container">
+      <ReactFlowProvider>
+        <InfraNetworkMapInner components={components} onEditComponent={onEditComponent} />
+      </ReactFlowProvider>
+    </div>
+  )
+}

--- a/frontend/src/pages/Infrastructure.css
+++ b/frontend/src/pages/Infrastructure.css
@@ -86,6 +86,48 @@
   border-style: dashed;
 }
 
+/* ── NETWORK MAP ────────────────────────────────────────────────────────────── */
+
+.infra-map-container {
+  height: calc(100vh - 200px);
+  min-height: 400px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.infra-map-empty {
+  padding: 60px 40px;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text3);
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+/* Override ReactFlow controls for dark theme */
+.infra-map-container .react-flow__controls-button {
+  background: var(--bg3);
+  border-bottom: 1px solid var(--border);
+  color: var(--text2);
+  fill: var(--text2);
+}
+
+.infra-map-container .react-flow__controls-button:hover {
+  background: var(--bg4);
+}
+
+.infra-map-container .react-flow__controls-button svg {
+  fill: var(--text2);
+}
+
+/* Hide ReactFlow attribution */
+.infra-map-container .react-flow__attribution {
+  display: none;
+}
+
 /* ── CARD LIST ─────────────────────────────────────────────────────────────── */
 
 .infra-card-list {

--- a/frontend/src/pages/Infrastructure.tsx
+++ b/frontend/src/pages/Infrastructure.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Topbar } from '../components/Topbar'
+import { InfraNetworkMap } from '../components/InfraNetworkMap'
 import { infrastructure as infraApi } from '../api/client'
 import type {
   ComponentType,
@@ -739,9 +740,10 @@ export function Infrastructure() {
 
         {/* ── Network Map tab ── */}
         {activeTab === 'map' && (
-          <div className="infra-map-placeholder">
-            Network map coming soon — relationships between components will be visualised here.
-          </div>
+          <InfraNetworkMap
+            components={components}
+            onEditComponent={openEdit}
+          />
         )}
 
       </div>


### PR DESCRIPTION
## What
Implements the Network Map tab on the Infrastructure page — a visual diagram of all infrastructure components with parent/child relationship edges, powered by `@xyflow/react` v12.

## Why
Closes Infra-6. Gives operators a spatial overview of their infrastructure topology alongside the existing card grid (Infra-5 tab).

## How
- Added `InfraNetworkMap` component (`/frontend/src/components/InfraNetworkMap.tsx`)
- Nodes styled per type: Proxmox (blue), Synology (purple), VM/LXC/Bare Metal/Windows (grey), Docker (teal) — each with an inline SVG icon
- Edges drawn from `parent_id` relationships: dashed line with arrow marker, low opacity
- Auto-layout on first render: top-down tree sorted by `parent_id` depth; roots float as standalone nodes
- Node positions persist to `localStorage` keyed by component ID — survives page refresh
- Status-only polls (every 30 s from parent) update node data without resetting positions
- Double-click a node opens the existing edit modal via callback prop
- Empty state (`< 2 components`) shows "Add more components to see the network map."
- ReactFlow Controls (zoom/fit) bottom-right; MiniMap bottom-left — both themed dark
- Dark-theme overrides added to `Infrastructure.css` (Controls buttons, background, MiniMap)

## Test coverage
- `npm run build` passes with zero TypeScript errors
- `docker compose up --build` must complete with zero errors
- Manual: tab switch, node drag + refresh (positions persist), double-click edit, fit view button

## Closes
Closes #Infra-6