### PR TITLE
fix: remove Traefik cert polling, fix card layout + height normalization

### DIFF
--- a/frontend/src/pages/Infrastructure.css
+++ b/frontend/src/pages/Infrastructure.css
@@ -134,7 +134,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
   gap: 12px;
-  align-items: start;
+  align-items: stretch;
 }
 
 /* ── COMPONENT CARD ────────────────────────────────────────────────────────── */
@@ -276,6 +276,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 8px;
+  margin-top: auto;
 }
 
 .infra-last-updated {

--- a/frontend/src/pages/Infrastructure.tsx
+++ b/frontend/src/pages/Infrastructure.tsx
@@ -521,18 +521,11 @@ export function Infrastructure() {
 
         <div className="infra-traefik-summary">
           {detail ? (
-            <>
-              <span className="infra-traefik-cert-count">{detail.cert_count} cert{detail.cert_count !== 1 ? 's' : ''}</span>
-              {detail.crit_count > 0 && (
-                <span className="infra-traefik-badge crit">{detail.crit_count} critical</span>
-              )}
-              {detail.warn_count > 0 && detail.crit_count === 0 && (
-                <span className="infra-traefik-badge warn">{detail.warn_count} expiring</span>
-              )}
-              <span className="infra-traefik-route-count">{detail.routes.length} route{detail.routes.length !== 1 ? 's' : ''}</span>
-            </>
+            <span className="infra-traefik-route-count">
+              {detail.routes.length} route{detail.routes.length !== 1 ? 's' : ''}
+            </span>
           ) : (
-            <span className="infra-traefik-cert-count">—</span>
+            <span className="infra-traefik-route-count">—</span>
           )}
         </div>
 
@@ -596,30 +589,38 @@ export function Infrastructure() {
           <div className="infra-card-status-group" onClick={e => e.stopPropagation()}>
             <span className={`infra-status-dot ${statusClass(c.last_status)}`} />
             <span className="infra-status-label">{statusLabel(c.last_status)}</span>
+          </div>
+        </div>
+
+        <div className="infra-card-footer">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1 }}>
+            {lastPolledAt && (
+              <span className="infra-last-updated">Last updated: {timeAgo(lastPolledAt)}</span>
+            )}
             {renderScanFeedback(c.id)}
-            <div className="infra-card-actions" style={{ marginLeft: 8 }}>
-              <button
-                className="infra-card-btn"
-                onClick={e => { e.stopPropagation(); void handleScan(c.id) }}
-                disabled={isDeleting || isScanning || scanningId !== null}
-              >
-                {isScanning ? 'Scanning…' : 'Scan Now'}
-              </button>
-              <button
-                className="infra-card-btn"
-                onClick={e => { e.stopPropagation(); openEdit(c) }}
-                disabled={isDeleting || isScanning}
-              >
-                Edit
-              </button>
-              <button
-                className="infra-card-btn danger"
-                onClick={e => { e.stopPropagation(); void handleDelete(c.id) }}
-                disabled={isDeleting || isScanning}
-              >
-                {isDeleting ? 'Deleting…' : 'Delete'}
-              </button>
-            </div>
+          </div>
+          <div className="infra-card-actions">
+            <button
+              className="infra-card-btn"
+              onClick={() => void handleScan(c.id)}
+              disabled={isDeleting || isScanning || scanningId !== null}
+            >
+              {isScanning ? 'Scanning…' : 'Scan Now'}
+            </button>
+            <button
+              className="infra-card-btn"
+              onClick={() => openEdit(c)}
+              disabled={isDeleting || isScanning}
+            >
+              Edit
+            </button>
+            <button
+              className="infra-card-btn danger"
+              onClick={() => void handleDelete(c.id)}
+              disabled={isDeleting || isScanning}
+            >
+              {isDeleting ? 'Deleting…' : 'Delete'}
+            </button>
           </div>
         </div>
       </div>

--- a/internal/jobs/traefik_component.go
+++ b/internal/jobs/traefik_component.go
@@ -3,14 +3,12 @@ package jobs
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"time"
 
 	"github.com/digitalcheffe/nora/internal/infra"
 	"github.com/digitalcheffe/nora/internal/models"
 	"github.com/digitalcheffe/nora/internal/repo"
-	"github.com/google/uuid"
 )
 
 // traefikComponentCredentials is the JSON shape stored in infrastructure_components.credentials
@@ -68,81 +66,6 @@ func pollTraefikComponent(ctx context.Context, store *repo.Store, c models.Infra
 
 	// ── Overview health (Infra-10) ────────────────────────────────────────────
 	pollTraefikOverview(ctx, store, c, client)
-
-	// ── Fetch certs ──────────────────────────────────────────────────────────
-
-	rawCerts, err := client.FetchCerts(ctx)
-	if err != nil {
-		return fmt.Errorf("fetch certs: %w", err)
-	}
-
-	// Convert TraefikCert → TraefikComponentCert.
-	compCerts := make([]*models.TraefikComponentCert, 0, len(rawCerts))
-	for _, rc := range rawCerts {
-		cc := &models.TraefikComponentCert{
-			ComponentID: c.ID,
-			Domain:      rc.Domain,
-			Issuer:      rc.Issuer,
-			ExpiresAt:   rc.ExpiresAt,
-			SANs:        rc.SANs,
-		}
-		compCerts = append(compCerts, cc)
-	}
-
-	if err := store.TraefikComponents.UpsertCerts(ctx, c.ID, compCerts); err != nil {
-		return fmt.Errorf("upsert certs: %w", err)
-	}
-
-	// ── Sync SSL checks ───────────────────────────────────────────────────────
-
-	// Build a map of existing owned checks by target (domain).
-	existingChecks, err := store.Checks.ListBySourceComponent(ctx, c.ID)
-	if err != nil {
-		return fmt.Errorf("list existing checks: %w", err)
-	}
-	existingByDomain := make(map[string]models.MonitorCheck, len(existingChecks))
-	for _, ch := range existingChecks {
-		existingByDomain[ch.Target] = ch
-	}
-
-	// Track which domains are still present so we can delete stale checks.
-	activeDomains := make(map[string]bool, len(compCerts))
-	sslSource := "component"
-	for _, cc := range compCerts {
-		activeDomains[cc.Domain] = true
-
-		var checkID string
-		if existing, ok := existingByDomain[cc.Domain]; ok {
-			checkID = existing.ID
-		} else {
-			checkID = uuid.New().String()
-		}
-
-		check := &models.MonitorCheck{
-			ID:                checkID,
-			Name:              c.Name + " — " + cc.Domain,
-			Type:              "ssl",
-			Target:            cc.Domain,
-			IntervalSecs:      300,
-			SSLWarnDays:       30,
-			SSLCritDays:       7,
-			SSLSource:         &sslSource,
-			SourceComponentID: &c.ID,
-			Enabled:           true,
-		}
-		if err := store.Checks.UpsertForComponent(ctx, check); err != nil {
-			log.Printf("traefik component scheduler: upsert check for %s: %v", cc.Domain, err)
-		}
-	}
-
-	// Delete checks for domains no longer present.
-	for domain, ch := range existingByDomain {
-		if !activeDomains[domain] {
-			if err := store.Checks.Delete(ctx, ch.ID); err != nil {
-				log.Printf("traefik component scheduler: delete stale check %s: %v", ch.ID, err)
-			}
-		}
-	}
 
 	// ── Fetch routes ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What
- Remove `FetchCerts` and SSL check sync from `pollTraefikComponent` — the Traefik ACME certs endpoint is not supported on this setup; failures were surfacing as card-level scan errors
- Restructure Docker card to have a proper footer (Last updated + scan feedback on left, buttons on right) matching all other card types
- Update Traefik card summary to show only route count — cert count removed
- Normalize card heights: grid uses `align-items: stretch`, footer pinned to bottom with `margin-top: auto`

## Why
Fixes Infra-12 polish items visible in the infrastructure card grid.

## How
- Backend: stripped certs + SSL check blocks from `pollTraefikComponent`, removed `fmt` and `uuid` imports
- Frontend: `renderDockerCard` restructured from header-only to header + footer; `renderTraefikCard` summary simplified; CSS grid and footer updated

## Test coverage
- `go build ./...` passes
- `npm run build` passes with zero TypeScript errors
- Verified layout in preview: Docker card footer correct, card heights uniform in a row

## Closes
Closes #136