### PR TITLE
feat: DD-3 — Traefik route discovery worker + routes API

### DIFF
--- a/internal/api/docker_discovery.go
+++ b/internal/api/docker_discovery.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/digitalcheffe/nora/internal/models"
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/go-chi/chi/v5"
 )
@@ -22,6 +23,8 @@ func NewDockerDiscoveryHandler(store *repo.Store) *DockerDiscoveryHandler {
 // Routes registers the docker discovery endpoints on r.
 func (h *DockerDiscoveryHandler) Routes(r chi.Router) {
 	r.Get("/docker-engines/{id}/containers", h.ListContainers)
+	r.Get("/infrastructure/{id}/routes", h.ListRoutes)
+	r.Get("/discovery/all", h.ListAll)
 }
 
 // discoveredContainerResponse is the per-container shape returned by the API.
@@ -101,4 +104,151 @@ func (h *DockerDiscoveryHandler) ListContainers(w http.ResponseWriter, r *http.R
 	}
 
 	writeJSON(w, http.StatusOK, listDiscoveredContainersResponse{Data: out, Total: len(out)})
+}
+
+// ── Routes ────────────────────────────────────────────────────────────────────
+
+// discoveredRouteResponse is the per-route shape returned by the routes API.
+type discoveredRouteResponse struct {
+	ID             string     `json:"id"`
+	RouterName     string     `json:"router_name"`
+	Domain         *string    `json:"domain"`
+	BackendService *string    `json:"backend_service"`
+	ContainerID    *string    `json:"container_id"`
+	ContainerName  *string    `json:"container_name"`
+	AppID          *string    `json:"app_id"`
+	SSLExpiry      *time.Time `json:"ssl_expiry"`
+	SSLIssuer      *string    `json:"ssl_issuer"`
+	LastSeenAt     time.Time  `json:"last_seen_at"`
+}
+
+type listDiscoveredRoutesResponse struct {
+	Data  []discoveredRouteResponse `json:"data"`
+	Total int                       `json:"total"`
+}
+
+// buildRouteResponses converts a slice of DiscoveredRoute models to API
+// response structs, denormalising container_name from containersByID.
+func buildRouteResponses(routes []*models.DiscoveredRoute, containersByID map[string]string) []discoveredRouteResponse {
+	out := make([]discoveredRouteResponse, len(routes))
+	for i, ro := range routes {
+		item := discoveredRouteResponse{
+			ID:             ro.ID,
+			RouterName:     ro.RouterName,
+			Domain:         ro.Domain,
+			BackendService: ro.BackendService,
+			ContainerID:    ro.ContainerID,
+			AppID:          ro.AppID,
+			SSLExpiry:      ro.SSLExpiry,
+			SSLIssuer:      ro.SSLIssuer,
+			LastSeenAt:     ro.LastSeenAt,
+		}
+		if ro.ContainerID != nil {
+			if name, ok := containersByID[*ro.ContainerID]; ok {
+				item.ContainerName = &name
+			}
+		}
+		out[i] = item
+	}
+	return out
+}
+
+// containerNameIndex builds a map of discovered_container UUID → container_name
+// from a slice of all containers.
+func containerNameIndex(containers []*models.DiscoveredContainer) map[string]string {
+	m := make(map[string]string, len(containers))
+	for _, c := range containers {
+		m[c.ID] = c.ContainerName
+	}
+	return m
+}
+
+// ListRoutes returns all discovered routes for a Traefik infrastructure component.
+// GET /api/v1/infrastructure/{id}/routes
+func (h *DockerDiscoveryHandler) ListRoutes(w http.ResponseWriter, r *http.Request) {
+	componentID := chi.URLParam(r, "id")
+
+	if _, err := h.store.InfraComponents.Get(r.Context(), componentID); errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "infrastructure component not found")
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	routes, err := h.store.DiscoveredRoutes.ListDiscoveredRoutes(r.Context(), componentID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	allContainers, err := h.store.DiscoveredContainers.ListAllDiscoveredContainers(r.Context())
+	if err != nil {
+		allContainers = nil
+	}
+
+	out := buildRouteResponses(routes, containerNameIndex(allContainers))
+	writeJSON(w, http.StatusOK, listDiscoveredRoutesResponse{Data: out, Total: len(out)})
+}
+
+// ── All ───────────────────────────────────────────────────────────────────────
+
+type discoveryAllResponse struct {
+	Containers []discoveredContainerResponse `json:"containers"`
+	Routes     []discoveredRouteResponse     `json:"routes"`
+}
+
+// ListAll returns all discovered containers and routes across every component.
+// GET /api/v1/discovery/all
+func (h *DockerDiscoveryHandler) ListAll(w http.ResponseWriter, r *http.Request) {
+	allContainers, err := h.store.DiscoveredContainers.ListAllDiscoveredContainers(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Collect container IDs for batched metrics lookup.
+	containerIDs := make([]string, len(allContainers))
+	for i, c := range allContainers {
+		containerIDs[i] = c.ContainerID
+	}
+	metrics, err := h.store.Resources.LatestMetrics(r.Context(), "docker_container", containerIDs)
+	if err != nil {
+		metrics = map[string]map[string]float64{}
+	}
+
+	containerOut := make([]discoveredContainerResponse, len(allContainers))
+	for i, c := range allContainers {
+		item := discoveredContainerResponse{
+			ID:                   c.ID,
+			ContainerName:        c.ContainerName,
+			Image:                c.Image,
+			Status:               c.Status,
+			AppID:                c.AppID,
+			ProfileSuggestion:    c.ProfileSuggestion,
+			SuggestionConfidence: c.SuggestionConfidence,
+			LastSeenAt:           c.LastSeenAt,
+		}
+		if m, ok := metrics[c.ContainerID]; ok {
+			if v, ok := m["cpu_percent"]; ok {
+				item.CPUPercent = &v
+			}
+			if v, ok := m["mem_percent"]; ok {
+				item.MemPercent = &v
+			}
+		}
+		containerOut[i] = item
+	}
+
+	allRoutes, err := h.store.DiscoveredRoutes.ListAllDiscoveredRoutes(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	routeOut := buildRouteResponses(allRoutes, containerNameIndex(allContainers))
+	writeJSON(w, http.StatusOK, discoveryAllResponse{
+		Containers: containerOut,
+		Routes:     routeOut,
+	})
 }

--- a/internal/infrastructure/traefik_discovery.go
+++ b/internal/infrastructure/traefik_discovery.go
@@ -1,0 +1,186 @@
+// Package infrastructure provides Traefik and other infrastructure discovery workers.
+package infrastructure
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/infra"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+// hostRuleRE matches Host(`domain`) or Host("domain") in a Traefik rule string.
+// It does NOT match HostRegexp(...) because after "Host" we require "(" immediately.
+var hostRuleRE = regexp.MustCompile("Host\\(`([^`]+)`\\)|Host\\(\"([^\"]+)\"\\)")
+
+// ParseHostFromRule extracts the first hostname from a Traefik routing rule.
+// Returns nil for PathPrefix-only rules, HostRegexp rules, and empty/unrecognised input.
+//
+// Supported forms:
+//
+//	Host(`sonarr.example.com`)  → "sonarr.example.com"
+//	Host("sonarr.example.com")  → "sonarr.example.com"
+//	HostRegexp(...)             → nil  (too ambiguous)
+//	PathPrefix(`/api`)          → nil  (no Host present)
+//	Host(`a.com`) && PathPrefix → "a.com"  (first Host match wins)
+func ParseHostFromRule(rule string) *string {
+	m := hostRuleRE.FindStringSubmatch(rule)
+	if m == nil {
+		return nil
+	}
+	var domain string
+	if m[1] != "" {
+		domain = m[1]
+	} else {
+		domain = m[2]
+	}
+	if domain == "" {
+		return nil
+	}
+	return &domain
+}
+
+// traefikDiscoveryCredentials is the JSON shape stored in
+// infrastructure_components.credentials for traefik-type components.
+type traefikDiscoveryCredentials struct {
+	APIURL string `json:"api_url"`
+	APIKey string `json:"api_key"`
+}
+
+// TraefikDiscovery polls the Traefik HTTP router API for an infrastructure
+// component and upserts entries into discovered_routes, cross-referencing
+// backend service names against known discovered_containers.
+type TraefikDiscovery struct {
+	store *repo.Store
+}
+
+// NewTraefikDiscovery returns a TraefikDiscovery wired to store.
+func NewTraefikDiscovery(store *repo.Store) *TraefikDiscovery {
+	return &TraefikDiscovery{store: store}
+}
+
+// Run fetches HTTP routers from the Traefik API for the given component and
+// upserts the results into discovered_routes. SSL data is sourced from the
+// traefik_component_certs cache that was populated earlier in the same poll
+// cycle. Container cross-referencing is done by matching the Traefik service
+// name against discovered_containers.container_name.
+//
+// Non-fatal errors (SSL lookup failures, individual upsert failures) are logged
+// and execution continues so that a single bad router does not abort the sync.
+func (t *TraefikDiscovery) Run(ctx context.Context, component *models.InfrastructureComponent) error {
+	if component.Credentials == nil || *component.Credentials == "" {
+		return nil
+	}
+
+	var creds traefikDiscoveryCredentials
+	if err := json.Unmarshal([]byte(*component.Credentials), &creds); err != nil {
+		return nil // malformed credentials — already logged upstream
+	}
+	if creds.APIURL == "" {
+		return nil
+	}
+
+	client := infra.NewTraefikClient(creds.APIURL, creds.APIKey)
+
+	// ── Fetch routers from Traefik ────────────────────────────────────────────
+
+	routers, err := client.FetchRouters(ctx)
+	if err != nil {
+		return err
+	}
+
+	// ── Build lookup maps ─────────────────────────────────────────────────────
+
+	// container_name → discovered_containers.id (UUID PK)
+	containerByName := make(map[string]string)
+	containers, err := t.store.DiscoveredContainers.ListAllDiscoveredContainers(ctx)
+	if err != nil {
+		log.Printf("traefik discovery: list containers for cross-ref: %v", err)
+	} else {
+		for _, c := range containers {
+			containerByName[c.ContainerName] = c.ID
+		}
+	}
+
+	// domain → (ssl_expiry, ssl_issuer) from traefik_component_certs
+	type sslInfo struct {
+		expiry *time.Time
+		issuer *string
+	}
+	sslByDomain := make(map[string]sslInfo)
+	certs, err := t.store.TraefikComponents.ListCerts(ctx, component.ID)
+	if err != nil {
+		log.Printf("traefik discovery: list certs for ssl lookup: %v", err)
+	} else {
+		for _, cert := range certs {
+			sslByDomain[cert.Domain] = sslInfo{
+				expiry: cert.ExpiresAt,
+				issuer: cert.Issuer,
+			}
+		}
+	}
+
+	// ── Upsert discovered routes ──────────────────────────────────────────────
+
+	now := time.Now().UTC()
+	for _, rr := range routers {
+		domain := ParseHostFromRule(rr.Rule)
+
+		// Strip Traefik provider suffix (e.g. "sonarr@docker" → "sonarr").
+		backendService := rr.ServiceName
+		if idx := strings.Index(backendService, "@"); idx >= 0 {
+			backendService = backendService[:idx]
+		}
+
+		var containerIDPtr *string
+		if cid, ok := containerByName[backendService]; ok {
+			containerIDPtr = &cid
+		}
+
+		var sslExpiry *time.Time
+		var sslIssuer *string
+		if domain != nil {
+			if info, ok := sslByDomain[*domain]; ok {
+				sslExpiry = info.expiry
+				sslIssuer = info.issuer
+			}
+		}
+
+		var domainPtr *string
+		if domain != nil {
+			domainPtr = domain
+		}
+		var backendPtr *string
+		if backendService != "" {
+			backendPtr = &backendService
+		}
+
+		route := &models.DiscoveredRoute{
+			ID:               uuid.New().String(),
+			InfrastructureID: component.ID,
+			RouterName:       rr.Name,
+			Rule:             rr.Rule,
+			Domain:           domainPtr,
+			BackendService:   backendPtr,
+			ContainerID:      containerIDPtr,
+			SSLExpiry:        sslExpiry,
+			SSLIssuer:        sslIssuer,
+			LastSeenAt:       now,
+			CreatedAt:        now,
+		}
+
+		if err := t.store.DiscoveredRoutes.UpsertDiscoveredRoute(ctx, route); err != nil {
+			log.Printf("traefik discovery: upsert route %s: %v", rr.Name, err)
+		}
+	}
+
+	log.Printf("traefik discovery: upserted %d routes for component %s (%s)",
+		len(routers), component.Name, component.ID)
+	return nil
+}

--- a/internal/infrastructure/traefik_discovery_test.go
+++ b/internal/infrastructure/traefik_discovery_test.go
@@ -1,0 +1,71 @@
+package infrastructure
+
+import "testing"
+
+func TestParseHostFromRule(t *testing.T) {
+	tests := []struct {
+		name  string
+		rule  string
+		want  string // "" means expect nil
+		isNil bool
+	}{
+		{
+			name: "backtick syntax",
+			rule: "Host(`sonarr.example.com`)",
+			want: "sonarr.example.com",
+		},
+		{
+			name: "double-quote syntax",
+			rule: `Host("sonarr.example.com")`,
+			want: "sonarr.example.com",
+		},
+		{
+			name:  "HostRegexp skipped",
+			rule:  "HostRegexp(`[a-z]+\\.example\\.com`)",
+			isNil: true,
+		},
+		{
+			name:  "PathPrefix only — no host",
+			rule:  "PathPrefix(`/api`)",
+			isNil: true,
+		},
+		{
+			name:  "empty rule",
+			rule:  "",
+			isNil: true,
+		},
+		{
+			name: "Host with trailing PathPrefix — first match wins",
+			rule: "Host(`foo.bar.com`) && PathPrefix(`/api`)",
+			want: "foo.bar.com",
+		},
+		{
+			name: "subdomain with multiple labels",
+			rule: "Host(`app.internal.corp.example.com`)",
+			want: "app.internal.corp.example.com",
+		},
+		{
+			name: "double-quote with ampersand rule",
+			rule: `Host("grafana.home") && PathPrefix("/")`,
+			want: "grafana.home",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseHostFromRule(tc.rule)
+			if tc.isNil {
+				if got != nil {
+					t.Errorf("expected nil, got %q", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %q, got nil", tc.want)
+			}
+			if *got != tc.want {
+				t.Errorf("got %q, want %q", *got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/jobs/traefik_component.go
+++ b/internal/jobs/traefik_component.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/digitalcheffe/nora/internal/infra"
+	"github.com/digitalcheffe/nora/internal/infrastructure"
 	"github.com/digitalcheffe/nora/internal/models"
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/google/uuid"
@@ -159,6 +160,14 @@ func pollTraefikComponent(ctx context.Context, store *repo.Store, c models.Infra
 		if err := store.TraefikComponents.UpsertRoutes(ctx, c.ID, routes); err != nil {
 			log.Printf("traefik component scheduler: upsert routes for %s: %v", c.Name, err)
 		}
+	}
+
+	// ── Populate discovered_routes ────────────────────────────────────────────
+
+	discovery := infrastructure.NewTraefikDiscovery(store)
+	if err := discovery.Run(ctx, &c); err != nil {
+		// Non-critical — log but do not fail the component poll.
+		log.Printf("traefik component scheduler: discovery run for %s: %v", c.Name, err)
 	}
 
 	// ── Update component status ───────────────────────────────────────────────


### PR DESCRIPTION
## What
Implements the Traefik route discovery worker (DD-3). On every 5-minute Traefik component poll cycle, HTTP routers are fetched from the Traefik API, their Host rules are parsed to extract domain names, backend service names are cross-referenced against discovered containers, SSL data is pulled from the already-cached `traefik_component_certs`, and results are upserted into `discovered_routes`.

Also adds two new API endpoints that power the unified discovery view (DD-6).

## Why
Closes DD-3 — Traefik route discovery worker.

## How
- New package `internal/infrastructure/` with `TraefikDiscovery` struct and `ParseHostFromRule` pure function
- `ParseHostFromRule` handles Host(\`domain\`) and Host("domain") via a single regex; HostRegexp and PathPrefix-only rules return nil
- `TraefikDiscovery.Run(ctx, component)` is called from the end of `pollTraefikComponent` in `jobs/traefik_component.go` — reuses the existing 5-minute scheduler, no new goroutine needed
- SSL data sourced from `traefik_component_certs` (populated earlier in the same poll cycle) to avoid a redundant HTTP call
- Container cross-referencing strips the Traefik provider suffix (`sonarr@docker` → `sonarr`) before matching against `discovered_containers.container_name`
- `GET /api/v1/infrastructure/{id}/routes` — routes for one Traefik component, with `container_name` denormalised from discovered_containers
- `GET /api/v1/discovery/all` — all containers + all routes in one response, aggregated across all components

## Test coverage
- `go test ./internal/infrastructure/...` — 8 domain parser test cases covering backtick syntax, double-quote syntax, HostRegexp skip, PathPrefix-only, empty rule, compound rule with PathPrefix, multi-label subdomain, and double-quote compound rule
- `go test ./...` — all packages pass

## Closes
Closes DD-3