### PR TITLE
feat: DD-7 — app enrichment on link

### DIFF
--- a/internal/api/docker_discovery.go
+++ b/internal/api/docker_discovery.go
@@ -1,13 +1,13 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
 
 	"github.com/digitalcheffe/nora/internal/apptemplate"
+	"github.com/digitalcheffe/nora/internal/docker"
 	"github.com/digitalcheffe/nora/internal/models"
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/go-chi/chi/v5"
@@ -311,6 +311,7 @@ func (h *DockerDiscoveryHandler) LinkContainerApp(w http.ResponseWriter, r *http
 			return
 		}
 		container.AppID = &req.AppID
+		_ = docker.EnrichAppOnLink(r.Context(), h.store, h.profiles, req.AppID, &id, nil)
 		writeJSON(w, http.StatusOK, container)
 
 	case "create":
@@ -354,6 +355,7 @@ func (h *DockerDiscoveryHandler) LinkContainerApp(w http.ResponseWriter, r *http
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
+		_ = docker.EnrichAppOnLink(r.Context(), h.store, h.profiles, app.ID, &id, nil)
 		writeJSON(w, http.StatusCreated, app)
 
 	default:
@@ -422,7 +424,7 @@ func (h *DockerDiscoveryHandler) LinkRouteApp(w http.ResponseWriter, r *http.Req
 		}
 		linkedAppID = req.AppID
 		route.AppID = &linkedAppID
-		h.maybeCreateSSLCheck(r.Context(), route)
+		_ = docker.EnrichAppOnLink(r.Context(), h.store, h.profiles, linkedAppID, nil, &id)
 		writeJSON(w, http.StatusOK, route)
 
 
@@ -468,7 +470,7 @@ func (h *DockerDiscoveryHandler) LinkRouteApp(w http.ResponseWriter, r *http.Req
 		}
 		linkedAppID = app.ID
 		route.AppID = &linkedAppID
-		h.maybeCreateSSLCheck(r.Context(), route)
+		_ = docker.EnrichAppOnLink(r.Context(), h.store, h.profiles, linkedAppID, nil, &id)
 		writeJSON(w, http.StatusCreated, app)
 
 	default:
@@ -494,27 +496,3 @@ func (h *DockerDiscoveryHandler) UnlinkRouteApp(w http.ResponseWriter, r *http.R
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// maybeCreateSSLCheck creates an ssl monitor check for route.Domain if the route
-// has a domain and no ssl check for that domain already exists.
-func (h *DockerDiscoveryHandler) maybeCreateSSLCheck(ctx context.Context, route *models.DiscoveredRoute) {
-	if route.Domain == nil || *route.Domain == "" {
-		return
-	}
-	domain := *route.Domain
-	exists, err := h.store.Checks.ExistsForTypeAndTarget(ctx, "ssl", domain)
-	if err != nil || exists {
-		return
-	}
-	check := &models.MonitorCheck{
-		ID:           uuid.New().String(),
-		Name:         "SSL — " + domain,
-		Type:         "ssl",
-		Target:       domain,
-		IntervalSecs: 3600,
-		SSLWarnDays:  30,
-		SSLCritDays:  7,
-		Enabled:      true,
-		CreatedAt:    time.Now().UTC(),
-	}
-	_ = h.store.Checks.Create(ctx, check)
-}

--- a/internal/docker/enrichment.go
+++ b/internal/docker/enrichment.go
@@ -1,0 +1,177 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/apptemplate"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+// EnrichAppOnLink wires up monitor checks, SSL checks, and historical resource
+// readings when a discovered container or route is linked to an app.
+//
+// containerID is the UUID of the discovered_containers row (not the Docker ID).
+// routeID is the UUID of the discovered_routes row.
+//
+// All enrichment steps are best-effort: errors are logged but do not prevent
+// the link from completing. The function returns an error only if the app
+// itself cannot be loaded.
+func EnrichAppOnLink(
+	ctx context.Context,
+	store *repo.Store,
+	profiles apptemplate.Loader,
+	appID string,
+	containerID *string,
+	routeID *string,
+) error {
+	app, err := store.Apps.Get(ctx, appID)
+	if err != nil {
+		return fmt.Errorf("enrichment: load app %s: %w", appID, err)
+	}
+
+	// Step 1 — monitor check from app profile.
+	if app.ProfileID != "" {
+		tmpl, err := profiles.Get(app.ProfileID)
+		if err != nil {
+			log.Printf("enrichment: load profile %q for app %q: %v", app.ProfileID, app.Name, err)
+		} else if tmpl != nil && tmpl.Monitor.CheckType != "" && tmpl.Monitor.CheckURL != "" {
+			enrichMonitorCheck(ctx, store, app, tmpl)
+		}
+	}
+
+	// Step 2 — SSL check from discovered route domain.
+	if routeID != nil {
+		enrichSSLCheck(ctx, store, *routeID)
+	}
+
+	// Step 3 — backfill historical resource readings.
+	if containerID != nil {
+		enrichResourceReadings(ctx, store, app, *containerID)
+	}
+
+	return nil
+}
+
+// enrichMonitorCheck creates a monitor check from the profile's monitor config
+// if one with the same type and target does not already exist.
+func enrichMonitorCheck(ctx context.Context, store *repo.Store, app *models.App, tmpl *apptemplate.AppTemplate) {
+	target := substituteBaseURL(tmpl.Monitor.CheckURL, app.Config)
+	exists, err := store.Checks.ExistsForTypeAndTarget(ctx, tmpl.Monitor.CheckType, target)
+	if err != nil {
+		log.Printf("enrichment: check existence query for app %q: %v", app.Name, err)
+		return
+	}
+	if exists {
+		return
+	}
+	check := &models.MonitorCheck{
+		ID:           uuid.New().String(),
+		AppID:        app.ID,
+		Name:         tmpl.Meta.Name + " — " + tmpl.Monitor.CheckType,
+		Type:         tmpl.Monitor.CheckType,
+		Target:       target,
+		IntervalSecs: parseIntervalSecs(tmpl.Monitor.CheckInterval, 300),
+		Enabled:      true,
+		CreatedAt:    time.Now().UTC(),
+	}
+	if tmpl.Monitor.HealthyStatus != 0 {
+		check.ExpectedStatus = tmpl.Monitor.HealthyStatus
+	}
+	if err := store.Checks.Create(ctx, check); err != nil {
+		log.Printf("enrichment: create monitor check for app %q: %v", app.Name, err)
+		return
+	}
+	log.Printf("enrichment: created monitor check for app %q", app.Name)
+}
+
+// enrichSSLCheck creates an SSL monitor check for the route's domain if one
+// does not already exist.
+func enrichSSLCheck(ctx context.Context, store *repo.Store, routeID string) {
+	route, err := store.DiscoveredRoutes.GetDiscoveredRoute(ctx, routeID)
+	if err != nil {
+		log.Printf("enrichment: load route %q: %v", routeID, err)
+		return
+	}
+	if route.Domain == nil || *route.Domain == "" {
+		return
+	}
+	domain := *route.Domain
+	exists, err := store.Checks.ExistsForTypeAndTarget(ctx, "ssl", domain)
+	if err != nil {
+		log.Printf("enrichment: ssl check existence for domain %q: %v", domain, err)
+		return
+	}
+	if exists {
+		return
+	}
+	check := &models.MonitorCheck{
+		ID:           uuid.New().String(),
+		Name:         "SSL — " + domain,
+		Type:         "ssl",
+		Target:       domain,
+		IntervalSecs: 3600,
+		SSLWarnDays:  30,
+		SSLCritDays:  7,
+		Enabled:      true,
+		CreatedAt:    time.Now().UTC(),
+	}
+	if err := store.Checks.Create(ctx, check); err != nil {
+		log.Printf("enrichment: create SSL check for domain %q: %v", domain, err)
+		return
+	}
+	log.Printf("enrichment: created SSL check for domain %q", domain)
+}
+
+// enrichResourceReadings backfills app_id on resource_readings for the docker
+// container linked via discoveredContainerUUID.
+func enrichResourceReadings(ctx context.Context, store *repo.Store, app *models.App, discoveredContainerUUID string) {
+	container, err := store.DiscoveredContainers.GetDiscoveredContainer(ctx, discoveredContainerUUID)
+	if err != nil {
+		log.Printf("enrichment: load discovered container %q: %v", discoveredContainerUUID, err)
+		return
+	}
+	n, err := store.Resources.BackfillAppID(ctx, container.ContainerID, app.ID)
+	if err != nil {
+		log.Printf("enrichment: backfill resource readings for app %q: %v", app.Name, err)
+		return
+	}
+	if n > 0 {
+		log.Printf("enrichment: backfilled %d resource readings for app %q", n, app.Name)
+	}
+}
+
+// substituteBaseURL replaces {base_url} in tmplURL with the base_url value
+// from the app config JSON. Returns tmplURL unchanged if no base_url is found.
+func substituteBaseURL(tmplURL string, cfg models.ConfigJSON) string {
+	if !strings.Contains(tmplURL, "{base_url}") {
+		return tmplURL
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(cfg, &m); err != nil {
+		return tmplURL
+	}
+	if v, ok := m["base_url"].(string); ok {
+		return strings.ReplaceAll(tmplURL, "{base_url}", v)
+	}
+	return tmplURL
+}
+
+// parseIntervalSecs converts a duration string (e.g. "5m", "1h", "30s") to
+// seconds. Returns fallback when s is empty or cannot be parsed.
+func parseIntervalSecs(s string, fallback int) int {
+	if s == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return fallback
+	}
+	return int(d.Seconds())
+}

--- a/internal/docker/enrichment_test.go
+++ b/internal/docker/enrichment_test.go
@@ -1,0 +1,408 @@
+package docker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/apptemplate"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// ── Mock implementations ────────────────────────────────────────────────────
+
+type enrichMockAppRepo struct {
+	apps map[string]*models.App
+}
+
+func (m *enrichMockAppRepo) List(_ context.Context) ([]models.App, error)         { return nil, nil }
+func (m *enrichMockAppRepo) Create(_ context.Context, a *models.App) error         { m.apps[a.ID] = a; return nil }
+func (m *enrichMockAppRepo) Get(_ context.Context, id string) (*models.App, error) {
+	a, ok := m.apps[id]
+	if !ok {
+		return nil, repo.ErrNotFound
+	}
+	return a, nil
+}
+func (m *enrichMockAppRepo) GetByToken(_ context.Context, _ string) (*models.App, error) {
+	return nil, repo.ErrNotFound
+}
+func (m *enrichMockAppRepo) Update(_ context.Context, _ *models.App) error           { return nil }
+func (m *enrichMockAppRepo) Delete(_ context.Context, _ string) error                { return nil }
+func (m *enrichMockAppRepo) UpdateToken(_ context.Context, _, _ string) error        { return nil }
+func (m *enrichMockAppRepo) SetDockerEngineID(_ context.Context, _, _ string) error  { return nil }
+
+type enrichMockCheckRepo struct {
+	created []*models.MonitorCheck
+	// existsByTarget lets tests control ExistsForTypeAndTarget per target string.
+	existsByTarget map[string]bool
+}
+
+func (m *enrichMockCheckRepo) List(_ context.Context) ([]models.MonitorCheck, error) { return nil, nil }
+func (m *enrichMockCheckRepo) Create(_ context.Context, c *models.MonitorCheck) error {
+	m.created = append(m.created, c)
+	return nil
+}
+func (m *enrichMockCheckRepo) Get(_ context.Context, _ string) (*models.MonitorCheck, error) {
+	return nil, repo.ErrNotFound
+}
+func (m *enrichMockCheckRepo) Update(_ context.Context, _ *models.MonitorCheck) error { return nil }
+func (m *enrichMockCheckRepo) Delete(_ context.Context, _ string) error               { return nil }
+func (m *enrichMockCheckRepo) UpdateStatus(_ context.Context, _, _, _ string, _ time.Time) error {
+	return nil
+}
+func (m *enrichMockCheckRepo) ListBySourceComponent(_ context.Context, _ string) ([]models.MonitorCheck, error) {
+	return nil, nil
+}
+func (m *enrichMockCheckRepo) DeleteBySourceComponent(_ context.Context, _ string) error { return nil }
+func (m *enrichMockCheckRepo) UpsertForComponent(_ context.Context, _ *models.MonitorCheck) error {
+	return nil
+}
+func (m *enrichMockCheckRepo) ExistsForTypeAndTarget(_ context.Context, _, target string) (bool, error) {
+	return m.existsByTarget[target], nil
+}
+
+type enrichMockContainerRepo struct {
+	containers map[string]*models.DiscoveredContainer
+}
+
+func (m *enrichMockContainerRepo) UpsertDiscoveredContainer(_ context.Context, _ *models.DiscoveredContainer) error {
+	return nil
+}
+func (m *enrichMockContainerRepo) ListDiscoveredContainers(_ context.Context, _ string) ([]*models.DiscoveredContainer, error) {
+	return nil, nil
+}
+func (m *enrichMockContainerRepo) ListAllDiscoveredContainers(_ context.Context) ([]*models.DiscoveredContainer, error) {
+	return nil, nil
+}
+func (m *enrichMockContainerRepo) GetDiscoveredContainer(_ context.Context, id string) (*models.DiscoveredContainer, error) {
+	c, ok := m.containers[id]
+	if !ok {
+		return nil, repo.ErrNotFound
+	}
+	return c, nil
+}
+func (m *enrichMockContainerRepo) SetDiscoveredContainerApp(_ context.Context, _, _ string) error {
+	return nil
+}
+func (m *enrichMockContainerRepo) ClearDiscoveredContainerApp(_ context.Context, _ string) error {
+	return nil
+}
+func (m *enrichMockContainerRepo) UpdateDiscoveredContainerStatus(_ context.Context, _ string, _ string, _ time.Time) error {
+	return nil
+}
+
+type enrichMockRouteRepo struct {
+	routes map[string]*models.DiscoveredRoute
+}
+
+func (m *enrichMockRouteRepo) UpsertDiscoveredRoute(_ context.Context, _ *models.DiscoveredRoute) error {
+	return nil
+}
+func (m *enrichMockRouteRepo) ListDiscoveredRoutes(_ context.Context, _ string) ([]*models.DiscoveredRoute, error) {
+	return nil, nil
+}
+func (m *enrichMockRouteRepo) ListAllDiscoveredRoutes(_ context.Context) ([]*models.DiscoveredRoute, error) {
+	return nil, nil
+}
+func (m *enrichMockRouteRepo) GetDiscoveredRoute(_ context.Context, id string) (*models.DiscoveredRoute, error) {
+	r, ok := m.routes[id]
+	if !ok {
+		return nil, repo.ErrNotFound
+	}
+	return r, nil
+}
+func (m *enrichMockRouteRepo) SetDiscoveredRouteApp(_ context.Context, _, _ string) error { return nil }
+func (m *enrichMockRouteRepo) ClearDiscoveredRouteApp(_ context.Context, _ string) error  { return nil }
+
+type enrichMockResourceRepo struct {
+	backfilled int64
+}
+
+func (m *enrichMockResourceRepo) Create(_ context.Context, _ *models.ResourceReading) error {
+	return nil
+}
+func (m *enrichMockResourceRepo) LatestMetrics(_ context.Context, _ string, _ []string) (map[string]map[string]float64, error) {
+	return nil, nil
+}
+func (m *enrichMockResourceRepo) BackfillAppID(_ context.Context, _, _ string) (int64, error) {
+	return m.backfilled, nil
+}
+
+// mockProfileLoader implements apptemplate.Loader for tests.
+type mockProfileLoader struct {
+	templates map[string]*apptemplate.AppTemplate
+}
+
+func (m *mockProfileLoader) Get(id string) (*apptemplate.AppTemplate, error) {
+	t, ok := m.templates[id]
+	if !ok {
+		return nil, nil
+	}
+	return t, nil
+}
+
+// buildStore builds a minimal *repo.Store with only the repos used by enrichment.
+func buildEnrichStore(
+	apps repo.AppRepo,
+	checks repo.CheckRepo,
+	containers repo.DiscoveredContainerRepo,
+	routes repo.DiscoveredRouteRepo,
+	resources repo.ResourceReadingRepo,
+) *repo.Store {
+	return &repo.Store{
+		Apps:                 apps,
+		Checks:               checks,
+		DiscoveredContainers: containers,
+		DiscoveredRoutes:     routes,
+		Resources:            resources,
+	}
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+// TestEnrichAppOnLink_ProfileWithMonitorConfig verifies that a monitor check is
+// created when the app's profile has a monitor config and no matching check exists.
+func TestEnrichAppOnLink_ProfileWithMonitorConfig(t *testing.T) {
+	appID := "app-1"
+	containerUUID := "container-uuid-1"
+
+	apps := &enrichMockAppRepo{apps: map[string]*models.App{
+		appID: {
+			ID:        appID,
+			Name:      "Sonarr",
+			ProfileID: "sonarr",
+			Config:    models.ConfigJSON(`{"base_url":"http://sonarr:8989"}`),
+		},
+	}}
+	checks := &enrichMockCheckRepo{existsByTarget: map[string]bool{}}
+	containers := &enrichMockContainerRepo{containers: map[string]*models.DiscoveredContainer{
+		containerUUID: {ID: containerUUID, ContainerID: "abc123", ContainerName: "sonarr"},
+	}}
+	resources := &enrichMockResourceRepo{backfilled: 3}
+
+	profiles := &mockProfileLoader{templates: map[string]*apptemplate.AppTemplate{
+		"sonarr": {
+			Meta:    apptemplate.AppTemplateMeta{Name: "Sonarr"},
+			Monitor: apptemplate.Monitor{CheckType: "url", CheckURL: "{base_url}/ping", CheckInterval: "5m", HealthyStatus: 200},
+		},
+	}}
+
+	store := buildEnrichStore(apps, checks, containers, nil, resources)
+	if err := EnrichAppOnLink(context.Background(), store, profiles, appID, &containerUUID, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(checks.created) != 1 {
+		t.Fatalf("expected 1 monitor check created, got %d", len(checks.created))
+	}
+	c := checks.created[0]
+	if c.Type != "url" {
+		t.Errorf("check type = %q, want %q", c.Type, "url")
+	}
+	if c.Target != "http://sonarr:8989/ping" {
+		t.Errorf("check target = %q, want %q", c.Target, "http://sonarr:8989/ping")
+	}
+	if c.IntervalSecs != 300 {
+		t.Errorf("interval_secs = %d, want 300", c.IntervalSecs)
+	}
+	if c.ExpectedStatus != 200 {
+		t.Errorf("expected_status = %d, want 200", c.ExpectedStatus)
+	}
+	if c.AppID != appID {
+		t.Errorf("check app_id = %q, want %q", c.AppID, appID)
+	}
+}
+
+// TestEnrichAppOnLink_ProfileWithoutMonitorConfig verifies that no monitor check
+// is created when the profile has no monitor configuration.
+func TestEnrichAppOnLink_ProfileWithoutMonitorConfig(t *testing.T) {
+	appID := "app-2"
+
+	apps := &enrichMockAppRepo{apps: map[string]*models.App{
+		appID: {ID: appID, Name: "MyApp", ProfileID: "generic", Config: models.ConfigJSON(`{}`)},
+	}}
+	checks := &enrichMockCheckRepo{existsByTarget: map[string]bool{}}
+
+	profiles := &mockProfileLoader{templates: map[string]*apptemplate.AppTemplate{
+		"generic": {
+			Meta:    apptemplate.AppTemplateMeta{Name: "Generic"},
+			Monitor: apptemplate.Monitor{}, // no check_type or check_url
+		},
+	}}
+
+	store := buildEnrichStore(apps, checks, nil, nil, nil)
+	if err := EnrichAppOnLink(context.Background(), store, profiles, appID, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(checks.created) != 0 {
+		t.Errorf("expected 0 checks created, got %d", len(checks.created))
+	}
+}
+
+// TestEnrichAppOnLink_RouteWithDomain verifies that an SSL check is created when
+// the linked route has a domain.
+func TestEnrichAppOnLink_RouteWithDomain(t *testing.T) {
+	appID := "app-3"
+	routeUUID := "route-uuid-1"
+	domain := "sonarr.example.com"
+
+	apps := &enrichMockAppRepo{apps: map[string]*models.App{
+		appID: {ID: appID, Name: "Sonarr", ProfileID: "", Config: models.ConfigJSON(`{}`)},
+	}}
+	checks := &enrichMockCheckRepo{existsByTarget: map[string]bool{}}
+	routes := &enrichMockRouteRepo{routes: map[string]*models.DiscoveredRoute{
+		routeUUID: {ID: routeUUID, RouterName: "sonarr-router", Rule: "Host(`sonarr.example.com`)", Domain: &domain},
+	}}
+
+	store := buildEnrichStore(apps, checks, nil, routes, nil)
+	if err := EnrichAppOnLink(context.Background(), store, &apptemplate.NoopLoader{}, appID, nil, &routeUUID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(checks.created) != 1 {
+		t.Fatalf("expected 1 SSL check created, got %d", len(checks.created))
+	}
+	c := checks.created[0]
+	if c.Type != "ssl" {
+		t.Errorf("check type = %q, want %q", c.Type, "ssl")
+	}
+	if c.Target != domain {
+		t.Errorf("check target = %q, want %q", c.Target, domain)
+	}
+	if c.SSLWarnDays != 30 {
+		t.Errorf("ssl_warn_days = %d, want 30", c.SSLWarnDays)
+	}
+	if c.SSLCritDays != 7 {
+		t.Errorf("ssl_crit_days = %d, want 7", c.SSLCritDays)
+	}
+	if c.IntervalSecs != 3600 {
+		t.Errorf("interval_secs = %d, want 3600", c.IntervalSecs)
+	}
+}
+
+// TestEnrichAppOnLink_RouteWithoutDomain verifies that no SSL check is created
+// when the route has no domain.
+func TestEnrichAppOnLink_RouteWithoutDomain(t *testing.T) {
+	appID := "app-4"
+	routeUUID := "route-uuid-2"
+
+	apps := &enrichMockAppRepo{apps: map[string]*models.App{
+		appID: {ID: appID, Name: "MyApp", ProfileID: "", Config: models.ConfigJSON(`{}`)},
+	}}
+	checks := &enrichMockCheckRepo{existsByTarget: map[string]bool{}}
+	routes := &enrichMockRouteRepo{routes: map[string]*models.DiscoveredRoute{
+		routeUUID: {ID: routeUUID, RouterName: "router-no-domain", Rule: "PathPrefix(`/`)", Domain: nil},
+	}}
+
+	store := buildEnrichStore(apps, checks, nil, routes, nil)
+	if err := EnrichAppOnLink(context.Background(), store, &apptemplate.NoopLoader{}, appID, nil, &routeUUID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(checks.created) != 0 {
+		t.Errorf("expected 0 checks created, got %d", len(checks.created))
+	}
+}
+
+// TestEnrichAppOnLink_DuplicateCheckPrevention verifies that enrichment does not
+// create a check when one already exists for the same type and target.
+func TestEnrichAppOnLink_DuplicateCheckPrevention(t *testing.T) {
+	appID := "app-5"
+	routeUUID := "route-uuid-3"
+	domain := "already.example.com"
+
+	apps := &enrichMockAppRepo{apps: map[string]*models.App{
+		appID: {ID: appID, Name: "App", ProfileID: "sonarr", Config: models.ConfigJSON(`{"base_url":"http://sonarr:8989"}`)},
+	}}
+	// Both the monitor target and the ssl target already exist.
+	checks := &enrichMockCheckRepo{existsByTarget: map[string]bool{
+		"http://sonarr:8989/ping": true,
+		domain:                   true,
+	}}
+	routes := &enrichMockRouteRepo{routes: map[string]*models.DiscoveredRoute{
+		routeUUID: {ID: routeUUID, RouterName: "r", Rule: "Host(`already.example.com`)", Domain: &domain},
+	}}
+
+	profiles := &mockProfileLoader{templates: map[string]*apptemplate.AppTemplate{
+		"sonarr": {
+			Meta:    apptemplate.AppTemplateMeta{Name: "Sonarr"},
+			Monitor: apptemplate.Monitor{CheckType: "url", CheckURL: "{base_url}/ping", CheckInterval: "5m"},
+		},
+	}}
+
+	store := buildEnrichStore(apps, checks, nil, routes, nil)
+	if err := EnrichAppOnLink(context.Background(), store, profiles, appID, nil, &routeUUID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(checks.created) != 0 {
+		t.Errorf("expected 0 checks created (all exist), got %d", len(checks.created))
+	}
+}
+
+// TestEnrichAppOnLink_ResourceBackfill verifies that BackfillAppID is called with
+// the correct docker container ID when a container is linked.
+func TestEnrichAppOnLink_ResourceBackfill(t *testing.T) {
+	appID := "app-6"
+	containerUUID := "container-uuid-6"
+	dockerID := "deadbeef"
+
+	apps := &enrichMockAppRepo{apps: map[string]*models.App{
+		appID: {ID: appID, Name: "App", ProfileID: "", Config: models.ConfigJSON(`{}`)},
+	}}
+	checks := &enrichMockCheckRepo{existsByTarget: map[string]bool{}}
+	containers := &enrichMockContainerRepo{containers: map[string]*models.DiscoveredContainer{
+		containerUUID: {ID: containerUUID, ContainerID: dockerID, ContainerName: "myapp"},
+	}}
+	resources := &enrichMockResourceRepo{backfilled: 10}
+
+	store := buildEnrichStore(apps, checks, containers, nil, resources)
+	if err := EnrichAppOnLink(context.Background(), store, &apptemplate.NoopLoader{}, appID, &containerUUID, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The mock always reports the configured count; we just verify no error path
+	// was triggered (i.e., enrichment completed without panicking or returning early).
+}
+
+// ── Unit tests for helpers ──────────────────────────────────────────────────
+
+func TestParseIntervalSecs(t *testing.T) {
+	cases := []struct {
+		in       string
+		fallback int
+		want     int
+	}{
+		{"5m", 300, 300},
+		{"1h", 300, 3600},
+		{"30s", 300, 30},
+		{"", 300, 300},
+		{"bad", 300, 300},
+		{"-1m", 300, 300},
+	}
+	for _, tc := range cases {
+		got := parseIntervalSecs(tc.in, tc.fallback)
+		if got != tc.want {
+			t.Errorf("parseIntervalSecs(%q, %d) = %d, want %d", tc.in, tc.fallback, got, tc.want)
+		}
+	}
+}
+
+func TestSubstituteBaseURL(t *testing.T) {
+	cases := []struct {
+		tmpl string
+		cfg  string
+		want string
+	}{
+		{"{base_url}/ping", `{"base_url":"http://host:8989"}`, "http://host:8989/ping"},
+		{"{base_url}/api", `{}`, "{base_url}/api"},             // no base_url in config
+		{"/health", `{"base_url":"http://x"}`, "/health"},      // no placeholder in template
+		{"{base_url}", `{"base_url":"http://x"}`, "http://x"},
+		{"{base_url}", `not-json`, "{base_url}"},               // bad JSON — return as-is
+	}
+	for _, tc := range cases {
+		got := substituteBaseURL(tc.tmpl, models.ConfigJSON(tc.cfg))
+		if got != tc.want {
+			t.Errorf("substituteBaseURL(%q, %q) = %q, want %q", tc.tmpl, tc.cfg, got, tc.want)
+		}
+	}
+}

--- a/internal/docker/resources_test.go
+++ b/internal/docker/resources_test.go
@@ -50,6 +50,10 @@ func (r *mockResourceReadingRepo) LatestMetrics(_ context.Context, _ string, _ [
 	return map[string]map[string]float64{}, nil
 }
 
+func (r *mockResourceReadingRepo) BackfillAppID(_ context.Context, _, _ string) (int64, error) {
+	return 0, nil
+}
+
 // --- helpers --------------------------------------------------------------
 
 func newTestResourcePoller(appRepo repo.AppRepo, eventRepo repo.EventRepo, resRepo repo.ResourceReadingRepo, cli resourcePollerAPI) *ResourcePoller {

--- a/internal/repo/resources.go
+++ b/internal/repo/resources.go
@@ -17,6 +17,11 @@ type ResourceReadingRepo interface {
 	// for each sourceID in sourceIDs, filtered by sourceType.
 	// Returns map[sourceID]map[metric]float64. Missing entries mean no data yet.
 	LatestMetrics(ctx context.Context, sourceType string, sourceIDs []string) (map[string]map[string]float64, error)
+
+	// BackfillAppID sets app_id on all resource_readings for the given docker
+	// containerID (source_type='docker_container') where app_id is currently NULL.
+	// Returns the number of rows updated.
+	BackfillAppID(ctx context.Context, containerID, appID string) (int64, error)
 }
 
 type sqliteResourceReadingRepo struct {
@@ -82,6 +87,17 @@ func (r *sqliteResourceReadingRepo) LatestMetrics(ctx context.Context, sourceTyp
 		return nil, fmt.Errorf("latest metrics rows: %w", err)
 	}
 	return result, nil
+}
+
+func (r *sqliteResourceReadingRepo) BackfillAppID(ctx context.Context, containerID, appID string) (int64, error) {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE resource_readings SET app_id = ? WHERE source_type = 'docker_container' AND source_id = ? AND app_id IS NULL`,
+		appID, containerID)
+	if err != nil {
+		return 0, fmt.Errorf("backfill resource readings app_id: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
 }
 
 // toStringInterfaces converts a []string to []interface{} for use with sqlx.In.

--- a/migrations/014_resource_readings_app_id.sql
+++ b/migrations/014_resource_readings_app_id.sql
@@ -1,0 +1,6 @@
+-- 014_resource_readings_app_id.sql
+-- Add optional app_id FK to resource_readings so readings can be backfilled
+-- when a discovered container is linked to an NORA app (DD-7 enrichment).
+ALTER TABLE resource_readings ADD COLUMN app_id TEXT REFERENCES apps(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_resource_readings_app ON resource_readings(app_id);


### PR DESCRIPTION
## What
Automatically wires up health checks, SSL checks, and historical resource data when a discovered container or route is linked to an app.

## Why
Closes DD-7. When a user links a discovery entity to an app, NORA can infer everything from the profile and discovery data — no manual setup required.

## How
- **`migrations/014`**: adds nullable `app_id` FK column to `resource_readings` for backfill
- **`internal/repo/resources.go`**: adds `BackfillAppID` to `ResourceReadingRepo` — bulk-updates readings for a docker container ID where `app_id IS NULL`
- **`internal/docker/enrichment.go`**: `EnrichAppOnLink` runs three best-effort steps:
  1. Monitor check — loads profile, substitutes `{base_url}` from app config, creates check if none exists for that type+target
  2. SSL check — creates `ssl` check for route domain (1h/warn30d/crit7d) if none exists
  3. Resource backfill — calls `BackfillAppID` via the discovered container's docker ID
- **`internal/api/docker_discovery.go`**: both `LinkContainerApp` and `LinkRouteApp` call `EnrichAppOnLink` after a successful link; `maybeCreateSSLCheck` removed (superseded by step 2 of enrichment)
- Enrichment errors are logged and never roll back the link

## Test coverage
- `TestEnrichAppOnLink_ProfileWithMonitorConfig` — check created with correct type, target, interval, app_id
- `TestEnrichAppOnLink_ProfileWithoutMonitorConfig` — no check created when profile has no monitor config
- `TestEnrichAppOnLink_RouteWithDomain` — SSL check created with correct target/thresholds
- `TestEnrichAppOnLink_RouteWithoutDomain` — no SSL check created for routes without a domain
- `TestEnrichAppOnLink_DuplicateCheckPrevention` — zero checks created when all already exist
- `TestEnrichAppOnLink_ResourceBackfill` — backfill path exercises without error
- `TestParseIntervalSecs` / `TestSubstituteBaseURL` — unit tests for helpers

## Closes
Closes DD-7