### PR TITLE
fix: guard null received_at and add time to older event rows

### DIFF
--- a/frontend/src/components/EventRow.tsx
+++ b/frontend/src/components/EventRow.tsx
@@ -3,17 +3,16 @@ import { events as eventsApi } from '../api/client'
 import type { Event } from '../api/types'
 
 function formatEventTime(iso: string): string {
+  if (!iso) return '—'
   const d = new Date(iso)
+  if (isNaN(d.getTime())) return '—'
   const now = new Date()
   const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate())
   const startOfYesterday = new Date(startOfToday.getTime() - 86400000)
-  if (d >= startOfToday) {
-    return d
-      .toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
-      .toLowerCase()
-  }
-  if (d >= startOfYesterday) return 'Yesterday'
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  const timePart = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true }).toLowerCase()
+  if (d >= startOfToday) return timePart
+  if (d >= startOfYesterday) return `Yesterday ${timePart}`
+  return `${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} ${timePart}`
 }
 
 interface Props {

--- a/frontend/src/pages/AppDetail.tsx
+++ b/frontend/src/pages/AppDetail.tsx
@@ -104,10 +104,13 @@ function Sparkline({ data, color = 'var(--accent)' }: { data: number[]; color?: 
 // ── Expanded event detail ─────────────────────────────────────────────────────
 
 function EventDetail({ event, appName }: { event: Event; appName: string }) {
-  const received = new Date(event.received_at).toLocaleString('en-US', {
-    year: 'numeric', month: '2-digit', day: '2-digit',
-    hour: 'numeric', minute: '2-digit', second: '2-digit', hour12: false,
-  })
+  const receivedDate = event.received_at ? new Date(event.received_at) : null
+  const received = receivedDate && !isNaN(receivedDate.getTime())
+    ? receivedDate.toLocaleString('en-US', {
+        year: 'numeric', month: '2-digit', day: '2-digit',
+        hour: 'numeric', minute: '2-digit', second: '2-digit', hour12: false,
+      })
+    : '—'
   return (
     <div className="detail-event-expand">
       <div className="detail-expand-meta">
@@ -144,14 +147,16 @@ function EventDetail({ event, appName }: { event: Event; appName: string }) {
 // ── Event row ─────────────────────────────────────────────────────────────────
 
 function formatEventTime(iso: string): string {
+  if (!iso) return '—'
   const d = new Date(iso)
+  if (isNaN(d.getTime())) return '—'
   const now = new Date()
   const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate())
   const startOfYesterday = new Date(startOfToday.getTime() - 86400000)
-  if (d >= startOfToday)
-    return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true }).toLowerCase()
-  if (d >= startOfYesterday) return 'Yesterday'
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  const timePart = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true }).toLowerCase()
+  if (d >= startOfToday) return timePart
+  if (d >= startOfYesterday) return `Yesterday ${timePart}`
+  return `${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} ${timePart}`
 }
 
 function DetailEventRow({ event, appName, expanded, onToggle }: {


### PR DESCRIPTION
## What
Fix missing timestamps on event list rows across the Events page and App Detail screen.

## Why
Closes timestamp rendering bug. Two root causes:
1. No null/Invalid Date guard — a falsy or unparseable `received_at` value caused the formatter to silently produce garbage output
2. Events older than yesterday showed only the date (`Mar 5`) with the time component dropped

## How
- Added `if (!iso) return '—'` and `isNaN(d.getTime())` guard to both `formatEventTime` copies (EventRow.tsx and AppDetail.tsx)
- Older events now render `MMM D h:mm` (e.g. `Mar 5 3:42pm`) — time was being discarded before
- Yesterday events now render `Yesterday h:mm` for clarity
- The expanded EventDetail panel's `received` field also guarded against null

## Test coverage
- `npm run build` passes with zero TypeScript errors
- Manually confirmed format logic: today → `3:42pm`, yesterday → `Yesterday 3:42pm`, older → `Mar 5 3:42pm`, null → `—`

## Closes
Closes #timestamp-bug