### PR TITLE
feat: Ghost CMS app profile (Content category)

### DIFF
--- a/appprofiles/ghost.yaml
+++ b/appprofiles/ghost.yaml
@@ -1,0 +1,85 @@
+meta:
+  name: Ghost
+  category: Content
+  logo: ghost.png
+  description: Headless CMS for blogs and newsletters
+  capability: full
+
+webhook:
+  setup_instructions: |
+    In Ghost Admin, go to Settings → Integrations → Add custom integration.
+    Create one webhook per event type you want to track.
+    Set the webhook URL to: {base_url}/ingest/{token}
+    Recommended events: Post published, Post unpublished, Member added, Member deleted.
+    Note: Ghost does not include the event type in the payload body. NORA infers it
+    from the payload structure (post/page/member key + current status).
+  recommended_events:
+    - post.published
+    - post.unpublished
+    - post.scheduled
+    - member.added
+    - member.deleted
+  not_recommended:
+    - post.deleted
+  field_mappings:
+    post_title: "$.post.current.title"
+    post_status: "$.post.current.status"
+    post_url: "$.post.current.url"
+    post_author: "$.post.current.primary_author.name"
+    page_title: "$.page.current.title"
+    page_status: "$.page.current.status"
+    member_name: "$.member.current.name"
+    member_email: "$.member.current.email"
+    member_status: "$.member.current.status"
+  event_type_keys:
+    - key: post
+      status_path: "$.post.current.status"
+      prefix: "post."
+      default: "post.deleted"
+    - key: page
+      status_path: "$.page.current.status"
+      prefix: "page."
+      default: "page.updated"
+    - key: member
+      present_path: "$.member.current.name"
+      if_present: "member.added"
+      if_absent: "member.deleted"
+  severity_field: event_type
+  display_template: "Ghost event"
+  display_templates:
+    post.published: "Published — {post_title}"
+    post.draft: "Unpublished — {post_title}"
+    post.scheduled: "Scheduled — {post_title}"
+    post.deleted: "Deleted — {post_title}"
+    page.published: "Page published — {page_title}"
+    page.draft: "Page draft — {page_title}"
+    member.added: "New member — {member_name}"
+    member.deleted: "Member removed — {member_name}"
+  severity_mapping:
+    post.published: info
+    post.draft: warn
+    post.scheduled: info
+    post.deleted: warn
+    page.published: info
+    page.draft: info
+    member.added: info
+    member.deleted: warn
+
+monitor:
+  check_type: url
+  check_url: "{base_url}/ghost/api/v4/admin/site/"
+  auth_header: "Authorization: Ghost {admin_api_key}"
+  healthy_status: 200
+  check_interval: 5m
+
+digest:
+  categories:
+    - label: Posts Published
+      match_field: event_type
+      match_value: post.published
+    - label: Member Activity
+      match_field: event_type
+      match_value: member.added
+    - label: Member Activity
+      match_field: event_type
+      match_value: member.deleted

--- a/internal/apptemplate/apptemplate.go
+++ b/internal/apptemplate/apptemplate.go
@@ -28,17 +28,41 @@ type AppTemplateMeta struct {
 	Capability  string `yaml:"capability"`
 }
 
+// EventTypeKeyRule synthesizes an event_type field from payload structure.
+// Used for apps (like Ghost) that do not include the event type in the payload body.
+// Rules are evaluated in order; the first matching top-level key wins.
+type EventTypeKeyRule struct {
+	// Key is the top-level JSON key whose presence triggers this rule (e.g. "post").
+	Key string `yaml:"key"`
+	// StatusPath is a JSONPath to extract a status value (e.g. "$.post.current.status").
+	// When set, event_type is synthesized as Prefix + status_value.
+	// If the path resolves to empty, falls through to Default.
+	StatusPath string `yaml:"status_path"`
+	// Prefix is prepended to the StatusPath value (e.g. "post.").
+	Prefix string `yaml:"prefix"`
+	// PresentPath is a JSONPath checked for presence.
+	// If non-empty → IfPresent is used; if empty/missing → IfAbsent.
+	PresentPath string `yaml:"present_path"`
+	// IfPresent is the event_type when PresentPath resolves to a non-empty value.
+	IfPresent string `yaml:"if_present"`
+	// IfAbsent is the event_type when PresentPath is empty or missing.
+	IfAbsent string `yaml:"if_absent"`
+	// Default is used when StatusPath yields an empty value and no PresentPath is set.
+	Default string `yaml:"default"`
+}
+
 // Webhook holds ingest processing configuration for the template.
 type Webhook struct {
-	SetupInstructions    string            `yaml:"setup_instructions"`
-	RecommendedEvents    []string          `yaml:"recommended_events"`
-	NotRecommended       []string          `yaml:"not_recommended"`
-	FieldMappings        map[string]string `yaml:"field_mappings"`
-	DisplayTemplate      string            `yaml:"display_template"`
-	DisplayTemplates     map[string]string `yaml:"display_templates"`
-	SeverityField        string            `yaml:"severity_field"`
-	SeverityCompoundField string           `yaml:"severity_compound_field"`
-	SeverityMapping      map[string]string `yaml:"severity_mapping"`
+	SetupInstructions     string             `yaml:"setup_instructions"`
+	RecommendedEvents     []string           `yaml:"recommended_events"`
+	NotRecommended        []string           `yaml:"not_recommended"`
+	FieldMappings         map[string]string  `yaml:"field_mappings"`
+	EventTypeKeys         []EventTypeKeyRule `yaml:"event_type_keys"`
+	DisplayTemplate       string             `yaml:"display_template"`
+	DisplayTemplates      map[string]string  `yaml:"display_templates"`
+	SeverityField         string             `yaml:"severity_field"`
+	SeverityCompoundField string             `yaml:"severity_compound_field"`
+	SeverityMapping       map[string]string  `yaml:"severity_mapping"`
 }
 
 // Monitor holds active check configuration for the template.
@@ -128,11 +152,48 @@ func (r *Registry) List() map[string]*AppTemplate {
 	return out
 }
 
+// InferEventTypeFromKeys inspects a decoded JSON payload for the first matching
+// EventTypeKeyRule and returns a synthesized event_type string.
+// Returns "" if no rule matches.
+func InferEventTypeFromKeys(payload interface{}, keys []EventTypeKeyRule) string {
+	obj, ok := payload.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	for _, rule := range keys {
+		if _, ok := obj[rule.Key]; !ok {
+			continue
+		}
+		// Top-level key found — apply rule.
+		if rule.StatusPath != "" {
+			if v, ok := jsonPathGet(payload, rule.StatusPath); ok && v != "" {
+				return rule.Prefix + v
+			}
+			if rule.Default != "" {
+				return rule.Default
+			}
+		}
+		if rule.PresentPath != "" {
+			v, _ := jsonPathGet(payload, rule.PresentPath)
+			if v != "" {
+				return rule.IfPresent
+			}
+			return rule.IfAbsent
+		}
+		if rule.Default != "" {
+			return rule.Default
+		}
+	}
+	return ""
+}
+
 // ExtractFields evaluates each JSONPath in the template's field_mappings against payload
 // and returns a flat tag→value map. Returns an error only on JSON decode failure.
+// If the template has event_type_keys configured and event_type is not already extracted,
+// it synthesizes event_type from the payload structure.
 func (r *Registry) ExtractFields(templateID string, payload []byte) (map[string]string, error) {
 	t, ok := r.templates[templateID]
-	if !ok || len(t.Webhook.FieldMappings) == 0 {
+	if !ok {
 		return map[string]string{}, nil
 	}
 
@@ -147,6 +208,14 @@ func (r *Registry) ExtractFields(templateID string, payload []byte) (map[string]
 			out[tag] = v
 		}
 	}
+
+	// Synthesize event_type from payload structure when not already extracted.
+	if _, hasET := out["event_type"]; !hasET && len(t.Webhook.EventTypeKeys) > 0 {
+		if et := InferEventTypeFromKeys(root, t.Webhook.EventTypeKeys); et != "" {
+			out["event_type"] = et
+		}
+	}
+
 	return out, nil
 }
 

--- a/internal/apptemplate/apptemplate_test.go
+++ b/internal/apptemplate/apptemplate_test.go
@@ -780,3 +780,301 @@ func TestHomeAssistant_SeverityMapping(t *testing.T) {
 		}
 	}
 }
+
+// ---- Ghost ----
+
+const ghostYAML = `
+meta:
+  name: Ghost
+  category: Content
+  logo: ghost.png
+  description: Headless CMS for blogs and newsletters
+  capability: full
+webhook:
+  field_mappings:
+    post_title: "$.post.current.title"
+    post_status: "$.post.current.status"
+    post_url: "$.post.current.url"
+    page_title: "$.page.current.title"
+    member_name: "$.member.current.name"
+    member_email: "$.member.current.email"
+  event_type_keys:
+    - key: post
+      status_path: "$.post.current.status"
+      prefix: "post."
+      default: "post.deleted"
+    - key: page
+      status_path: "$.page.current.status"
+      prefix: "page."
+      default: "page.updated"
+    - key: member
+      present_path: "$.member.current.name"
+      if_present: "member.added"
+      if_absent: "member.deleted"
+  severity_field: event_type
+  display_template: "Ghost event"
+  display_templates:
+    post.published: "Published — {post_title}"
+    post.draft: "Unpublished — {post_title}"
+    post.scheduled: "Scheduled — {post_title}"
+    post.deleted: "Deleted — {post_title}"
+    page.published: "Page published — {page_title}"
+    member.added: "New member — {member_name}"
+    member.deleted: "Member removed — {member_name}"
+  severity_mapping:
+    post.published: info
+    post.draft: warn
+    post.scheduled: info
+    post.deleted: warn
+    page.published: info
+    member.added: info
+    member.deleted: warn
+monitor:
+  check_type: url
+  check_url: "{base_url}/ghost/api/v4/admin/site/"
+  healthy_status: 200
+  check_interval: 5m
+digest:
+  categories:
+    - label: Posts Published
+      match_field: event_type
+      match_value: post.published
+    - label: Member Activity
+      match_field: event_type
+      match_value: member.added
+`
+
+func newGhostRegistry(t *testing.T) *apptemplate.Registry {
+	t.Helper()
+	fsys := fstest.MapFS{
+		"ghost.yaml": {Data: []byte(ghostYAML)},
+	}
+	reg, err := apptemplate.NewRegistry(fsys)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	return reg
+}
+
+// TestGhost_PostPublished verifies event_type inference and display text for a published post.
+func TestGhost_PostPublished(t *testing.T) {
+	reg := newGhostRegistry(t)
+
+	payload := []byte(`{
+		"post": {
+			"current": {
+				"title": "Hello World",
+				"status": "published",
+				"url": "https://example.com/hello-world/",
+				"primary_author": {"name": "Ryan"}
+			},
+			"previous": {"status": "draft"}
+		}
+	}`)
+
+	fields, err := reg.ExtractFields("ghost", payload)
+	if err != nil {
+		t.Fatalf("ExtractFields error: %v", err)
+	}
+
+	if fields["event_type"] != "post.published" {
+		t.Errorf("event_type = %q, want %q", fields["event_type"], "post.published")
+	}
+	if fields["post_title"] != "Hello World" {
+		t.Errorf("post_title = %q, want %q", fields["post_title"], "Hello World")
+	}
+
+	got := reg.RenderDisplayText("ghost", fields)
+	want := "Published — Hello World"
+	if got != want {
+		t.Errorf("RenderDisplayText = %q, want %q", got, want)
+	}
+}
+
+// TestGhost_PostUnpublished verifies a post moved to draft renders as "Unpublished".
+func TestGhost_PostUnpublished(t *testing.T) {
+	reg := newGhostRegistry(t)
+
+	payload := []byte(`{
+		"post": {
+			"current": {
+				"title": "My Post",
+				"status": "draft"
+			},
+			"previous": {"status": "published"}
+		}
+	}`)
+
+	fields, err := reg.ExtractFields("ghost", payload)
+	if err != nil {
+		t.Fatalf("ExtractFields error: %v", err)
+	}
+
+	if fields["event_type"] != "post.draft" {
+		t.Errorf("event_type = %q, want %q", fields["event_type"], "post.draft")
+	}
+
+	got := reg.RenderDisplayText("ghost", fields)
+	want := "Unpublished — My Post"
+	if got != want {
+		t.Errorf("RenderDisplayText = %q, want %q", got, want)
+	}
+}
+
+// TestGhost_PostDeleted verifies a post with empty current status resolves to post.deleted.
+func TestGhost_PostDeleted(t *testing.T) {
+	reg := newGhostRegistry(t)
+
+	// Ghost sends empty current on delete.
+	payload := []byte(`{
+		"post": {
+			"current": {},
+			"previous": {"title": "Old Post", "status": "published"}
+		}
+	}`)
+
+	fields, err := reg.ExtractFields("ghost", payload)
+	if err != nil {
+		t.Fatalf("ExtractFields error: %v", err)
+	}
+
+	if fields["event_type"] != "post.deleted" {
+		t.Errorf("event_type = %q, want %q", fields["event_type"], "post.deleted")
+	}
+}
+
+// TestGhost_MemberAdded verifies member.added is inferred when current.name is present.
+func TestGhost_MemberAdded(t *testing.T) {
+	reg := newGhostRegistry(t)
+
+	payload := []byte(`{
+		"member": {
+			"current": {
+				"name": "Jane Doe",
+				"email": "jane@example.com",
+				"status": "free"
+			}
+		}
+	}`)
+
+	fields, err := reg.ExtractFields("ghost", payload)
+	if err != nil {
+		t.Fatalf("ExtractFields error: %v", err)
+	}
+
+	if fields["event_type"] != "member.added" {
+		t.Errorf("event_type = %q, want %q", fields["event_type"], "member.added")
+	}
+	if fields["member_name"] != "Jane Doe" {
+		t.Errorf("member_name = %q, want %q", fields["member_name"], "Jane Doe")
+	}
+
+	got := reg.RenderDisplayText("ghost", fields)
+	want := "New member — Jane Doe"
+	if got != want {
+		t.Errorf("RenderDisplayText = %q, want %q", got, want)
+	}
+}
+
+// TestGhost_MemberDeleted verifies member.deleted is inferred when current.name is absent.
+func TestGhost_MemberDeleted(t *testing.T) {
+	reg := newGhostRegistry(t)
+
+	// Ghost sends empty current on member delete.
+	payload := []byte(`{
+		"member": {
+			"current": {},
+			"previous": {"name": "Jane Doe", "email": "jane@example.com", "status": "free"}
+		}
+	}`)
+
+	fields, err := reg.ExtractFields("ghost", payload)
+	if err != nil {
+		t.Fatalf("ExtractFields error: %v", err)
+	}
+
+	if fields["event_type"] != "member.deleted" {
+		t.Errorf("event_type = %q, want %q", fields["event_type"], "member.deleted")
+	}
+
+	// Severity for member.deleted should be warn.
+	got := reg.MapSeverity("ghost", fields)
+	if got != "warn" {
+		t.Errorf("MapSeverity = %q, want warn", got)
+	}
+}
+
+// TestGhost_SeverityMapping verifies Ghost event types map to correct severity levels.
+func TestGhost_SeverityMapping(t *testing.T) {
+	reg := newGhostRegistry(t)
+
+	cases := []struct {
+		eventType string
+		want      string
+	}{
+		{"post.published", "info"},
+		{"post.draft", "warn"},
+		{"post.scheduled", "info"},
+		{"post.deleted", "warn"},
+		{"page.published", "info"},
+		{"member.added", "info"},
+		{"member.deleted", "warn"},
+		{"unknown.event", "info"},
+	}
+
+	for _, c := range cases {
+		fields := map[string]string{"event_type": c.eventType}
+		got := reg.MapSeverity("ghost", fields)
+		if got != c.want {
+			t.Errorf("MapSeverity(event_type=%q) = %q, want %q", c.eventType, got, c.want)
+		}
+	}
+}
+
+// TestGhost_PagePublished verifies page event type is correctly inferred.
+func TestGhost_PagePublished(t *testing.T) {
+	reg := newGhostRegistry(t)
+
+	payload := []byte(`{
+		"page": {
+			"current": {
+				"title": "About Us",
+				"status": "published"
+			}
+		}
+	}`)
+
+	fields, err := reg.ExtractFields("ghost", payload)
+	if err != nil {
+		t.Fatalf("ExtractFields error: %v", err)
+	}
+
+	if fields["event_type"] != "page.published" {
+		t.Errorf("event_type = %q, want %q", fields["event_type"], "page.published")
+	}
+
+	got := reg.RenderDisplayText("ghost", fields)
+	want := "Page published — About Us"
+	if got != want {
+		t.Errorf("RenderDisplayText = %q, want %q", got, want)
+	}
+}
+
+// TestGhost_LoadsFromYAML verifies the ghost template loads correctly from the YAML constant.
+func TestGhost_LoadsFromYAML(t *testing.T) {
+	reg := newGhostRegistry(t)
+
+	tmpl, err := reg.Get("ghost")
+	if err != nil || tmpl == nil {
+		t.Fatalf("Get ghost: err=%v tmpl=%v", err, tmpl)
+	}
+	if tmpl.Meta.Name != "Ghost" {
+		t.Errorf("name = %q, want Ghost", tmpl.Meta.Name)
+	}
+	if tmpl.Meta.Category != "Content" {
+		t.Errorf("category = %q, want Content", tmpl.Meta.Category)
+	}
+	if len(tmpl.Webhook.EventTypeKeys) != 3 {
+		t.Errorf("event_type_keys len = %d, want 3", len(tmpl.Webhook.EventTypeKeys))
+	}
+}

--- a/internal/ingest/pipeline.go
+++ b/internal/ingest/pipeline.go
@@ -60,6 +60,15 @@ func Process(ctx context.Context, store *repo.Store, profiler apptemplate.Loader
 		p, err := profiler.Get(app.ProfileID)
 		if err == nil && p != nil {
 			fieldsMap = extractFields(rawBody, p.Webhook.FieldMappings)
+			// Synthesize event_type from payload structure when the template uses key detection.
+			if _, hasET := fieldsMap["event_type"]; !hasET && len(p.Webhook.EventTypeKeys) > 0 {
+				var decoded interface{}
+				if jsonErr := json.Unmarshal(rawBody, &decoded); jsonErr == nil {
+					if et := apptemplate.InferEventTypeFromKeys(decoded, p.Webhook.EventTypeKeys); et != "" {
+						fieldsMap["event_type"] = et
+					}
+				}
+			}
 			severity = mapSeverity(fieldsMap, p.Webhook.SeverityField, p.Webhook.SeverityCompoundField, p.Webhook.SeverityMapping)
 			// Pick per-eventType template if available, fall back to global template.
 			tmpl := p.Webhook.DisplayTemplate


### PR DESCRIPTION
## What
Adds Ghost CMS to the NORA app profile library as the first `Content` category app.

## Why
Ghost is a common homelab CMS/newsletter platform. This closes the Ghost profile task (depends on T-20 profile schema + loader, T-21 v1 profiles).

## How

**Ghost has no event type in payload body.** To solve this generically, a new `EventTypeKeys` mechanism was added to the AppTemplate schema. It allows YAML profiles to declare rules that synthesize `event_type` from payload structure — no Ghost-specific code in the engine.

Three rule types supported:
- `status_path` + `prefix` — e.g. `post.current.status = "published"` → `"post.published"`
- `status_path` + `default` — fallback when status is empty (e.g. deleted post → `"post.deleted"`)
- `present_path` + `if_present`/`if_absent` — e.g. `member.current.name` present → `"member.added"`, absent → `"member.deleted"`

**Files changed:**
- `internal/apptemplate/apptemplate.go` — `EventTypeKeyRule` struct, `EventTypeKeys []EventTypeKeyRule` on `Webhook`, exported `InferEventTypeFromKeys`, `ExtractFields` synthesizes `event_type` when keys configured
- `internal/ingest/pipeline.go` — `Process` calls `InferEventTypeFromKeys` after field extraction
- `appprofiles/ghost.yaml` — full profile with post/page/member event detection, URL health check against Ghost Admin API, digest categories
- `internal/apptemplate/apptemplate_test.go` — 8 Ghost test cases

**Event type detection (Option A — payload inference):**
- `post.current.status = "published"` → `post.published`
- `post.current.status = "draft"` → `post.draft` (rendered as "Unpublished")
- `post.current.status = "scheduled"` → `post.scheduled`
- empty `post.current` → `post.deleted`
- `member.current.name` present → `member.added`
- `member.current.name` absent → `member.deleted`

## Test coverage
- `TestGhost_PostPublished` — event_type inference + display text
- `TestGhost_PostUnpublished` — draft status → "Unpublished — {title}"
- `TestGhost_PostDeleted` — empty current → post.deleted
- `TestGhost_MemberAdded` — name present → member.added + display text
- `TestGhost_MemberDeleted` — empty current → member.deleted + warn severity
- `TestGhost_SeverityMapping` — all 7 event types
- `TestGhost_PagePublished` — page event detection
- `TestGhost_LoadsFromYAML` — loads, category=Content, 3 event_type_keys

`go test ./...` ✅ | `npm run build` ✅

## Closes
Closes this issue