### PR TITLE
feat: DD-4 — App linking API

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -184,7 +184,7 @@ func main() {
 		api.NewInfraComponentHandler(infraComponentRepo, resourceRollupRepo, checkRepo, traefikComponentRepo).Routes(r)
 		api.NewProfilesHandler(registry, customProfileRepo).Routes(r)
 		api.NewInfraHandler(infraRepo, syncWorker).Routes(r)
-		api.NewDockerDiscoveryHandler(store).Routes(r)
+		api.NewDockerDiscoveryHandler(store, registry).Routes(r)
 		api.NewDigestHandler(store, digestJob).Routes(r)
 		api.NewSettingsHandler(store).Routes(r)
 		api.NewIntegrationDriversHandler(settingsRepo).Routes(r)

--- a/internal/api/docker_discovery.go
+++ b/internal/api/docker_discovery.go
@@ -1,23 +1,28 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
 
+	"github.com/digitalcheffe/nora/internal/apptemplate"
 	"github.com/digitalcheffe/nora/internal/models"
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 )
 
 // DockerDiscoveryHandler serves the container discovery endpoints.
 type DockerDiscoveryHandler struct {
-	store *repo.Store
+	store    *repo.Store
+	profiles apptemplate.Loader
 }
 
-// NewDockerDiscoveryHandler returns a DockerDiscoveryHandler wired to store.
-func NewDockerDiscoveryHandler(store *repo.Store) *DockerDiscoveryHandler {
-	return &DockerDiscoveryHandler{store: store}
+// NewDockerDiscoveryHandler returns a DockerDiscoveryHandler wired to store and profiles.
+func NewDockerDiscoveryHandler(store *repo.Store, profiles apptemplate.Loader) *DockerDiscoveryHandler {
+	return &DockerDiscoveryHandler{store: store, profiles: profiles}
 }
 
 // Routes registers the docker discovery endpoints on r.
@@ -25,6 +30,10 @@ func (h *DockerDiscoveryHandler) Routes(r chi.Router) {
 	r.Get("/docker-engines/{id}/containers", h.ListContainers)
 	r.Get("/infrastructure/{id}/routes", h.ListRoutes)
 	r.Get("/discovery/all", h.ListAll)
+	r.Post("/discovered-containers/{id}/link-app", h.LinkContainerApp)
+	r.Delete("/discovered-containers/{id}/link-app", h.UnlinkContainerApp)
+	r.Post("/discovered-routes/{id}/link-app", h.LinkRouteApp)
+	r.Delete("/discovered-routes/{id}/link-app", h.UnlinkRouteApp)
 }
 
 // discoveredContainerResponse is the per-container shape returned by the API.
@@ -251,4 +260,268 @@ func (h *DockerDiscoveryHandler) ListAll(w http.ResponseWriter, r *http.Request)
 		Containers: containerOut,
 		Routes:     routeOut,
 	})
+}
+
+// ── Link / Unlink ─────────────────────────────────────────────────────────────
+
+type linkAppRequest struct {
+	Mode      string          `json:"mode"`       // "existing" | "create"
+	AppID     string          `json:"app_id"`     // mode=existing
+	ProfileID string          `json:"profile_id"` // mode=create
+	Name      string          `json:"name"`       // mode=create
+	Config    json.RawMessage `json:"config"`     // mode=create
+}
+
+// LinkContainerApp links a discovered container to an app.
+// POST /api/v1/discovered-containers/{id}/link-app
+func (h *DockerDiscoveryHandler) LinkContainerApp(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	container, err := h.store.DiscoveredContainers.GetDiscoveredContainer(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "discovered container not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var req linkAppRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	switch req.Mode {
+	case "existing":
+		if req.AppID == "" {
+			writeError(w, http.StatusUnprocessableEntity, "app_id is required for mode=existing")
+			return
+		}
+		app, err := h.store.Apps.Get(r.Context(), req.AppID)
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusUnprocessableEntity, "app_id does not exist")
+			return
+		}
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if err := h.store.DiscoveredContainers.SetDiscoveredContainerApp(r.Context(), id, req.AppID); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		// Set docker_engine_id on the app if not already set.
+		if app.DockerEngineID == "" {
+			_ = h.store.Apps.SetDockerEngineID(r.Context(), req.AppID, container.DockerEngineID)
+		}
+		container.AppID = &req.AppID
+		writeJSON(w, http.StatusOK, container)
+
+	case "create":
+		if req.Name == "" {
+			writeError(w, http.StatusUnprocessableEntity, "name is required for mode=create")
+			return
+		}
+		if req.ProfileID == "" {
+			writeError(w, http.StatusUnprocessableEntity, "profile_id is required for mode=create")
+			return
+		}
+		if t, _ := h.profiles.Get(req.ProfileID); t == nil {
+			writeError(w, http.StatusUnprocessableEntity, "profile_id does not exist")
+			return
+		}
+		token, err := generateToken()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to generate token")
+			return
+		}
+		cfg := models.ConfigJSON("{}")
+		if len(req.Config) > 0 {
+			cfg = models.ConfigJSON(req.Config)
+		}
+		app := &models.App{
+			ID:             uuid.New().String(),
+			Name:           req.Name,
+			Token:          token,
+			ProfileID:      req.ProfileID,
+			DockerEngineID: container.DockerEngineID,
+			Config:         cfg,
+			RateLimit:      100,
+			CreatedAt:      time.Now().UTC(),
+		}
+		if err := h.store.Apps.Create(r.Context(), app); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if err := h.store.DiscoveredContainers.SetDiscoveredContainerApp(r.Context(), id, app.ID); err != nil {
+			// Best-effort rollback — orphaned app is better than silent failure.
+			_ = h.store.Apps.Delete(r.Context(), app.ID)
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusCreated, app)
+
+	default:
+		writeError(w, http.StatusUnprocessableEntity, "mode must be 'existing' or 'create'")
+	}
+}
+
+// UnlinkContainerApp sets app_id back to null on a discovered container.
+// DELETE /api/v1/discovered-containers/{id}/link-app
+func (h *DockerDiscoveryHandler) UnlinkContainerApp(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if _, err := h.store.DiscoveredContainers.GetDiscoveredContainer(r.Context(), id); errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "discovered container not found")
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if err := h.store.DiscoveredContainers.ClearDiscoveredContainerApp(r.Context(), id); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// LinkRouteApp links a discovered route to an app, and auto-creates an SSL check
+// for the route's domain if one does not already exist.
+// POST /api/v1/discovered-routes/{id}/link-app
+func (h *DockerDiscoveryHandler) LinkRouteApp(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	route, err := h.store.DiscoveredRoutes.GetDiscoveredRoute(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "discovered route not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var req linkAppRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	var linkedAppID string
+
+	switch req.Mode {
+	case "existing":
+		if req.AppID == "" {
+			writeError(w, http.StatusUnprocessableEntity, "app_id is required for mode=existing")
+			return
+		}
+		if _, err := h.store.Apps.Get(r.Context(), req.AppID); errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusUnprocessableEntity, "app_id does not exist")
+			return
+		} else if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if err := h.store.DiscoveredRoutes.SetDiscoveredRouteApp(r.Context(), id, req.AppID); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		linkedAppID = req.AppID
+		route.AppID = &linkedAppID
+		h.maybeCreateSSLCheck(r.Context(), route)
+		writeJSON(w, http.StatusOK, route)
+
+
+	case "create":
+		if req.Name == "" {
+			writeError(w, http.StatusUnprocessableEntity, "name is required for mode=create")
+			return
+		}
+		if req.ProfileID == "" {
+			writeError(w, http.StatusUnprocessableEntity, "profile_id is required for mode=create")
+			return
+		}
+		if t, _ := h.profiles.Get(req.ProfileID); t == nil {
+			writeError(w, http.StatusUnprocessableEntity, "profile_id does not exist")
+			return
+		}
+		token, err := generateToken()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to generate token")
+			return
+		}
+		cfg := models.ConfigJSON("{}")
+		if len(req.Config) > 0 {
+			cfg = models.ConfigJSON(req.Config)
+		}
+		app := &models.App{
+			ID:        uuid.New().String(),
+			Name:      req.Name,
+			Token:     token,
+			ProfileID: req.ProfileID,
+			Config:    cfg,
+			RateLimit: 100,
+			CreatedAt: time.Now().UTC(),
+		}
+		if err := h.store.Apps.Create(r.Context(), app); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if err := h.store.DiscoveredRoutes.SetDiscoveredRouteApp(r.Context(), id, app.ID); err != nil {
+			_ = h.store.Apps.Delete(r.Context(), app.ID)
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		linkedAppID = app.ID
+		route.AppID = &linkedAppID
+		h.maybeCreateSSLCheck(r.Context(), route)
+		writeJSON(w, http.StatusCreated, app)
+
+	default:
+		writeError(w, http.StatusUnprocessableEntity, "mode must be 'existing' or 'create'")
+	}
+}
+
+// UnlinkRouteApp sets app_id back to null on a discovered route.
+// DELETE /api/v1/discovered-routes/{id}/link-app
+func (h *DockerDiscoveryHandler) UnlinkRouteApp(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if _, err := h.store.DiscoveredRoutes.GetDiscoveredRoute(r.Context(), id); errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "discovered route not found")
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if err := h.store.DiscoveredRoutes.ClearDiscoveredRouteApp(r.Context(), id); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// maybeCreateSSLCheck creates an ssl monitor check for route.Domain if the route
+// has a domain and no ssl check for that domain already exists.
+func (h *DockerDiscoveryHandler) maybeCreateSSLCheck(ctx context.Context, route *models.DiscoveredRoute) {
+	if route.Domain == nil || *route.Domain == "" {
+		return
+	}
+	domain := *route.Domain
+	exists, err := h.store.Checks.ExistsForTypeAndTarget(ctx, "ssl", domain)
+	if err != nil || exists {
+		return
+	}
+	check := &models.MonitorCheck{
+		ID:           uuid.New().String(),
+		Name:         "SSL — " + domain,
+		Type:         "ssl",
+		Target:       domain,
+		IntervalSecs: 3600,
+		SSLWarnDays:  30,
+		SSLCritDays:  7,
+		Enabled:      true,
+		CreatedAt:    time.Now().UTC(),
+	}
+	_ = h.store.Checks.Create(ctx, check)
 }

--- a/internal/api/docker_discovery_link_test.go
+++ b/internal/api/docker_discovery_link_test.go
@@ -1,0 +1,500 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/api"
+	"github.com/digitalcheffe/nora/internal/apptemplate"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+// newDiscoveryLinkRouter builds a DockerDiscoveryHandler-backed chi router
+// using an in-memory DB. It returns both the router and the db so callers
+// can seed data directly.
+func newDiscoveryLinkRouter(t *testing.T, profiles apptemplate.Loader) (http.Handler, *sqlx.DB) {
+	t.Helper()
+	db := newTestDB(t)
+	store := repo.NewStore(
+		repo.NewAppRepo(db),
+		repo.NewEventRepo(db),
+		repo.NewCheckRepo(db),
+		repo.NewRollupRepo(db),
+		repo.NewResourceReadingRepo(db),
+		repo.NewResourceRollupRepo(db),
+		repo.NewInfraComponentRepo(db),
+		repo.NewDockerEngineRepo(db),
+		repo.NewInfraRepo(db),
+		repo.NewSettingsRepo(db),
+		repo.NewMetricsRepo(db),
+		repo.NewUserRepo(db),
+		repo.NewTraefikComponentRepo(db),
+		repo.NewDiscoveredContainerRepo(db),
+		repo.NewDiscoveredRouteRepo(db),
+	)
+	h := api.NewDockerDiscoveryHandler(store, profiles)
+	r := chi.NewRouter()
+	h.Routes(r)
+	return r, db
+}
+
+// seedDockerEngineForLink inserts a docker_engines row and returns its ID.
+func seedDockerEngineForLink(t *testing.T, db *sqlx.DB) string {
+	t.Helper()
+	id := uuid.NewString()
+	_, err := db.Exec(
+		`INSERT INTO docker_engines (id, name, socket_type, socket_path) VALUES (?, 'eng', 'local', '/var/run/docker.sock')`, id)
+	if err != nil {
+		t.Fatalf("seed docker engine: %v", err)
+	}
+	return id
+}
+
+// seedInfraComponentForLink inserts an infrastructure_components row and returns its ID.
+func seedInfraComponentForLink(t *testing.T, db *sqlx.DB) string {
+	t.Helper()
+	id := uuid.NewString()
+	_, err := db.Exec(
+		`INSERT INTO infrastructure_components (id, name, type, collection_method) VALUES (?, 'traefik', 'traefik', 'traefik_api')`, id)
+	if err != nil {
+		t.Fatalf("seed infra component: %v", err)
+	}
+	return id
+}
+
+// seedDiscoveredContainer inserts a discovered_containers row and returns its ID.
+func seedDiscoveredContainer(t *testing.T, db *sqlx.DB, engineID string) string {
+	t.Helper()
+	containerRepo := repo.NewDiscoveredContainerRepo(db)
+	now := time.Now().UTC()
+	c := &models.DiscoveredContainer{
+		DockerEngineID: engineID,
+		ContainerID:    uuid.NewString(),
+		ContainerName:  "sonarr",
+		Image:          "linuxserver/sonarr:latest",
+		Status:         "running",
+		LastSeenAt:     now,
+		CreatedAt:      now,
+	}
+	if err := containerRepo.UpsertDiscoveredContainer(t.Context(), c); err != nil {
+		t.Fatalf("seed discovered container: %v", err)
+	}
+	return c.ID
+}
+
+// seedDiscoveredRoute inserts a discovered_routes row and returns its ID.
+func seedDiscoveredRoute(t *testing.T, db *sqlx.DB, infraID string, domain *string) string {
+	t.Helper()
+	routeRepo := repo.NewDiscoveredRouteRepo(db)
+	now := time.Now().UTC()
+	ro := &models.DiscoveredRoute{
+		InfrastructureID: infraID,
+		RouterName:       "sonarr-router",
+		Rule:             "Host(`sonarr.example.com`)",
+		Domain:           domain,
+		LastSeenAt:       now,
+		CreatedAt:        now,
+	}
+	if err := routeRepo.UpsertDiscoveredRoute(t.Context(), ro); err != nil {
+		t.Fatalf("seed discovered route: %v", err)
+	}
+	return ro.ID
+}
+
+// seedApp inserts an apps row and returns its ID.
+func seedAppForLink(t *testing.T, db *sqlx.DB) string {
+	t.Helper()
+	id := uuid.NewString()
+	_, err := db.Exec(
+		`INSERT INTO apps (id, name, token, rate_limit, created_at) VALUES (?, 'TestApp', 'tok-link', 100, datetime('now'))`, id)
+	if err != nil {
+		t.Fatalf("seed app: %v", err)
+	}
+	return id
+}
+
+// stubbedProfiles returns a Loader whose Get always returns a non-nil template
+// for "sonarr" and nil for anything else.
+type stubbedProfiles struct{}
+
+func (s *stubbedProfiles) Get(id string) (*apptemplate.AppTemplate, error) {
+	if id == "sonarr" {
+		return &apptemplate.AppTemplate{}, nil
+	}
+	return nil, nil
+}
+
+// ── LinkContainerApp ───────────────────────────────────────────────────────────
+
+func TestLinkContainerApp_ExistingMode_OK(t *testing.T) {
+	router, db := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	engineID := seedDockerEngineForLink(t, db)
+	containerID := seedDiscoveredContainer(t, db, engineID)
+	appID := seedAppForLink(t, db)
+
+	body, _ := json.Marshal(map[string]any{"mode": "existing", "app_id": appID})
+	req := httptest.NewRequest(http.MethodPost, "/discovered-containers/"+containerID+"/link-app", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var c models.DiscoveredContainer
+	if err := json.NewDecoder(rr.Body).Decode(&c); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if c.AppID == nil || *c.AppID != appID {
+		t.Errorf("app_id: want %s, got %v", appID, c.AppID)
+	}
+}
+
+func TestLinkContainerApp_ExistingMode_InvalidAppID(t *testing.T) {
+	router, db := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	engineID := seedDockerEngineForLink(t, db)
+	containerID := seedDiscoveredContainer(t, db, engineID)
+
+	body, _ := json.Marshal(map[string]any{"mode": "existing", "app_id": "does-not-exist"})
+	req := httptest.NewRequest(http.MethodPost, "/discovered-containers/"+containerID+"/link-app", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestLinkContainerApp_CreateMode_OK(t *testing.T) {
+	router, db := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	engineID := seedDockerEngineForLink(t, db)
+	containerID := seedDiscoveredContainer(t, db, engineID)
+
+	body, _ := json.Marshal(map[string]any{
+		"mode":       "create",
+		"profile_id": "sonarr",
+		"name":       "My Sonarr",
+		"config":     map[string]any{"base_url": "http://sonarr:8989"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/discovered-containers/"+containerID+"/link-app", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var app models.App
+	if err := json.NewDecoder(rr.Body).Decode(&app); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if app.ID == "" {
+		t.Error("app.ID must not be empty")
+	}
+	if app.ProfileID != "sonarr" {
+		t.Errorf("profile_id: want sonarr, got %s", app.ProfileID)
+	}
+	if app.DockerEngineID != engineID {
+		t.Errorf("docker_engine_id: want %s, got %s", engineID, app.DockerEngineID)
+	}
+	// Verify the container is linked.
+	checkDB := repo.NewDiscoveredContainerRepo(db)
+	got, _ := checkDB.GetDiscoveredContainer(t.Context(), containerID)
+	if got.AppID == nil || *got.AppID != app.ID {
+		t.Errorf("container app_id: want %s, got %v", app.ID, got.AppID)
+	}
+}
+
+func TestLinkContainerApp_CreateMode_InvalidProfileID(t *testing.T) {
+	router, db := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	engineID := seedDockerEngineForLink(t, db)
+	containerID := seedDiscoveredContainer(t, db, engineID)
+
+	body, _ := json.Marshal(map[string]any{"mode": "create", "profile_id": "nonexistent", "name": "x"})
+	req := httptest.NewRequest(http.MethodPost, "/discovered-containers/"+containerID+"/link-app", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestLinkContainerApp_NotFound(t *testing.T) {
+	router, _ := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	body, _ := json.Marshal(map[string]any{"mode": "existing", "app_id": "x"})
+	req := httptest.NewRequest(http.MethodPost, "/discovered-containers/does-not-exist/link-app", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+}
+
+// ── UnlinkContainerApp ────────────────────────────────────────────────────────
+
+func TestUnlinkContainerApp_OK(t *testing.T) {
+	router, db := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	engineID := seedDockerEngineForLink(t, db)
+	containerID := seedDiscoveredContainer(t, db, engineID)
+	appID := seedAppForLink(t, db)
+
+	// Link first.
+	linkBody, _ := json.Marshal(map[string]any{"mode": "existing", "app_id": appID})
+	linkReq := httptest.NewRequest(http.MethodPost, "/discovered-containers/"+containerID+"/link-app", bytes.NewReader(linkBody))
+	linkReq.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(httptest.NewRecorder(), linkReq)
+
+	// Now unlink.
+	req := httptest.NewRequest(http.MethodDelete, "/discovered-containers/"+containerID+"/link-app", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+	// Verify app_id is null.
+	checkDB := repo.NewDiscoveredContainerRepo(db)
+	got, _ := checkDB.GetDiscoveredContainer(t.Context(), containerID)
+	if got.AppID != nil {
+		t.Errorf("app_id: want nil, got %v", got.AppID)
+	}
+	// Verify the app still exists.
+	appRepo := repo.NewAppRepo(db)
+	if _, err := appRepo.Get(t.Context(), appID); err != nil {
+		t.Errorf("app should still exist after unlink: %v", err)
+	}
+}
+
+func TestUnlinkContainerApp_NotFound(t *testing.T) {
+	router, _ := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	req := httptest.NewRequest(http.MethodDelete, "/discovered-containers/does-not-exist/link-app", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+}
+
+// ── LinkRouteApp ──────────────────────────────────────────────────────────────
+
+func TestLinkRouteApp_ExistingMode_OK(t *testing.T) {
+	router, db := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	infraID := seedInfraComponentForLink(t, db)
+	domain := "sonarr.example.com"
+	routeID := seedDiscoveredRoute(t, db, infraID, &domain)
+	appID := seedAppForLink(t, db)
+
+	body, _ := json.Marshal(map[string]any{"mode": "existing", "app_id": appID})
+	req := httptest.NewRequest(http.MethodPost, "/discovered-routes/"+routeID+"/link-app", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// SSL check should have been auto-created.
+	checkRepo := repo.NewCheckRepo(db)
+	exists, err := checkRepo.ExistsForTypeAndTarget(t.Context(), "ssl", domain)
+	if err != nil {
+		t.Fatalf("exists check: %v", err)
+	}
+	if !exists {
+		t.Error("expected SSL check to be auto-created for domain")
+	}
+}
+
+func TestLinkRouteApp_NoDomain_NoSSLCheck(t *testing.T) {
+	router, db := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	infraID := seedInfraComponentForLink(t, db)
+	routeID := seedDiscoveredRoute(t, db, infraID, nil) // no domain
+	appID := seedAppForLink(t, db)
+
+	body, _ := json.Marshal(map[string]any{"mode": "existing", "app_id": appID})
+	req := httptest.NewRequest(http.MethodPost, "/discovered-routes/"+routeID+"/link-app", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	// No SSL check created for domain-less routes.
+	checkRepo := repo.NewCheckRepo(db)
+	checks, _ := checkRepo.List(t.Context())
+	for _, c := range checks {
+		if c.Type == "ssl" {
+			t.Error("unexpected SSL check created for route without domain")
+		}
+	}
+}
+
+func TestLinkRouteApp_NoDuplicateSSLCheck(t *testing.T) {
+	router, db := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	infraID := seedInfraComponentForLink(t, db)
+	domain := "dupe.example.com"
+	routeID := seedDiscoveredRoute(t, db, infraID, &domain)
+	appID := seedAppForLink(t, db)
+
+	// Pre-create an SSL check for the same domain.
+	checkRepo := repo.NewCheckRepo(db)
+	existing := &models.MonitorCheck{
+		ID:           uuid.NewString(),
+		Name:         "SSL — " + domain,
+		Type:         "ssl",
+		Target:       domain,
+		IntervalSecs: 3600,
+		SSLWarnDays:  30,
+		SSLCritDays:  7,
+		Enabled:      true,
+		CreatedAt:    time.Now().UTC(),
+	}
+	if err := checkRepo.Create(t.Context(), existing); err != nil {
+		t.Fatalf("pre-create check: %v", err)
+	}
+
+	// Link the route.
+	body, _ := json.Marshal(map[string]any{"mode": "existing", "app_id": appID})
+	req := httptest.NewRequest(http.MethodPost, "/discovered-routes/"+routeID+"/link-app", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Still only one SSL check for this domain.
+	checks, _ := checkRepo.List(t.Context())
+	count := 0
+	for _, c := range checks {
+		if c.Type == "ssl" && c.Target == domain {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 SSL check for domain, got %d", count)
+	}
+}
+
+func TestLinkRouteApp_CreateMode_OK(t *testing.T) {
+	router, db := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	infraID := seedInfraComponentForLink(t, db)
+	domain := "create.example.com"
+	routeID := seedDiscoveredRoute(t, db, infraID, &domain)
+
+	body, _ := json.Marshal(map[string]any{
+		"mode":       "create",
+		"profile_id": "sonarr",
+		"name":       "Create Route App",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/discovered-routes/"+routeID+"/link-app", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var app models.App
+	if err := json.NewDecoder(rr.Body).Decode(&app); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if app.ID == "" {
+		t.Error("app.ID must not be empty")
+	}
+	// SSL check auto-created.
+	checkRepo := repo.NewCheckRepo(db)
+	exists, _ := checkRepo.ExistsForTypeAndTarget(t.Context(), "ssl", domain)
+	if !exists {
+		t.Error("expected SSL check auto-created for route domain")
+	}
+}
+
+func TestLinkRouteApp_InvalidAppID(t *testing.T) {
+	router, db := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	infraID := seedInfraComponentForLink(t, db)
+	routeID := seedDiscoveredRoute(t, db, infraID, nil)
+
+	body, _ := json.Marshal(map[string]any{"mode": "existing", "app_id": "nope"})
+	req := httptest.NewRequest(http.MethodPost, "/discovered-routes/"+routeID+"/link-app", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d", rr.Code)
+	}
+}
+
+func TestLinkRouteApp_InvalidProfileID(t *testing.T) {
+	router, db := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	infraID := seedInfraComponentForLink(t, db)
+	routeID := seedDiscoveredRoute(t, db, infraID, nil)
+
+	body, _ := json.Marshal(map[string]any{"mode": "create", "profile_id": "unknown", "name": "x"})
+	req := httptest.NewRequest(http.MethodPost, "/discovered-routes/"+routeID+"/link-app", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d", rr.Code)
+	}
+}
+
+// ── UnlinkRouteApp ────────────────────────────────────────────────────────────
+
+func TestUnlinkRouteApp_OK(t *testing.T) {
+	router, db := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	infraID := seedInfraComponentForLink(t, db)
+	routeID := seedDiscoveredRoute(t, db, infraID, nil)
+	appID := seedAppForLink(t, db)
+
+	// Link first.
+	linkBody, _ := json.Marshal(map[string]any{"mode": "existing", "app_id": appID})
+	linkReq := httptest.NewRequest(http.MethodPost, "/discovered-routes/"+routeID+"/link-app", bytes.NewReader(linkBody))
+	linkReq.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(httptest.NewRecorder(), linkReq)
+
+	req := httptest.NewRequest(http.MethodDelete, "/discovered-routes/"+routeID+"/link-app", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+	routeRepo := repo.NewDiscoveredRouteRepo(db)
+	got, _ := routeRepo.GetDiscoveredRoute(t.Context(), routeID)
+	if got.AppID != nil {
+		t.Errorf("app_id: want nil after unlink, got %v", got.AppID)
+	}
+	// App still exists.
+	appRepo := repo.NewAppRepo(db)
+	if _, err := appRepo.Get(t.Context(), appID); err != nil {
+		t.Errorf("app should still exist after unlink: %v", err)
+	}
+}
+
+func TestUnlinkRouteApp_NotFound(t *testing.T) {
+	router, _ := newDiscoveryLinkRouter(t, &stubbedProfiles{})
+	req := httptest.NewRequest(http.MethodDelete, "/discovered-routes/does-not-exist/link-app", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+}

--- a/internal/docker/watcher_test.go
+++ b/internal/docker/watcher_test.go
@@ -49,6 +49,7 @@ func (r *mockAppRepo) GetByToken(_ context.Context, _ string) (*models.App, erro
 func (r *mockAppRepo) Update(_ context.Context, _ *models.App) error                 { return nil }
 func (r *mockAppRepo) Delete(_ context.Context, _ string) error                      { return nil }
 func (r *mockAppRepo) UpdateToken(_ context.Context, _, _ string) error              { return nil }
+func (r *mockAppRepo) SetDockerEngineID(_ context.Context, _, _ string) error       { return nil }
 
 type mockEventRepo struct {
 	created []*models.Event

--- a/internal/repo/apps.go
+++ b/internal/repo/apps.go
@@ -22,6 +22,8 @@ type AppRepo interface {
 	Update(ctx context.Context, app *models.App) error
 	Delete(ctx context.Context, id string) error
 	UpdateToken(ctx context.Context, id, token string) error
+	// SetDockerEngineID sets the docker_engine_id on the app unconditionally.
+	SetDockerEngineID(ctx context.Context, appID, engineID string) error
 }
 
 type sqliteAppRepo struct {
@@ -120,6 +122,18 @@ func (r *sqliteAppRepo) UpdateToken(ctx context.Context, id, token string) error
 	res, err := r.db.ExecContext(ctx, `UPDATE apps SET token=? WHERE id=?`, token, id)
 	if err != nil {
 		return fmt.Errorf("update token: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sqliteAppRepo) SetDockerEngineID(ctx context.Context, appID, engineID string) error {
+	res, err := r.db.ExecContext(ctx, `UPDATE apps SET docker_engine_id=? WHERE id=?`, engineID, appID)
+	if err != nil {
+		return fmt.Errorf("set docker_engine_id on app %s: %w", appID, err)
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {

--- a/internal/repo/checks.go
+++ b/internal/repo/checks.go
@@ -25,6 +25,8 @@ type CheckRepo interface {
 	DeleteBySourceComponent(ctx context.Context, componentID string) error
 	// UpsertForComponent inserts or updates a Traefik-owned SSL check.
 	UpsertForComponent(ctx context.Context, check *models.MonitorCheck) error
+	// ExistsForTypeAndTarget reports whether any check with the given type and target exists.
+	ExistsForTypeAndTarget(ctx context.Context, checkType, target string) (bool, error)
 }
 
 type sqliteCheckRepo struct {
@@ -160,6 +162,16 @@ func (r *sqliteCheckRepo) DeleteBySourceComponent(ctx context.Context, component
 		return fmt.Errorf("delete checks by component: %w", err)
 	}
 	return nil
+}
+
+func (r *sqliteCheckRepo) ExistsForTypeAndTarget(ctx context.Context, checkType, target string) (bool, error) {
+	var count int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM monitor_checks WHERE type = ? AND target = ?`, checkType, target).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("exists check for type/target: %w", err)
+	}
+	return count > 0, nil
 }
 
 // UpsertForComponent inserts or updates a Traefik-owned SSL check identified by

--- a/internal/repo/discovery.go
+++ b/internal/repo/discovery.go
@@ -21,6 +21,7 @@ type DiscoveredContainerRepo interface {
 	ListAllDiscoveredContainers(ctx context.Context) ([]*models.DiscoveredContainer, error)
 	GetDiscoveredContainer(ctx context.Context, id string) (*models.DiscoveredContainer, error)
 	SetDiscoveredContainerApp(ctx context.Context, id string, appID string) error
+	ClearDiscoveredContainerApp(ctx context.Context, id string) error
 	UpdateDiscoveredContainerStatus(ctx context.Context, id string, status string, lastSeenAt time.Time) error
 }
 
@@ -31,6 +32,7 @@ type DiscoveredRouteRepo interface {
 	ListAllDiscoveredRoutes(ctx context.Context) ([]*models.DiscoveredRoute, error)
 	GetDiscoveredRoute(ctx context.Context, id string) (*models.DiscoveredRoute, error)
 	SetDiscoveredRouteApp(ctx context.Context, id string, appID string) error
+	ClearDiscoveredRouteApp(ctx context.Context, id string) error
 }
 
 // ── DiscoveredContainerRepo implementation ────────────────────────────────────
@@ -120,6 +122,19 @@ func (r *sqliteDiscoveredContainerRepo) SetDiscoveredContainerApp(ctx context.Co
 		`UPDATE discovered_containers SET app_id = ? WHERE id = ?`, appID, id)
 	if err != nil {
 		return fmt.Errorf("set app on discovered container %s: %w", id, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("discovered container %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+func (r *sqliteDiscoveredContainerRepo) ClearDiscoveredContainerApp(ctx context.Context, id string) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE discovered_containers SET app_id = NULL WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("clear app on discovered container %s: %w", id, err)
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
@@ -230,6 +245,19 @@ func (r *sqliteDiscoveredRouteRepo) SetDiscoveredRouteApp(ctx context.Context, i
 		`UPDATE discovered_routes SET app_id = ? WHERE id = ?`, appID, id)
 	if err != nil {
 		return fmt.Errorf("set app on discovered route %s: %w", id, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("discovered route %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+func (r *sqliteDiscoveredRouteRepo) ClearDiscoveredRouteApp(ctx context.Context, id string) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE discovered_routes SET app_id = NULL WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("clear app on discovered route %s: %w", id, err)
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {


### PR DESCRIPTION
## What
Adds POST and DELETE endpoints to link/unlink discovered containers and routes to NORA apps.

## Why
Closes DD-4. Once Docker and Traefik discovery workers are running (DD-2, DD-3), users need a way to connect discovered resources to NORA apps — either by choosing an existing app or creating a new one from a profile suggestion.

## How

**New endpoints:**
- `POST /api/v1/discovered-containers/{id}/link-app` — mode=existing links to an existing app; mode=create creates a new app from a profile and links it atomically (with best-effort rollback on partial failure)
- `DELETE /api/v1/discovered-containers/{id}/link-app` — sets app_id back to NULL without deleting the app
- `POST /api/v1/discovered-routes/{id}/link-app` — same two modes; also auto-creates an SSL monitor check for the route's domain if one does not already exist
- `DELETE /api/v1/discovered-routes/{id}/link-app` — sets app_id back to NULL

**Repo additions:**
- `AppRepo.SetDockerEngineID` — sets docker_engine_id on an app
- `DiscoveredContainerRepo.ClearDiscoveredContainerApp` / `DiscoveredRouteRepo.ClearDiscoveredRouteApp` — sets app_id to NULL
- `CheckRepo.ExistsForTypeAndTarget` — dedup guard for SSL auto-creation

**Profile validation** uses the existing `apptemplate.Loader` (now injected into `DockerDiscoveryHandler`).

## Test coverage
- `go test ./...` passes across all packages
- `internal/api/docker_discovery_link_test.go` covers all 4 endpoints with happy-path and error-path cases:
  - mode=existing with valid/invalid app_id
  - mode=create with valid/invalid profile_id
  - SSL check auto-creation on route link with domain
  - No duplicate SSL check when one already exists
  - Domain-less route does not create SSL check
  - Unlink returns 204 and leaves app record intact
  - 404 for nonexistent container/route IDs

## Closes
Closes DD-4