### PR TITLE
fix: log silent early-returns in ScanOneComponent + detach scan context

### DIFF
--- a/internal/api/infra_components.go
+++ b/internal/api/infra_components.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -402,9 +403,11 @@ func (h *InfraComponentHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Run with a generous timeout so the caller gets a real result.
-	ctx := r.Context()
-	status, scanErr := jobs.ScanOneComponent(ctx, h.store, c)
+	// Use a detached context with a hard timeout so the poll isn't killed
+	// if the browser closes the connection before the scan finishes.
+	scanCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	status, scanErr := jobs.ScanOneComponent(scanCtx, h.store, c)
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	resp := scanResult{

--- a/internal/api/infra_components_test.go
+++ b/internal/api/infra_components_test.go
@@ -20,7 +20,15 @@ func newInfraComponentRouter(t *testing.T) http.Handler {
 	rollups := repo.NewResourceRollupRepo(db)
 	checks := repo.NewCheckRepo(db)
 	tc := repo.NewTraefikComponentRepo(db)
-	h := api.NewInfraComponentHandler(ic, rollups, checks, tc)
+	store := repo.NewStore(
+		repo.NewAppRepo(db), repo.NewEventRepo(db), checks,
+		repo.NewRollupRepo(db), repo.NewResourceReadingRepo(db), rollups,
+		ic, repo.NewDockerEngineRepo(db),
+		repo.NewInfraRepo(db), repo.NewSettingsRepo(db), repo.NewMetricsRepo(db),
+		repo.NewUserRepo(db), tc,
+		repo.NewDiscoveredContainerRepo(db), repo.NewDiscoveredRouteRepo(db), nil,
+	)
+	h := api.NewInfraComponentHandler(ic, rollups, checks, tc, store)
 	r := chi.NewRouter()
 	h.Routes(r)
 	return r

--- a/internal/api/topology_test.go
+++ b/internal/api/topology_test.go
@@ -181,7 +181,15 @@ func TestGetTopology_FullChain(t *testing.T) {
 	topoHandler := api.NewTopologyHandler(ic, de, apps, rollups)
 	checks := repo.NewCheckRepo(db)
 	tc := repo.NewTraefikComponentRepo(db)
-	icHandler := api.NewInfraComponentHandler(ic, rollups, checks, tc)
+	store := repo.NewStore(
+		apps, repo.NewEventRepo(db), checks,
+		repo.NewRollupRepo(db), repo.NewResourceReadingRepo(db), rollups,
+		ic, de,
+		repo.NewInfraRepo(db), repo.NewSettingsRepo(db), repo.NewMetricsRepo(db),
+		repo.NewUserRepo(db), tc,
+		repo.NewDiscoveredContainerRepo(db), repo.NewDiscoveredRouteRepo(db), nil,
+	)
+	icHandler := api.NewInfraComponentHandler(ic, rollups, checks, tc, store)
 	r := chi.NewRouter()
 	topoHandler.Routes(r)
 	icHandler.Routes(r)

--- a/internal/jobs/scan.go
+++ b/internal/jobs/scan.go
@@ -27,43 +27,52 @@ func ScanOneComponent(ctx context.Context, store *repo.Store, c *models.Infrastr
 	switch c.CollectionMethod {
 	case "proxmox_api":
 		if c.Credentials == nil || *c.Credentials == "" {
+			log.Printf("scan: %s (%s): no credentials configured", c.Name, c.ID)
 			return "offline", fmt.Errorf("no credentials configured — edit the component and save credentials first")
 		}
 		poller, err := infra.NewProxmoxPoller(c.ID, *c.Credentials)
 		if err != nil {
+			log.Printf("scan: %s (%s): invalid credentials: %v", c.Name, c.ID, err)
 			return "offline", fmt.Errorf("invalid credentials: %w", err)
 		}
 		pollErr = poller.Poll(ctx, store)
 
 	case "synology_api":
 		if c.Credentials == nil || *c.Credentials == "" {
+			log.Printf("scan: %s (%s): no credentials configured", c.Name, c.ID)
 			return "offline", fmt.Errorf("no credentials configured — edit the component and save credentials first")
 		}
 		poller, err := infra.NewSynologyPoller(c.ID, *c.Credentials)
 		if err != nil {
+			log.Printf("scan: %s (%s): invalid credentials: %v", c.Name, c.ID, err)
 			return "offline", fmt.Errorf("invalid credentials: %w", err)
 		}
 		pollErr = poller.Poll(ctx, store)
 
 	case "snmp":
 		if c.SNMPConfig == nil || *c.SNMPConfig == "" {
+			log.Printf("scan: %s (%s): no SNMP config", c.Name, c.ID)
 			return "offline", fmt.Errorf("no SNMP config — edit the component and save SNMP settings first")
 		}
 		poller, err := infra.NewSNMPPoller(c.ID, c.IP, *c.SNMPConfig)
 		if err != nil {
+			log.Printf("scan: %s (%s): invalid SNMP config: %v", c.Name, c.ID, err)
 			return "offline", fmt.Errorf("invalid SNMP config: %w", err)
 		}
 		pollErr = poller.Poll(ctx, store)
 
 	case "traefik_api":
 		if c.Credentials == nil || *c.Credentials == "" {
+			log.Printf("scan: %s (%s): no credentials configured", c.Name, c.ID)
 			return "offline", fmt.Errorf("no credentials configured — edit the component and save credentials first")
 		}
 		var creds traefikComponentCredentials
 		if err := json.Unmarshal([]byte(*c.Credentials), &creds); err != nil {
+			log.Printf("scan: %s (%s): invalid credentials JSON: %v", c.Name, c.ID, err)
 			return "offline", fmt.Errorf("invalid credentials JSON: %w", err)
 		}
 		if creds.APIURL == "" {
+			log.Printf("scan: %s (%s): api_url is empty", c.Name, c.ID)
 			return "offline", fmt.Errorf("api_url is empty — edit the component and set the Traefik API URL")
 		}
 		pollErr = pollTraefikComponent(ctx, store, *c, creds)


### PR DESCRIPTION
## What
Two bugs causing the Proxmox manual scan to log \"starting scan\" and then go completely silent — no metrics, no events, no further logs.

## Why
Closes #126 (or the bug reported: Proxmox scan drops silently, no metrics stored)

## How

**Bug 1 — silent early-returns in `ScanOneComponent`** (`internal/jobs/scan.go`):
Every early-return path inside `proxmox_api`, `synology_api`, `snmp`, and `traefik_api` cases was returning an error with zero server-side logging. If credentials were nil/empty or credential JSON was invalid, the function returned after \"starting scan\" with no further output — making the failure invisible in logs. Added `log.Printf` before every early return so the reason is always visible.

**Bug 2 — scan inheriting `r.Context()`** (`internal/api/infra_components.go`):
The `Scan` handler passed `r.Context()` directly to the poll. If the browser closed the connection mid-poll (slow Proxmox, network latency), every `store.Resources.Create` and `UpdateStatus` call inside `Poll` received a cancelled context and silently failed. The comment even said \"generous timeout\" but no timeout was ever applied. Replaced with `context.WithTimeout(context.Background(), 2*time.Minute)` so the poll runs to completion regardless of the HTTP connection state.

**Pre-existing test breakage** (`internal/api/infra_components_test.go`, `topology_test.go`):
PR #125 added a `*repo.Store` parameter to `NewInfraComponentHandler` but never updated the two test helpers — they compiled broken since that merge. Fixed both helpers to pass a properly wired store.

## Test coverage
- `go test ./internal/jobs/... ./internal/infra/... ./internal/api/...` passes
- Existing Proxmox poller tests (`proxmox_test.go`) cover the Poll path end-to-end
- The two previously broken test files now compile and pass

## Closes
Closes #126