### PR TITLE
feat: DD-2 — Docker discovery worker + profile matching

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -126,6 +126,14 @@ func main() {
 	dockerCtx, dockerCancel := context.WithCancel(context.Background())
 	defer dockerCancel()
 
+	// Ensure a local docker engine record exists so discovered containers can
+	// be associated with it. This is idempotent — it reuses the existing record
+	// if one with socket_type="local" is already present.
+	localEngineID, err := docker.EnsureLocalEngine(context.Background(), store)
+	if err != nil {
+		log.Printf("docker discovery: could not ensure local engine record: %v", err)
+	}
+
 	if watcher, err := docker.NewWatcher(store); err != nil {
 		log.Printf("docker watcher: socket not available, skipping (%v)", err)
 	} else {
@@ -136,6 +144,17 @@ func main() {
 			watcher.SetContainerStartHook(healthPoller.CheckContainer)
 			go healthPoller.Start(dockerCtx)
 		}
+
+		// Wire up the discovery worker to upsert containers and run profile matching.
+		if localEngineID != "" {
+			if discoverer, err := docker.NewDiscoverer(store, registry, localEngineID); err != nil {
+				log.Printf("docker discoverer: %v", err)
+			} else {
+				watcher.SetDiscoveryHook(discoverer.HandleEvent)
+				go discoverer.ScanAll(dockerCtx)
+			}
+		}
+
 		go watcher.Start(dockerCtx)
 	}
 
@@ -165,6 +184,7 @@ func main() {
 		api.NewInfraComponentHandler(infraComponentRepo, resourceRollupRepo, checkRepo, traefikComponentRepo).Routes(r)
 		api.NewProfilesHandler(registry, customProfileRepo).Routes(r)
 		api.NewInfraHandler(infraRepo, syncWorker).Routes(r)
+		api.NewDockerDiscoveryHandler(store).Routes(r)
 		api.NewDigestHandler(store, digestJob).Routes(r)
 		api.NewSettingsHandler(store).Routes(r)
 		api.NewIntegrationDriversHandler(settingsRepo).Routes(r)

--- a/internal/api/docker_discovery.go
+++ b/internal/api/docker_discovery.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+)
+
+// DockerDiscoveryHandler serves the container discovery endpoints.
+type DockerDiscoveryHandler struct {
+	store *repo.Store
+}
+
+// NewDockerDiscoveryHandler returns a DockerDiscoveryHandler wired to store.
+func NewDockerDiscoveryHandler(store *repo.Store) *DockerDiscoveryHandler {
+	return &DockerDiscoveryHandler{store: store}
+}
+
+// Routes registers the docker discovery endpoints on r.
+func (h *DockerDiscoveryHandler) Routes(r chi.Router) {
+	r.Get("/docker-engines/{id}/containers", h.ListContainers)
+}
+
+// discoveredContainerResponse is the per-container shape returned by the API.
+type discoveredContainerResponse struct {
+	ID                   string    `json:"id"`
+	ContainerName        string    `json:"container_name"`
+	Image                string    `json:"image"`
+	Status               string    `json:"status"`
+	AppID                *string   `json:"app_id"`
+	ProfileSuggestion    *string   `json:"profile_suggestion"`
+	SuggestionConfidence *int      `json:"suggestion_confidence"`
+	CPUPercent           *float64  `json:"cpu_percent"`
+	MemPercent           *float64  `json:"mem_percent"`
+	LastSeenAt           time.Time `json:"last_seen_at"`
+}
+
+type listDiscoveredContainersResponse struct {
+	Data  []discoveredContainerResponse `json:"data"`
+	Total int                           `json:"total"`
+}
+
+// ListContainers returns all discovered containers for a docker engine.
+// GET /api/v1/docker-engines/{id}/containers
+func (h *DockerDiscoveryHandler) ListContainers(w http.ResponseWriter, r *http.Request) {
+	engineID := chi.URLParam(r, "id")
+
+	// Verify the engine exists.
+	if _, err := h.store.DockerEngines.Get(r.Context(), engineID); errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "docker engine not found")
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	containers, err := h.store.DiscoveredContainers.ListDiscoveredContainers(r.Context(), engineID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Collect container IDs for a batched resource reading lookup.
+	containerIDs := make([]string, len(containers))
+	for i, c := range containers {
+		containerIDs[i] = c.ContainerID
+	}
+
+	metrics, err := h.store.Resources.LatestMetrics(r.Context(), "docker_container", containerIDs)
+	if err != nil {
+		// Non-fatal — return containers without metrics rather than erroring.
+		metrics = map[string]map[string]float64{}
+	}
+
+	out := make([]discoveredContainerResponse, len(containers))
+	for i, c := range containers {
+		item := discoveredContainerResponse{
+			ID:                   c.ID,
+			ContainerName:        c.ContainerName,
+			Image:                c.Image,
+			Status:               c.Status,
+			AppID:                c.AppID,
+			ProfileSuggestion:    c.ProfileSuggestion,
+			SuggestionConfidence: c.SuggestionConfidence,
+			LastSeenAt:           c.LastSeenAt,
+		}
+
+		if m, ok := metrics[c.ContainerID]; ok {
+			if v, ok := m["cpu_percent"]; ok {
+				item.CPUPercent = &v
+			}
+			if v, ok := m["mem_percent"]; ok {
+				item.MemPercent = &v
+			}
+		}
+
+		out[i] = item
+	}
+
+	writeJSON(w, http.StatusOK, listDiscoveredContainersResponse{Data: out, Total: len(out)})
+}

--- a/internal/docker/discovery.go
+++ b/internal/docker/discovery.go
@@ -1,0 +1,143 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	dockerclient "github.com/docker/docker/client"
+	"github.com/google/uuid"
+
+	"github.com/digitalcheffe/nora/internal/apptemplate"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// discoveryListAPI is the minimal Docker client subset needed for the initial
+// container scan, enabling mock injection in tests.
+type discoveryListAPI interface {
+	ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
+}
+
+// Discoverer writes container discovery records into discovered_containers and
+// runs profile matching on every upsert.
+type Discoverer struct {
+	store    *repo.Store
+	registry *apptemplate.Registry
+	engineID string
+	client   discoveryListAPI
+}
+
+// NewDiscoverer creates a Discoverer connected to the local Docker daemon.
+// It returns an error only if the Docker client cannot be constructed.
+func NewDiscoverer(store *repo.Store, registry *apptemplate.Registry, engineID string) (*Discoverer, error) {
+	cli, err := dockerclient.NewClientWithOpts(
+		dockerclient.FromEnv,
+		dockerclient.WithAPIVersionNegotiation(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("docker client: %w", err)
+	}
+	return &Discoverer{store: store, registry: registry, engineID: engineID, client: cli}, nil
+}
+
+// newDiscovererWithClient creates a Discoverer with an injected client (for tests).
+func newDiscovererWithClient(store *repo.Store, registry *apptemplate.Registry, engineID string, cli discoveryListAPI) *Discoverer {
+	return &Discoverer{store: store, registry: registry, engineID: engineID, client: cli}
+}
+
+// ScanAll lists all running containers from the Docker daemon and upserts each
+// one into discovered_containers. Called once at NORA startup.
+func (d *Discoverer) ScanAll(ctx context.Context) {
+	log.Printf("docker discovery: scanning all running containers for engine %s", d.engineID)
+
+	containers, err := d.client.ContainerList(ctx, container.ListOptions{})
+	if err != nil {
+		log.Printf("docker discovery: list containers: %v", err)
+		return
+	}
+
+	for _, c := range containers {
+		name := containerNameFrom(c.Names)
+		image := c.Image
+		if err := d.upsert(ctx, c.ID, name, image, "running"); err != nil {
+			log.Printf("docker discovery: upsert %s: %v", name, err)
+		}
+	}
+
+	log.Printf("docker discovery: initial scan complete — %d containers", len(containers))
+}
+
+// HandleEvent is the hook wired into the Watcher. It upserts the container
+// into discovered_containers and runs profile matching.
+// status is one of: running | stopped | exited
+func (d *Discoverer) HandleEvent(ctx context.Context, containerID, name, image, status string) {
+	if err := d.upsert(ctx, containerID, name, image, status); err != nil {
+		log.Printf("docker discovery: upsert event for %s: %v", name, err)
+	}
+}
+
+// upsert writes or updates a discovered_containers record and runs profile matching.
+func (d *Discoverer) upsert(ctx context.Context, containerID, name, image, status string) error {
+	now := time.Now().UTC()
+
+	dc := &models.DiscoveredContainer{
+		DockerEngineID: d.engineID,
+		ContainerID:    containerID,
+		ContainerName:  name,
+		Image:          image,
+		Status:         status,
+		LastSeenAt:     now,
+		CreatedAt:      now,
+	}
+
+	// Run profile matching and attach suggestion if confidence is sufficient.
+	if match := MatchContainerToProfile(name, image, d.registry); match != nil {
+		dc.ProfileSuggestion = &match.ProfileID
+		dc.SuggestionConfidence = &match.Confidence
+	}
+
+	return d.store.DiscoveredContainers.UpsertDiscoveredContainer(ctx, dc)
+}
+
+// containerNameFrom returns the primary container name from the Docker names
+// slice, stripping the leading "/" that Docker prepends.
+func containerNameFrom(names []string) string {
+	if len(names) == 0 {
+		return ""
+	}
+	return strings.TrimPrefix(names[0], "/")
+}
+
+// EnsureLocalEngine looks up the first docker_engine record with
+// socket_type="local". If none exists, it creates one and returns its ID.
+// This is used at startup to ensure the local Docker socket watcher has an
+// engine record to associate discovered containers with.
+func EnsureLocalEngine(ctx context.Context, store *repo.Store) (string, error) {
+	engines, err := store.DockerEngines.List(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list docker engines: %w", err)
+	}
+
+	for _, e := range engines {
+		if e.SocketType == "local" {
+			return e.ID, nil
+		}
+	}
+
+	// No local engine found — create one.
+	engine := &models.DockerEngine{
+		ID:         uuid.New().String(),
+		Name:       "Local Docker",
+		SocketType: "local",
+		SocketPath: "/var/run/docker.sock",
+	}
+	if err := store.DockerEngines.Create(ctx, engine); err != nil {
+		return "", fmt.Errorf("create local docker engine: %w", err)
+	}
+	log.Printf("docker discovery: created local engine record %s", engine.ID)
+	return engine.ID, nil
+}

--- a/internal/docker/matcher.go
+++ b/internal/docker/matcher.go
@@ -1,0 +1,90 @@
+package docker
+
+import (
+	"strings"
+
+	"github.com/digitalcheffe/nora/internal/apptemplate"
+)
+
+// MatchResult holds the outcome of a profile-matching attempt.
+type MatchResult struct {
+	ProfileID  string
+	Confidence int // 0-100
+}
+
+// MatchContainerToProfile attempts to match a container to a profile in the
+// registry using name and image heuristics. Returns nil when no match scores
+// 70 or above. Rules are applied in order; the first match wins.
+//
+// Rule precedence (highest confidence first):
+//  1. Exact container name == profile ID                                  → 95
+//  2. Image base name (no tag, no registry prefix) == profile ID         → 85
+//  3. Container name contains profile ID as substring                    → 80
+//  4. Image base name contains profile ID as substring                   → 70
+func MatchContainerToProfile(containerName, image string, registry *apptemplate.Registry) *MatchResult {
+	if registry == nil {
+		return nil
+	}
+
+	lName := strings.ToLower(containerName)
+	lImageBase := strings.ToLower(imageBaseName(image))
+
+	profiles := registry.List()
+
+	// We apply rules in priority order across all profiles; collect the best.
+	type candidate struct {
+		profileID  string
+		confidence int
+	}
+	var best *candidate
+
+	for profileID := range profiles {
+		lID := strings.ToLower(profileID)
+
+		conf := 0
+		switch {
+		case lName == lID:
+			conf = 95
+		case lImageBase == lID:
+			conf = 85
+		case strings.Contains(lName, lID):
+			conf = 80
+		case strings.Contains(lImageBase, lID):
+			conf = 70
+		}
+
+		if conf >= 70 && (best == nil || conf > best.confidence) {
+			best = &candidate{profileID: profileID, confidence: conf}
+		}
+	}
+
+	if best == nil {
+		return nil
+	}
+	return &MatchResult{ProfileID: best.profileID, Confidence: best.confidence}
+}
+
+// imageBaseName strips the registry prefix and tag from a Docker image string,
+// returning only the repository base name.
+//
+// Examples:
+//
+//	"lscr.io/linuxserver/sonarr:latest" → "sonarr"
+//	"nginx:1.25"                        → "nginx"
+//	"ghcr.io/home-assistant/home-assistant:stable" → "home-assistant"
+func imageBaseName(image string) string {
+	// Strip tag.
+	if i := strings.LastIndex(image, ":"); i != -1 {
+		// Ensure the colon is not part of a registry host:port
+		if !strings.Contains(image[i:], "/") {
+			image = image[:i]
+		}
+	}
+
+	// Strip registry/organisation prefix — take only the last path segment.
+	if i := strings.LastIndex(image, "/"); i != -1 {
+		image = image[i+1:]
+	}
+
+	return image
+}

--- a/internal/docker/matcher_test.go
+++ b/internal/docker/matcher_test.go
@@ -1,0 +1,155 @@
+package docker
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/digitalcheffe/nora/internal/apptemplate"
+)
+
+// buildRegistry constructs a minimal Registry containing only the given profile IDs.
+func buildRegistry(profileIDs ...string) *apptemplate.Registry {
+	memFS := fstest.MapFS{}
+	for _, id := range profileIDs {
+		memFS[id+".yaml"] = &fstest.MapFile{
+			Data: []byte("meta:\n  name: " + id + "\n"),
+		}
+	}
+	reg, err := apptemplate.NewRegistry(fs.FS(memFS))
+	if err != nil {
+		panic("buildRegistry: " + err.Error())
+	}
+	return reg
+}
+
+func TestMatchContainerToProfile(t *testing.T) {
+	reg := buildRegistry("sonarr", "radarr", "plex", "home-assistant")
+
+	tests := []struct {
+		name          string
+		containerName string
+		image         string
+		wantProfile   string // "" means nil result expected
+		wantConf      int
+	}{
+		{
+			name:          "exact container name match",
+			containerName: "sonarr",
+			image:         "some-unrelated-image:latest",
+			wantProfile:   "sonarr",
+			wantConf:      95,
+		},
+		{
+			name:          "exact match is case-insensitive",
+			containerName: "Sonarr",
+			image:         "",
+			wantProfile:   "sonarr",
+			wantConf:      95,
+		},
+		{
+			name:          "image base name exact match",
+			containerName: "my-media-server",
+			image:         "lscr.io/linuxserver/sonarr:latest",
+			wantProfile:   "sonarr",
+			wantConf:      85,
+		},
+		{
+			name:          "image base name exact match no registry prefix",
+			containerName: "my-container",
+			image:         "plex:1.32",
+			wantProfile:   "plex",
+			wantConf:      85,
+		},
+		{
+			name:          "container name contains profile ID as substring",
+			containerName: "sonarr-4k",
+			image:         "unrelated-image:latest",
+			wantProfile:   "sonarr",
+			wantConf:      80,
+		},
+		{
+			name:          "image base name contains profile ID as substring",
+			containerName: "my-pvr",
+			image:         "ghcr.io/team/sonarr-custom:edge",
+			wantProfile:   "sonarr",
+			wantConf:      70,
+		},
+		{
+			name:          "no match returns nil",
+			containerName: "postgres",
+			image:         "postgres:15",
+			wantProfile:   "",
+			wantConf:      0,
+		},
+		{
+			name:          "below threshold confidence is not returned",
+			containerName: "totally-unrelated",
+			image:         "totally-unrelated:latest",
+			wantProfile:   "",
+			wantConf:      0,
+		},
+		{
+			name:          "nil registry returns nil",
+			containerName: "sonarr",
+			image:         "sonarr:latest",
+			wantProfile:   "",
+			wantConf:      0,
+		},
+		{
+			name:          "home-assistant hyphenated image base name",
+			containerName: "ha",
+			image:         "ghcr.io/home-assistant/home-assistant:stable",
+			wantProfile:   "home-assistant",
+			wantConf:      85,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var r *apptemplate.Registry
+			if tc.name != "nil registry returns nil" {
+				r = reg
+			}
+
+			got := MatchContainerToProfile(tc.containerName, tc.image, r)
+
+			if tc.wantProfile == "" {
+				if got != nil {
+					t.Errorf("expected nil result, got ProfileID=%q Confidence=%d", got.ProfileID, got.Confidence)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatalf("expected match for profile %q, got nil", tc.wantProfile)
+			}
+			if got.ProfileID != tc.wantProfile {
+				t.Errorf("ProfileID: got %q, want %q", got.ProfileID, tc.wantProfile)
+			}
+			if got.Confidence != tc.wantConf {
+				t.Errorf("Confidence: got %d, want %d", got.Confidence, tc.wantConf)
+			}
+		})
+	}
+}
+
+func TestImageBaseName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"nginx:latest", "nginx"},
+		{"lscr.io/linuxserver/sonarr:latest", "sonarr"},
+		{"ghcr.io/home-assistant/home-assistant:stable", "home-assistant"},
+		{"registry.example.com:5000/myapp:v1.2", "myapp"},
+		{"ubuntu", "ubuntu"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := imageBaseName(tc.input)
+		if got != tc.want {
+			t.Errorf("imageBaseName(%q): got %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/internal/docker/resources_test.go
+++ b/internal/docker/resources_test.go
@@ -46,6 +46,10 @@ func (r *mockResourceReadingRepo) Create(_ context.Context, reading *models.Reso
 	return nil
 }
 
+func (r *mockResourceReadingRepo) LatestMetrics(_ context.Context, _ string, _ []string) (map[string]map[string]float64, error) {
+	return map[string]map[string]float64{}, nil
+}
+
 // --- helpers --------------------------------------------------------------
 
 func newTestResourcePoller(appRepo repo.AppRepo, eventRepo repo.EventRepo, resRepo repo.ResourceReadingRepo, cli resourcePollerAPI) *ResourcePoller {

--- a/internal/docker/watcher.go
+++ b/internal/docker/watcher.go
@@ -24,6 +24,10 @@ type dockerAPI interface {
 	Close() error
 }
 
+// DiscoveryFunc is the callback signature for container discovery hooks.
+// containerID is the full Docker container ID; status is one of: running | stopped | exited.
+type DiscoveryFunc func(ctx context.Context, containerID, name, image, status string)
+
 // Watcher streams container lifecycle events from the Docker daemon and writes
 // them to the NORA events table.
 type Watcher struct {
@@ -32,6 +36,9 @@ type Watcher struct {
 	// onContainerStart is called after a "start" event is processed.
 	// It is used to trigger an immediate health check via the HealthPoller.
 	onContainerStart func(ctx context.Context, containerID string)
+	// discoveryHook, if set, is called (in a goroutine) on every container
+	// lifecycle event so the Discoverer can upsert into discovered_containers.
+	discoveryHook DiscoveryFunc
 }
 
 // SetContainerStartHook registers a callback that is called (in a goroutine)
@@ -39,6 +46,13 @@ type Watcher struct {
 // health check without coupling Watcher and HealthPoller.
 func (w *Watcher) SetContainerStartHook(fn func(ctx context.Context, containerID string)) {
 	w.onContainerStart = fn
+}
+
+// SetDiscoveryHook registers a callback that is called (in a goroutine) on
+// every container lifecycle event (start, stop, die, kill, restart). Used to
+// upsert into discovered_containers without coupling Watcher and Discoverer.
+func (w *Watcher) SetDiscoveryHook(fn DiscoveryFunc) {
+	w.discoveryHook = fn
 }
 
 // NewWatcher creates a Watcher connected to the Docker daemon. It returns an
@@ -117,6 +131,14 @@ func (w *Watcher) handleEvent(ctx context.Context, msg events.Message) error {
 		go w.onContainerStart(ctx, containerID)
 	}
 
+	// Notify the discovery worker so it can upsert into discovered_containers.
+	if w.discoveryHook != nil {
+		image := msg.Actor.Attributes["image"]
+		status := containerStatusFromAction(action)
+		cid := msg.Actor.ID
+		go w.discoveryHook(ctx, cid, containerName, image, status)
+	}
+
 	// Try to find a matching app by container name (case-insensitive).
 	appID := ""
 	apps, err := w.store.Apps.List(ctx)
@@ -189,6 +211,19 @@ func parseExitCode(s string) int {
 		return 0
 	}
 	return n
+}
+
+// containerStatusFromAction maps a Docker event action to a discovered_containers
+// status value (running | stopped | exited).
+func containerStatusFromAction(action string) string {
+	switch action {
+	case "start", "restart":
+		return "running"
+	case "die":
+		return "exited"
+	default: // stop, kill
+		return "stopped"
+	}
 }
 
 // jsonStr returns s as a JSON-encoded string (with quotes and escaping).

--- a/internal/repo/resources.go
+++ b/internal/repo/resources.go
@@ -12,6 +12,11 @@ import (
 type ResourceReadingRepo interface {
 	// Create persists a single resource metric reading.
 	Create(ctx context.Context, r *models.ResourceReading) error
+
+	// LatestMetrics returns the most recent value of cpu_percent and mem_percent
+	// for each sourceID in sourceIDs, filtered by sourceType.
+	// Returns map[sourceID]map[metric]float64. Missing entries mean no data yet.
+	LatestMetrics(ctx context.Context, sourceType string, sourceIDs []string) (map[string]map[string]float64, error)
 }
 
 type sqliteResourceReadingRepo struct {
@@ -32,4 +37,58 @@ func (r *sqliteResourceReadingRepo) Create(ctx context.Context, reading *models.
 		return fmt.Errorf("create resource reading: %w", err)
 	}
 	return nil
+}
+
+func (r *sqliteResourceReadingRepo) LatestMetrics(ctx context.Context, sourceType string, sourceIDs []string) (map[string]map[string]float64, error) {
+	result := make(map[string]map[string]float64)
+	if len(sourceIDs) == 0 {
+		return result, nil
+	}
+
+	query, args, err := sqlx.In(`
+		WITH latest AS (
+			SELECT source_id, metric, value,
+			       ROW_NUMBER() OVER (PARTITION BY source_id, metric ORDER BY recorded_at DESC) AS rn
+			FROM resource_readings
+			WHERE source_type = ?
+			  AND source_id   IN (?)
+			  AND metric      IN ('cpu_percent', 'mem_percent')
+		)
+		SELECT source_id, metric, value FROM latest WHERE rn = 1
+	`, append([]interface{}{sourceType}, toStringInterfaces(sourceIDs)...)...)
+	if err != nil {
+		return nil, fmt.Errorf("build latest metrics query: %w", err)
+	}
+	query = r.db.Rebind(query)
+
+	rows, err := r.db.QueryxContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("latest metrics: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var sourceID, metric string
+		var value float64
+		if err := rows.Scan(&sourceID, &metric, &value); err != nil {
+			return nil, fmt.Errorf("scan latest metrics row: %w", err)
+		}
+		if result[sourceID] == nil {
+			result[sourceID] = make(map[string]float64)
+		}
+		result[sourceID][metric] = value
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("latest metrics rows: %w", err)
+	}
+	return result, nil
+}
+
+// toStringInterfaces converts a []string to []interface{} for use with sqlx.In.
+func toStringInterfaces(ss []string) []interface{} {
+	out := make([]interface{}, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
 }


### PR DESCRIPTION
## What
Extends the Docker integration to upsert discovered containers into `discovered_containers` and run profile matching on every upsert.

## Why
Closes DD-2. Builds on the DD-1 schema to give NORA a persistent, queryable view of what containers are running on each Docker engine — with automatic app-profile suggestions so the user can one-click link containers to NORA apps.

## How

**`internal/docker/matcher.go`** — `MatchContainerToProfile` heuristic engine:
- Confidence 95: exact container name == profile ID
- Confidence 85: image base name (no tag/registry) == profile ID
- Confidence 80: container name contains profile ID as substring
- Confidence 70: image base name contains profile ID as substring
- Returns nil for no match or confidence < 70; never auto-links

**`internal/docker/discovery.go`** — `Discoverer` struct:
- `ScanAll` — called once at startup; lists all running containers via Docker client and upserts each one
- `HandleEvent` — the hook wired into the Watcher; called on every container lifecycle event
- `EnsureLocalEngine` — idempotent: looks up or creates a `docker_engines` row with `socket_type=local`

**`internal/docker/watcher.go`** — `DiscoveryFunc` hook type + `SetDiscoveryHook` + `containerStatusFromAction` helper wired into `handleEvent`; image comes from `msg.Actor.Attributes["image"]`

**`internal/repo/resources.go`** — `LatestMetrics` added to `ResourceReadingRepo` interface; SQLite implementation uses a `ROW_NUMBER()` window function + `sqlx.In` for batched container ID lookup

**`internal/api/docker_discovery.go`** — `GET /api/v1/docker-engines/{id}/containers`: verifies engine exists, lists containers, batches the resource reading lookup, and returns the merged response with `cpu_percent`/`mem_percent` (null if no readings yet)

**`cmd/nora/main.go`** — wires `EnsureLocalEngine` → `Discoverer` → `Watcher.SetDiscoveryHook`; registers `DockerDiscoveryHandler`

## Test coverage
- `internal/docker/matcher_test.go`: 10 sub-tests covering exact name match, case-insensitive match, image base name exact, image base name with registry prefix, name substring, image substring, no match, below-threshold, nil registry, hyphenated profile ID
- `imageBaseName` unit test with 6 cases
- All existing docker, repo, api, infra, and jobs tests continue to pass (`go test ./...`)
- `go vet ./...` clean

## Closes
Closes DD-2