### PR TITLE
feat: Synology DSM full integration — system info, CPU/memory, volumes, disks, updates (Infra-9)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { AppDetail } from './pages/AppDetail'
 import { Infrastructure } from './pages/Infrastructure'
 import { InfraComponentDetail } from './pages/InfraComponentDetail'
 import { ProxmoxDetail } from './pages/ProxmoxDetail'
+import { SynologyDetail } from './pages/SynologyDetail'
 import { TraefikDetail } from './pages/TraefikDetail'
 import { Settings } from './pages/Settings'
 import { AppTemplateEditor } from './pages/AppTemplateEditor'
@@ -29,6 +30,7 @@ export default function App() {
           <Route path="apps/:id" element={<AppDetail />} />
           <Route path="topology" element={<Infrastructure />} />
           <Route path="topology/proxmox/:componentId" element={<ProxmoxDetail />} />
+          <Route path="topology/synology/:componentId" element={<SynologyDetail />} />
           <Route path="topology/traefik/:componentId" element={<TraefikDetail />} />
           <Route path="topology/:id" element={<InfraComponentDetail />} />
           <Route path="settings" element={<Settings />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -40,6 +40,7 @@ import type {
   SMTPSettings,
   SNMPDetail,
   ScanResult,
+  SynologyDetail,
   SendNowResult,
   SyncResult,
   TimeseriesBucket,
@@ -394,6 +395,13 @@ export const infrastructure = {
 
   unlinkApp: (componentId: string, appId: string) =>
     request<void>('DELETE', `/infrastructure/${componentId}/apps/${appId}`),
+}
+
+// ── Synology Detail ───────────────────────────────────────────────────────────
+
+export const synology = {
+  detail: (id: string) =>
+    request<{ data: SynologyDetail; no_data?: boolean }>('GET', `/infrastructure/${id}/synology`),
 }
 
 // ── Proxmox Detail ────────────────────────────────────────────────────────────

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -479,6 +479,49 @@ export interface ProxmoxTaskFailure {
   node: string
 }
 
+// ── Synology Detail ──────────────────────────────────────────────────────────
+
+export interface SynologyMemory {
+  used_bytes: number
+  total_bytes: number
+  percent: number
+}
+
+export interface SynologyVolume {
+  path: string
+  status: string
+  used_bytes: number
+  total_bytes: number
+  percent: number
+}
+
+export interface SynologyDisk {
+  slot: number
+  model: string
+  temperature_c: number
+  status: string
+}
+
+export interface SynologyUpdate {
+  available: boolean
+  version: string
+}
+
+export interface SynologyDetail {
+  model: string
+  dsm_version: string
+  hostname: string
+  uptime: string
+  uptime_secs: number
+  temperature_c: number
+  cpu_percent: number
+  memory: SynologyMemory
+  volumes: SynologyVolume[]
+  disks: SynologyDisk[]
+  update: SynologyUpdate
+  polled_at: string
+}
+
 // ── Docker Discovery ─────────────────────────────────────────────────────────
 
 export interface DiscoveredContainer {

--- a/frontend/src/pages/InfraComponentDetail.tsx
+++ b/frontend/src/pages/InfraComponentDetail.tsx
@@ -441,6 +441,12 @@ export function InfraComponentDetail() {
     return null
   }
 
+  // Synology components have their own detail page.
+  if (component.type === 'synology') {
+    navigate(`/topology/synology/${component.id}`, { replace: true })
+    return null
+  }
+
   return (
     <>
       <Topbar title={component.name} />

--- a/frontend/src/pages/SynologyDetail.css
+++ b/frontend/src/pages/SynologyDetail.css
@@ -1,0 +1,377 @@
+/* ── Synology Detail Page ────────────────────────────────────────────────── */
+
+.syn-loading,
+.syn-error {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--text2);
+  padding: 24px 0;
+}
+
+/* ── Header ──────────────────────────────────────────────────────────────── */
+
+.syn-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.syn-header-left {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.syn-back-btn {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.syn-back-btn:hover { color: var(--text); }
+
+.syn-title {
+  font-family: var(--mono);
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+
+.syn-header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding-top: 4px;
+}
+
+.syn-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.syn-status-dot.online   { background: var(--green); }
+.syn-status-dot.degraded { background: var(--yellow, #eab308); }
+.syn-status-dot.offline  { background: var(--red); }
+.syn-status-dot.unknown  { background: var(--text3); }
+
+.syn-status-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  text-transform: capitalize;
+}
+
+.syn-type-badge {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  background: var(--surface2, rgba(255,255,255,0.05));
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 6px;
+}
+
+.syn-ip {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+}
+
+.syn-polled-at {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+}
+
+/* ── Card ────────────────────────────────────────────────────────────────── */
+
+.syn-card {
+  background: var(--surface, #1a1a2e);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 20px;
+}
+
+/* ── Section ─────────────────────────────────────────────────────────────── */
+
+.syn-section {
+  padding: 12px 0;
+}
+
+.syn-section:first-child { padding-top: 0; }
+.syn-section:last-child  { padding-bottom: 0; }
+
+.syn-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 0 -20px;
+}
+
+.syn-section-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text3);
+  margin-bottom: 10px;
+}
+
+/* ── System Info grid ────────────────────────────────────────────────────── */
+
+.syn-info-grid {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 4px 12px;
+}
+
+.syn-info-key {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text3);
+  align-self: center;
+}
+
+.syn-info-val {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text);
+}
+
+/* ── Resource bars ───────────────────────────────────────────────────────── */
+
+.syn-res-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.syn-res-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.syn-res-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  width: 36px;
+  flex-shrink: 0;
+}
+
+.syn-res-track {
+  flex: 1;
+  height: 6px;
+  background: var(--surface2, rgba(255,255,255,0.07));
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.syn-res-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.syn-res-pct {
+  font-family: var(--mono);
+  font-size: 11px;
+  width: 36px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.syn-res-extra {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  white-space: nowrap;
+}
+
+/* ── Volumes ─────────────────────────────────────────────────────────────── */
+
+.syn-vol-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.syn-vol-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-left: 2px solid transparent;
+  padding-left: 4px;
+}
+
+.syn-vol-row.syn-row-warn { border-left-color: var(--yellow, #eab308); }
+.syn-vol-row.syn-row-crit { border-left-color: var(--red); }
+
+.syn-vol-path {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  width: 80px;
+  flex-shrink: 0;
+}
+
+.syn-vol-bar {
+  flex: 1;
+}
+
+.syn-vol-size {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  white-space: nowrap;
+}
+
+.syn-vol-status {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+  min-width: 70px;
+}
+
+/* ── Disks ───────────────────────────────────────────────────────────────── */
+
+.syn-disk-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.syn-disk-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  border-left: 2px solid transparent;
+  padding-left: 4px;
+}
+
+.syn-disk-row.syn-row-warn { border-left-color: var(--yellow, #eab308); }
+.syn-disk-row.syn-row-crit { border-left-color: var(--red); }
+
+.syn-disk-slot {
+  color: var(--text3);
+  width: 48px;
+  flex-shrink: 0;
+}
+
+.syn-disk-model {
+  color: var(--text2);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.syn-disk-temp {
+  width: 40px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.syn-disk-status {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text2);
+  white-space: nowrap;
+  min-width: 70px;
+}
+
+/* ── Status dots (inline) ────────────────────────────────────────────────── */
+
+.syn-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.syn-dot.normal  { background: var(--green); }
+.syn-dot.warn    { background: var(--yellow, #eab308); }
+.syn-dot.crit    { background: var(--red); }
+.syn-dot.unknown { background: var(--text3); }
+
+/* ── Updates ─────────────────────────────────────────────────────────────── */
+
+.syn-update-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.syn-update-label {
+  color: var(--text3);
+  width: 36px;
+  flex-shrink: 0;
+}
+
+.syn-update-check {
+  color: var(--green);
+}
+
+.syn-update-arrow {
+  color: var(--yellow, #eab308);
+}
+
+.syn-update-value {
+  color: var(--text);
+}
+
+.syn-update-value.available {
+  color: var(--yellow, #eab308);
+  font-weight: 600;
+}
+
+.syn-update-current {
+  color: var(--text3);
+}
+
+.syn-update-current.muted,
+.syn-update-value.muted {
+  color: var(--text3);
+}
+
+/* ── Pending / awaiting ──────────────────────────────────────────────────── */
+
+.syn-pending-row {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text3);
+  font-style: italic;
+}
+
+.syn-awaiting {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  text-align: center;
+  padding-top: 16px;
+  margin-top: 8px;
+  border-top: 1px solid var(--border);
+}

--- a/frontend/src/pages/SynologyDetail.tsx
+++ b/frontend/src/pages/SynologyDetail.tsx
@@ -1,0 +1,335 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useAutoRefresh } from '../context/AutoRefreshContext'
+import { Topbar } from '../components/Topbar'
+import { infrastructure as infraApi, synology as synologyApi } from '../api/client'
+import type {
+  InfrastructureComponent,
+  SynologyDetail,
+  SynologyVolume,
+  SynologyDisk,
+} from '../api/types'
+import './SynologyDetail.css'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatBytes(bytes: number): string {
+  if (!bytes || bytes <= 0) return '0 B'
+  const tb = bytes / 1_099_511_627_776
+  if (tb >= 1) return `${tb.toFixed(1)} TB`
+  const gb = bytes / 1_073_741_824
+  if (gb >= 1) return `${gb.toFixed(1)} GB`
+  const mb = bytes / 1_048_576
+  return `${mb.toFixed(0)} MB`
+}
+
+function timeAgo(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const secs = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  if (secs < 60) return `${secs}s ago`
+  if (secs < 3600) return `${Math.floor(secs / 60)}m ago`
+  if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`
+  return `${Math.floor(secs / 86400)}d ago`
+}
+
+function tempColor(c: number): string {
+  if (c > 55) return 'var(--red)'
+  if (c > 45) return 'var(--yellow, #eab308)'
+  return 'var(--green)'
+}
+
+function barFillColor(pct: number): string {
+  if (pct >= 90) return 'var(--red)'
+  if (pct >= 70) return 'var(--yellow, #eab308)'
+  return 'var(--accent, #3b82f6)'
+}
+
+function statusDotClass(status: string): string {
+  switch (status.toLowerCase()) {
+    case 'normal': return 'syn-dot normal'
+    case 'degraded':
+    case 'warning': return 'syn-dot warn'
+    case 'crashed':
+    case 'critical': return 'syn-dot crit'
+    default: return 'syn-dot unknown'
+  }
+}
+
+function statusLabel(status: string): string {
+  if (!status) return '—'
+  return status.charAt(0).toUpperCase() + status.slice(1)
+}
+
+function hostStatusClass(s: string): string {
+  if (s === 'online') return 'online'
+  if (s === 'degraded') return 'degraded'
+  if (s === 'offline' || s === 'down') return 'offline'
+  return 'unknown'
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return <div className="syn-section-label">{children}</div>
+}
+
+function ResourceBar({
+  label, value, color, extra,
+}: { label: string; value: number; color: string; extra?: string }) {
+  return (
+    <div className="syn-res-row">
+      <div className="syn-res-label">{label}</div>
+      <div className="syn-res-track">
+        <div
+          className="syn-res-fill"
+          style={{ width: `${Math.min(Math.max(value, 0), 100)}%`, background: color }}
+        />
+      </div>
+      <div className="syn-res-pct" style={{ color }}>{value > 0 ? `${Math.round(value)}%` : '0%'}</div>
+      {extra && <div className="syn-res-extra">{extra}</div>}
+    </div>
+  )
+}
+
+function VolumeRow({ vol }: { vol: SynologyVolume }) {
+  const accentClass =
+    vol.status === 'crashed' ? 'syn-row-crit' :
+    vol.status === 'degraded' ? 'syn-row-warn' : ''
+  const color = barFillColor(vol.percent)
+  return (
+    <div className={`syn-vol-row ${accentClass}`}>
+      <div className="syn-vol-path">{vol.path}</div>
+      <div className="syn-res-track syn-vol-bar">
+        <div
+          className="syn-res-fill"
+          style={{ width: `${Math.min(Math.max(vol.percent, 0), 100)}%`, background: color }}
+        />
+      </div>
+      <div className="syn-res-pct" style={{ color }}>{Math.round(vol.percent)}%</div>
+      <div className="syn-vol-size">{formatBytes(vol.used_bytes)} / {formatBytes(vol.total_bytes)}</div>
+      <div className="syn-vol-status">
+        <span className={statusDotClass(vol.status)} />
+        {statusLabel(vol.status)}
+      </div>
+    </div>
+  )
+}
+
+function DiskRow({ disk }: { disk: SynologyDisk }) {
+  const accentClass =
+    disk.status === 'critical' ? 'syn-row-crit' :
+    disk.status === 'warning' ? 'syn-row-warn' : ''
+  return (
+    <div className={`syn-disk-row ${accentClass}`}>
+      <div className="syn-disk-slot">Disk {disk.slot}</div>
+      <div className="syn-disk-model">{disk.model || '—'}</div>
+      <div className="syn-disk-temp" style={{ color: tempColor(disk.temperature_c) }}>
+        {disk.temperature_c > 0 ? `${disk.temperature_c}°C` : '—'}
+      </div>
+      <div className="syn-disk-status">
+        <span className={statusDotClass(disk.status)} />
+        {statusLabel(disk.status)}
+      </div>
+    </div>
+  )
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export function SynologyDetail() {
+  const { componentId } = useParams<{ componentId: string }>()
+  const navigate = useNavigate()
+  const { tick } = useAutoRefresh()
+
+  const [component, setComponent] = useState<InfrastructureComponent | null>(null)
+  const [detail, setDetail] = useState<SynologyDetail | null>(null)
+  const [noData, setNoData] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    if (!componentId) return
+    try {
+      const [comp, detailResp] = await Promise.all([
+        infraApi.get(componentId),
+        synologyApi.detail(componentId),
+      ])
+      setComponent(comp)
+      setDetail(detailResp.data)
+      setNoData(detailResp.no_data === true)
+      setError(null)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to load Synology data')
+    } finally {
+      setLoading(false)
+    }
+  }, [componentId])
+
+  useEffect(() => { load() }, [load, tick])
+
+  if (loading) {
+    return (
+      <>
+        <Topbar title="Synology NAS" />
+        <div className="content"><div className="syn-loading">Loading…</div></div>
+      </>
+    )
+  }
+
+  if (error || !component) {
+    return (
+      <>
+        <Topbar title="Synology NAS" />
+        <div className="content">
+          <div className="syn-error">{error ?? 'Component not found'}</div>
+          <button className="syn-back-btn" onClick={() => navigate('/topology')}>← Back</button>
+        </div>
+      </>
+    )
+  }
+
+  const d = detail
+  const statusCls = hostStatusClass(component.last_status)
+
+  return (
+    <>
+      <Topbar title={component.name} />
+      <div className="content">
+
+        {/* Header */}
+        <div className="syn-header">
+          <div className="syn-header-left">
+            <button className="syn-back-btn" onClick={() => navigate('/topology')}>← Infrastructure</button>
+            <h1 className="syn-title">{component.name}</h1>
+          </div>
+          <div className="syn-header-right">
+            <span className={`syn-status-dot ${statusCls}`} />
+            <span className="syn-status-label">{component.last_status}</span>
+            <span className="syn-type-badge">Synology NAS</span>
+            {component.ip && <span className="syn-ip">{component.ip}</span>}
+            {d?.polled_at && (
+              <span className="syn-polled-at">polled {timeAgo(d.polled_at)}</span>
+            )}
+          </div>
+        </div>
+
+        {/* Card */}
+        <div className="syn-card">
+
+          {/* Section 1 — System Info */}
+          <div className="syn-section">
+            <SectionLabel>System Info</SectionLabel>
+            <div className="syn-info-grid">
+              <span className="syn-info-key">Model</span>
+              <span className="syn-info-val">{d?.model || '—'}</span>
+              <span className="syn-info-key">DSM</span>
+              <span className="syn-info-val">{d?.dsm_version || '—'}</span>
+              <span className="syn-info-key">Hostname</span>
+              <span className="syn-info-val">{d?.hostname || '—'}</span>
+              <span className="syn-info-key">Uptime</span>
+              <span className="syn-info-val">{d?.uptime || '—'}</span>
+              <span className="syn-info-key">Temp</span>
+              <span
+                className="syn-info-val"
+                style={d?.temperature_c ? { color: tempColor(d.temperature_c) } : undefined}
+              >
+                {d?.temperature_c ? `${d.temperature_c}°C` : '—'}
+              </span>
+            </div>
+          </div>
+
+          <div className="syn-divider" />
+
+          {/* Section 2 — CPU & Memory */}
+          <div className="syn-section">
+            <SectionLabel>CPU &amp; Memory</SectionLabel>
+            <div className="syn-res-list">
+              <ResourceBar
+                label="CPU"
+                value={d?.cpu_percent ?? 0}
+                color={barFillColor(d?.cpu_percent ?? 0)}
+              />
+              <ResourceBar
+                label="MEM"
+                value={d?.memory?.percent ?? 0}
+                color={barFillColor(d?.memory?.percent ?? 0)}
+                extra={
+                  d?.memory?.total_bytes
+                    ? `${formatBytes(d.memory.used_bytes)} / ${formatBytes(d.memory.total_bytes)}`
+                    : undefined
+                }
+              />
+            </div>
+          </div>
+
+          <div className="syn-divider" />
+
+          {/* Section 3 — Volumes */}
+          <div className="syn-section">
+            <SectionLabel>Volumes</SectionLabel>
+            {!d || d.volumes.length === 0 ? (
+              <div className="syn-pending-row">Pending first scan</div>
+            ) : (
+              <div className="syn-vol-list">
+                {d.volumes.map(vol => (
+                  <VolumeRow key={vol.path} vol={vol} />
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="syn-divider" />
+
+          {/* Section 4 — Disks */}
+          <div className="syn-section">
+            <SectionLabel>Disks</SectionLabel>
+            {!d || d.disks.length === 0 ? (
+              <div className="syn-pending-row">Pending first scan</div>
+            ) : (
+              <div className="syn-disk-list">
+                {d.disks.map(disk => (
+                  <DiskRow key={disk.slot} disk={disk} />
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="syn-divider" />
+
+          {/* Section 5 — Updates */}
+          <div className="syn-section">
+            <SectionLabel>Updates</SectionLabel>
+            <div className="syn-update-row">
+              <span className="syn-update-label">DSM</span>
+              {!d ? (
+                <span className="syn-update-value muted">—</span>
+              ) : d.update?.available ? (
+                <>
+                  <span className="syn-update-arrow">↑</span>
+                  <span className="syn-update-value available">{d.update.version} available</span>
+                  {d.dsm_version && (
+                    <span className="syn-update-current">(currently {d.dsm_version})</span>
+                  )}
+                </>
+              ) : (
+                <>
+                  <span className="syn-update-check">✓</span>
+                  <span className="syn-update-value">Up to date</span>
+                  {d.dsm_version && (
+                    <span className="syn-update-current muted">{d.dsm_version}</span>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* Pending note */}
+          {noData && (
+            <div className="syn-awaiting">Awaiting first scan</div>
+          )}
+
+        </div>
+      </div>
+    </>
+  )
+}

--- a/internal/api/infra_components.go
+++ b/internal/api/infra_components.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/digitalcheffe/nora/internal/infra"
 	"github.com/digitalcheffe/nora/internal/jobs"
 	"github.com/digitalcheffe/nora/internal/models"
 	"github.com/digitalcheffe/nora/internal/repo"
@@ -41,6 +42,7 @@ func (h *InfraComponentHandler) Routes(r chi.Router) {
 	r.Get("/infrastructure/{id}/resources", h.GetResources)
 	r.Get("/infrastructure/{id}/resources/history", h.GetResourceHistory)
 	r.Get("/infrastructure/{id}/snmp", h.GetSNMPDetail)
+	r.Get("/infrastructure/{id}/synology", h.GetSynologyDetail)
 	r.Get("/infrastructure/{id}/traefik/overview", h.GetTraefikOverview)
 	r.Get("/infrastructure/{id}/traefik/routers", h.GetTraefikRouters)
 	r.Get("/infrastructure/{id}/traefik/services", h.GetTraefikServices)
@@ -725,6 +727,50 @@ func (h *InfraComponentHandler) GetSNMPDetail(w http.ResponseWriter, r *http.Req
 		Disks: disks,
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// ── Synology detail ───────────────────────────────────────────────────────────
+
+// GetSynologyDetail returns the latest Synology DSM snapshot stored in synology_meta.
+// GET /api/v1/infrastructure/{id}/synology
+func (h *InfraComponentHandler) GetSynologyDetail(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	comp, err := h.components.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "component not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if comp.Type != "synology" {
+		writeError(w, http.StatusBadRequest, "component is not a Synology NAS")
+		return
+	}
+
+	// No poll has run yet — return a zero-value no_data response so the UI renders.
+	if comp.SynologyMeta == nil || *comp.SynologyMeta == "" {
+		resp := infra.SynologyMeta{
+			Volumes: []infra.SynologyVolume{},
+			Disks:   []infra.SynologyDisk{},
+		}
+		writeJSON(w, http.StatusOK, map[string]interface{}{"data": resp, "no_data": true})
+		return
+	}
+
+	var meta infra.SynologyMeta
+	if jsonErr := json.Unmarshal([]byte(*comp.SynologyMeta), &meta); jsonErr != nil {
+		writeError(w, http.StatusInternalServerError, "failed to parse synology_meta")
+		return
+	}
+	if meta.Volumes == nil {
+		meta.Volumes = []infra.SynologyVolume{}
+	}
+	if meta.Disks == nil {
+		meta.Disks = []infra.SynologyDisk{}
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"data": meta})
 }
 
 // ── Children & linked-app endpoints ──────────────────────────────────────────

--- a/internal/infra/synology.go
+++ b/internal/infra/synology.go
@@ -26,16 +26,71 @@ type SynologyCredentials struct {
 	VerifyTLS bool   `json:"verify_tls"`
 }
 
+// SynologyMeta is the rich snapshot stored in synology_meta and returned by the
+// detail API endpoint. It is populated by the poller on every poll cycle.
+type SynologyMeta struct {
+	Model        string           `json:"model"`
+	DSMVersion   string           `json:"dsm_version"`
+	Hostname     string           `json:"hostname"`
+	Uptime       string           `json:"uptime"`
+	UptimeSecs   int64            `json:"uptime_secs"`
+	TemperatureC int              `json:"temperature_c"`
+	CPUPercent   float64          `json:"cpu_percent"`
+	Memory       SynologyMemory   `json:"memory"`
+	Volumes      []SynologyVolume `json:"volumes"`
+	Disks        []SynologyDisk   `json:"disks"`
+	Update       SynologyUpdate   `json:"update"`
+	PolledAt     string           `json:"polled_at"`
+}
+
+// SynologyMemory is the memory sub-object within SynologyMeta.
+type SynologyMemory struct {
+	UsedBytes  int64   `json:"used_bytes"`
+	TotalBytes int64   `json:"total_bytes"`
+	Percent    float64 `json:"percent"`
+}
+
+// SynologyVolume is one entry in SynologyMeta.Volumes.
+type SynologyVolume struct {
+	Path       string  `json:"path"`
+	Status     string  `json:"status"`
+	UsedBytes  int64   `json:"used_bytes"`
+	TotalBytes int64   `json:"total_bytes"`
+	Percent    float64 `json:"percent"`
+}
+
+// SynologyDisk is one entry in SynologyMeta.Disks.
+type SynologyDisk struct {
+	Slot         int    `json:"slot"`
+	Model        string `json:"model"`
+	TemperatureC int    `json:"temperature_c"`
+	Status       string `json:"status"`
+}
+
+// SynologyUpdate is the DSM update state in SynologyMeta.
+type SynologyUpdate struct {
+	Available bool   `json:"available"`
+	Version   string `json:"version"`
+}
+
 // SynologyPoller polls a single Synology DSM instance, writing resource_readings
-// and generating events for degraded disk health. The session ID is reused across
-// poll cycles; a re-login occurs automatically on session expiry (error code 119).
+// and generating events for state changes. The session ID is cached and reused
+// across poll cycles; re-authentication occurs on session expiry (>6 days) or
+// when the API returns an auth error.
 type SynologyPoller struct {
 	componentID string
 	creds       SynologyCredentials
 	client      *http.Client
 
-	mu  sync.Mutex
-	sid string // empty means not yet authenticated
+	mu              sync.Mutex
+	sid             string
+	authenticatedAt time.Time
+
+	// State tracking for transition-based event generation.
+	volumeStates    sync.Map // vol_path (string) → last known status (string)
+	diskStates      sync.Map // slot key (string) → last known status (string)
+	diskTempFlagged sync.Map // slot key (string) → bool (currently above 50°C threshold)
+	lastUpdateVer   sync.Map // key "ver" → last seen available version string
 }
 
 // NewSynologyPoller creates a SynologyPoller from a component ID and credentials JSON.
@@ -77,52 +132,79 @@ type synoAuthData struct {
 	SID string `json:"sid"`
 }
 
-type synoSystemInfo struct {
-	CPUUserLoad float64 `json:"cpu_user_load"`
-	RAMTotal    float64 `json:"ram_total"`
-	RAMUsed     float64 `json:"ram_used"`
+// SYNO.Core.System method=info — system identity
+type synoCoreSystemInfo struct {
+	Model       string `json:"model"`
+	FirmwareVer string `json:"firmware_ver"`
+	HostName    string `json:"host_name"`
+	UpTime      int64  `json:"up_time"`    // seconds
+	Temperature int    `json:"temperature"` // Celsius
 }
 
-type synoStorageData struct {
-	Volumes []synoVolume `json:"volumes"`
+// SYNO.Core.System.Utilization method=get — CPU and memory utilization
+type synoUtilization struct {
+	CPU    synoUtilCPU    `json:"cpu"`
+	Memory synoUtilMemory `json:"memory"`
 }
 
-// synoVolume holds per-volume storage info. DSM returns byte counts as decimal
-// strings (e.g. "1073741824000") to avoid JSON integer-overflow on large arrays.
-type synoVolume struct {
-	VolPath       string `json:"vol_path"`
-	SizeTotalByte string `json:"size_total_byte"`
-	SizeUsedByte  string `json:"size_used_byte"`
+type synoUtilCPU struct {
+	UserLoad float64 `json:"user_load"` // 0–100
 }
 
-type synoDiskHealthData struct {
-	Disks []synoDisk `json:"disks"`
+type synoUtilMemory struct {
+	RealUsage float64 `json:"real_usage"` // percent 0–100
+	RealTotal int64   `json:"real_total"` // KB
+	AvailReal int64   `json:"avail_real"` // KB
 }
 
-type synoDisk struct {
-	ID     string `json:"id"`
-	Status string `json:"status"`
+// SYNO.Core.System method=info type=storage — volume health
+type synoCoreSystemStorage struct {
+	VolInfo []synoVolumeInfo `json:"vol_info"`
+}
+
+type synoVolumeInfo struct {
+	VolPath   string `json:"vol_path"`
+	Status    string `json:"status"`    // normal|degraded|crashed
+	TotalSize string `json:"total_size"` // decimal byte count string
+	UsedSize  string `json:"used_size"`  // decimal byte count string
+}
+
+// SYNO.Storage.CGI.Storage method=load_info — physical disk details
+type synoStorageDiskData struct {
+	Disks []synoStorageDisk `json:"disks"`
+}
+
+type synoStorageDisk struct {
+	Slot   int    `json:"slot"`
+	Model  string `json:"model"`
+	Temp   int    `json:"temp"`   // Celsius
+	Status string `json:"status"` // normal|warning|critical
+}
+
+// SYNO.Core.Upgrade method=check — DSM update availability
+type synoUpgradeData struct {
+	Available bool   `json:"update_available"`
+	Version   string `json:"version"`
 }
 
 // ── Authentication ────────────────────────────────────────────────────────────
 
-// login authenticates with DSM and stores the returned session ID.
+// login authenticates with DSM via entry.cgi and caches the returned SID.
 func (p *SynologyPoller) login(ctx context.Context) error {
-	u, err := url.Parse(p.creds.BaseURL + "/webapi/auth.cgi")
+	u, err := url.Parse(p.creds.BaseURL + "/webapi/entry.cgi")
 	if err != nil {
 		return fmt.Errorf("parse base URL: %w", err)
 	}
 	q := url.Values{}
 	q.Set("api", "SYNO.API.Auth")
-	q.Set("version", "3")
+	q.Set("version", "6")
 	q.Set("method", "login")
 	q.Set("account", p.creds.Username)
 	q.Set("passwd", p.creds.Password)
-	q.Set("session", "NORA")
-	q.Set("format", "cookie")
+	q.Set("format", "sid")
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), nil)
 	if err != nil {
 		return fmt.Errorf("build login request: %w", err)
 	}
@@ -155,7 +237,9 @@ func (p *SynologyPoller) login(ctx context.Context) error {
 
 	p.mu.Lock()
 	p.sid = authData.SID
+	p.authenticatedAt = time.Now().UTC()
 	p.mu.Unlock()
+	log.Printf("synology poller %s: authenticated (new SID)", p.componentID)
 	return nil
 }
 
@@ -168,20 +252,19 @@ func (p *SynologyPoller) Shutdown(ctx context.Context) {
 		return
 	}
 
-	u, err := url.Parse(p.creds.BaseURL + "/webapi/auth.cgi")
+	u, err := url.Parse(p.creds.BaseURL + "/webapi/entry.cgi")
 	if err != nil {
 		log.Printf("synology poller %s: logout: parse URL: %v", p.componentID, err)
 		return
 	}
 	q := url.Values{}
 	q.Set("api", "SYNO.API.Auth")
-	q.Set("version", "3")
+	q.Set("version", "6")
 	q.Set("method", "logout")
-	q.Set("session", "NORA")
 	q.Set("_sid", sid)
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), nil)
 	if err != nil {
 		log.Printf("synology poller %s: logout: build request: %v", p.componentID, err)
 		return
@@ -197,30 +280,39 @@ func (p *SynologyPoller) Shutdown(ctx context.Context) {
 
 // ── HTTP helper ───────────────────────────────────────────────────────────────
 
-// get performs an authenticated GET to entry.cgi and decodes the response data
-// into out. It automatically re-authenticates once on session expiry (code 119).
-func (p *SynologyPoller) get(ctx context.Context, params url.Values, out interface{}) error {
+// sidExpired returns true if re-authentication is needed (no SID or SID > 6 days old).
+func (p *SynologyPoller) sidExpired() bool {
 	p.mu.Lock()
-	sid := p.sid
-	p.mu.Unlock()
+	defer p.mu.Unlock()
+	if p.sid == "" {
+		return true
+	}
+	return time.Since(p.authenticatedAt) > 6*24*time.Hour
+}
 
-	if sid == "" {
+// get performs an authenticated GET to entry.cgi and decodes the response data
+// into out. It re-authenticates proactively if the SID is > 6 days old, and
+// retries once on session error codes (105, 106, 119).
+func (p *SynologyPoller) get(ctx context.Context, params url.Values, out interface{}) error {
+	if p.sidExpired() {
 		if err := p.login(ctx); err != nil {
 			return fmt.Errorf("authenticate: %w", err)
 		}
-		p.mu.Lock()
-		sid = p.sid
-		p.mu.Unlock()
 	}
+
+	p.mu.Lock()
+	sid := p.sid
+	p.mu.Unlock()
 
 	env, err := p.doGet(ctx, sid, params)
 	if err != nil {
 		return err
 	}
 
-	// Re-authenticate on session expiry and retry once.
-	if !env.Success && env.Error != nil && env.Error.Code == 119 {
-		log.Printf("synology poller %s: session expired, re-authenticating", p.componentID)
+	// Re-authenticate on session errors and retry once.
+	if !env.Success && env.Error != nil &&
+		(env.Error.Code == 119 || env.Error.Code == 105 || env.Error.Code == 106) {
+		log.Printf("synology poller %s: session error (code %d), re-authenticating", p.componentID, env.Error.Code)
 		if authErr := p.login(ctx); authErr != nil {
 			return fmt.Errorf("re-authenticate: %w", authErr)
 		}
@@ -277,28 +369,51 @@ func (p *SynologyPoller) doGet(ctx context.Context, sid string, params url.Value
 
 // ── Poll ──────────────────────────────────────────────────────────────────────
 
-// Poll runs one full cycle: system resources, volume usage, and disk health.
-// Returns an error if the system-resources call fails (indicating the host is
-// unreachable). Partial failures on subsequent calls set status="degraded".
+// Poll runs one full cycle: system info, CPU/memory, volumes, disks, and updates.
+// Returns an error only if system info fails (host unreachable). Partial failures
+// on subsequent calls set status="degraded" but do not abort the cycle.
 func (p *SynologyPoller) Poll(ctx context.Context, store *repo.Store) error {
 	now := time.Now().UTC()
+	meta := &SynologyMeta{
+		PolledAt: now.Format(time.RFC3339Nano),
+		Volumes:  []SynologyVolume{},
+		Disks:    []SynologyDisk{},
+	}
 
-	// System resources is the primary reachability test.
-	if err := p.pollSystemResources(ctx, store, now); err != nil {
-		return fmt.Errorf("system resources: %w", err)
+	// System info is the primary reachability test.
+	if err := p.fetchSystemInfo(ctx, meta); err != nil {
+		return fmt.Errorf("system info: %w", err)
 	}
 
 	degraded := false
 
-	if err := p.pollVolumeUsage(ctx, store, now); err != nil {
-		log.Printf("synology poller %s: volume usage: %v", p.componentID, err)
+	if err := p.fetchUtilization(ctx, store, meta, now); err != nil {
+		log.Printf("synology poller %s: utilization: %v", p.componentID, err)
 		degraded = true
 	}
 
-	diskDegraded, err := p.pollDiskHealth(ctx, store, now)
-	if err != nil {
-		log.Printf("synology poller %s: disk health: %v", p.componentID, err)
+	if err := p.fetchVolumes(ctx, store, meta, now); err != nil {
+		log.Printf("synology poller %s: volumes: %v", p.componentID, err)
 		degraded = true
+	}
+
+	diskDegraded, err := p.fetchDisks(ctx, store, meta, now)
+	if err != nil {
+		log.Printf("synology poller %s: disks: %v", p.componentID, err)
+		degraded = true
+	}
+
+	if err := p.fetchUpdates(ctx, store, meta, now); err != nil {
+		// Non-fatal — some DSM versions or permission sets restrict this API.
+		log.Printf("synology poller %s: updates: %v (non-fatal)", p.componentID, err)
+	}
+
+	// Persist snapshot to synology_meta column.
+	metaJSON, jsonErr := json.Marshal(meta)
+	if jsonErr == nil {
+		if storeErr := store.InfraComponents.UpdateSynologyMeta(ctx, p.componentID, string(metaJSON)); storeErr != nil {
+			log.Printf("synology poller %s: store meta: %v", p.componentID, storeErr)
+		}
 	}
 
 	status := "online"
@@ -312,28 +427,72 @@ func (p *SynologyPoller) Poll(ctx context.Context, store *repo.Store) error {
 	return nil
 }
 
-func (p *SynologyPoller) pollSystemResources(ctx context.Context, store *repo.Store, now time.Time) error {
+// formatSynoUptime converts seconds to a human-readable string like "21d 4h 11m".
+func formatSynoUptime(secs int64) string {
+	if secs <= 0 {
+		return "—"
+	}
+	d := secs / 86400
+	h := (secs % 86400) / 3600
+	m := (secs % 3600) / 60
+	if d > 0 {
+		return fmt.Sprintf("%dd %dh %dm", d, h, m)
+	}
+	return fmt.Sprintf("%dh %dm", h, m)
+}
+
+func (p *SynologyPoller) fetchSystemInfo(ctx context.Context, meta *SynologyMeta) error {
 	params := url.Values{}
 	params.Set("api", "SYNO.Core.System")
 	params.Set("version", "1")
 	params.Set("method", "info")
 
-	var info synoSystemInfo
+	var info synoCoreSystemInfo
 	if err := p.get(ctx, params, &info); err != nil {
 		return err
 	}
 
-	var memPercent float64
-	if info.RAMTotal > 0 {
-		memPercent = (info.RAMUsed / info.RAMTotal) * 100
+	meta.Model = info.Model
+	meta.DSMVersion = info.FirmwareVer
+	meta.Hostname = info.HostName
+	meta.UptimeSecs = info.UpTime
+	meta.Uptime = formatSynoUptime(info.UpTime)
+	meta.TemperatureC = info.Temperature
+	return nil
+}
+
+func (p *SynologyPoller) fetchUtilization(ctx context.Context, store *repo.Store, meta *SynologyMeta, now time.Time) error {
+	params := url.Values{}
+	params.Set("api", "SYNO.Core.System.Utilization")
+	params.Set("version", "1")
+	params.Set("method", "get")
+
+	var util synoUtilization
+	if err := p.get(ctx, params, &util); err != nil {
+		return err
+	}
+
+	meta.CPUPercent = util.CPU.UserLoad
+
+	// RealTotal and AvailReal are in KB; convert to bytes.
+	totalBytes := util.Memory.RealTotal * 1024
+	availBytes := util.Memory.AvailReal * 1024
+	usedBytes := totalBytes - availBytes
+	if usedBytes < 0 {
+		usedBytes = 0
+	}
+	meta.Memory = SynologyMemory{
+		UsedBytes:  usedBytes,
+		TotalBytes: totalBytes,
+		Percent:    util.Memory.RealUsage,
 	}
 
 	for _, m := range []struct {
 		metric string
 		value  float64
 	}{
-		{"cpu_percent", info.CPUUserLoad},
-		{"mem_percent", memPercent},
+		{"cpu_percent", util.CPU.UserLoad},
+		{"mem_percent", util.Memory.RealUsage},
 	} {
 		reading := &models.ResourceReading{
 			ID:         uuid.New().String(),
@@ -350,88 +509,202 @@ func (p *SynologyPoller) pollSystemResources(ctx context.Context, store *repo.St
 	return nil
 }
 
-func (p *SynologyPoller) pollVolumeUsage(ctx context.Context, store *repo.Store, now time.Time) error {
+func (p *SynologyPoller) fetchVolumes(ctx context.Context, store *repo.Store, meta *SynologyMeta, now time.Time) error {
 	params := url.Values{}
-	params.Set("api", "SYNO.Storage.CGI.Storage")
+	params.Set("api", "SYNO.Core.System")
 	params.Set("version", "1")
-	params.Set("method", "load_info")
+	params.Set("method", "info")
+	params.Set("type", "storage")
 
-	var storageData synoStorageData
+	var storageData synoCoreSystemStorage
 	if err := p.get(ctx, params, &storageData); err != nil {
 		return err
 	}
 
-	for _, vol := range storageData.Volumes {
-		total, err := strconv.ParseInt(vol.SizeTotalByte, 10, 64)
+	for _, vol := range storageData.VolInfo {
+		total, err := strconv.ParseInt(vol.TotalSize, 10, 64)
 		if err != nil || total == 0 {
 			continue
 		}
-		used, err := strconv.ParseInt(vol.SizeUsedByte, 10, 64)
+		used, err := strconv.ParseInt(vol.UsedSize, 10, 64)
 		if err != nil {
 			continue
 		}
 
-		diskPercent := (float64(used) / float64(total)) * 100
+		diskPct := (float64(used) / float64(total)) * 100
 		// Sanitise vol_path to a metric-safe key: "/volume1" → "volume1".
 		volKey := strings.TrimLeft(vol.VolPath, "/")
 		if volKey == "" {
 			volKey = "unknown"
 		}
 
+		meta.Volumes = append(meta.Volumes, SynologyVolume{
+			Path:       vol.VolPath,
+			Status:     vol.Status,
+			UsedBytes:  used,
+			TotalBytes: total,
+			Percent:    diskPct,
+		})
+
 		reading := &models.ResourceReading{
 			ID:         uuid.New().String(),
 			SourceID:   p.componentID,
 			SourceType: "synology",
 			Metric:     "disk_percent_" + volKey,
-			Value:      diskPercent,
+			Value:      diskPct,
 			RecordedAt: now,
 		}
 		if err := store.Resources.Create(ctx, reading); err != nil {
 			log.Printf("synology poller %s: write disk_percent_%s: %v", p.componentID, volKey, err)
 		}
+
+		// Emit volume status change events (transitions only).
+		lastStatusI, _ := p.volumeStates.Load(vol.VolPath)
+		lastStatus, _ := lastStatusI.(string)
+		if vol.Status != lastStatus {
+			p.volumeStates.Store(vol.VolPath, vol.Status)
+			if vol.Status == "degraded" || vol.Status == "crashed" {
+				severity := "warn"
+				displayText := fmt.Sprintf("Volume %s degraded", vol.VolPath)
+				if vol.Status == "crashed" {
+					severity = "error"
+					displayText = fmt.Sprintf("Volume %s crashed", vol.VolPath)
+				}
+				rawPayload, _ := json.Marshal(vol)
+				event := &models.Event{
+					ID:          uuid.New().String(),
+					ReceivedAt:  now,
+					Severity:    severity,
+					DisplayText: displayText,
+					RawPayload:  string(rawPayload),
+					Fields:      fmt.Sprintf(`{"source":"synology","component_id":%q,"vol_path":%q,"status":%q}`, p.componentID, vol.VolPath, vol.Status),
+				}
+				if err := store.Events.Create(ctx, event); err != nil {
+					log.Printf("synology poller %s: create volume event for %s: %v", p.componentID, vol.VolPath, err)
+				}
+			}
+		}
 	}
 	return nil
 }
 
-// pollDiskHealth checks disk status and fires events for non-normal disks.
-// Returns (degraded, error) — degraded is true if any disk is not "normal".
-func (p *SynologyPoller) pollDiskHealth(ctx context.Context, store *repo.Store, now time.Time) (bool, error) {
+// fetchDisks fetches physical disk details and returns (diskDegraded, error).
+func (p *SynologyPoller) fetchDisks(ctx context.Context, store *repo.Store, meta *SynologyMeta, now time.Time) (bool, error) {
 	params := url.Values{}
-	params.Set("api", "SYNO.Storage.CGI.DiskHealth")
+	params.Set("api", "SYNO.Storage.CGI.Storage")
 	params.Set("version", "1")
 	params.Set("method", "load_info")
 
-	var healthData synoDiskHealthData
-	if err := p.get(ctx, params, &healthData); err != nil {
+	var diskData synoStorageDiskData
+	if err := p.get(ctx, params, &diskData); err != nil {
 		return false, err
 	}
 
 	degraded := false
-	for _, disk := range healthData.Disks {
-		if disk.Status == "normal" {
-			continue
-		}
-		degraded = true
+	for _, disk := range diskData.Disks {
+		meta.Disks = append(meta.Disks, SynologyDisk{
+			Slot:         disk.Slot,
+			Model:        disk.Model,
+			TemperatureC: disk.Temp,
+			Status:       disk.Status,
+		})
 
-		severity := "warn"
-		if disk.Status == "critical" || disk.Status == "failing" {
-			severity = "error"
+		if disk.Status != "normal" {
+			degraded = true
 		}
 
-		rawPayload, _ := json.Marshal(disk)
-		event := &models.Event{
-			ID:          uuid.New().String(),
-			AppID:       "",
-			ReceivedAt:  now,
-			Severity:    severity,
-			DisplayText: fmt.Sprintf("Synology disk %s status: %s", disk.ID, disk.Status),
-			RawPayload:  string(rawPayload),
-			Fields:      fmt.Sprintf(`{"source":"synology","disk_id":%q,"status":%q}`, disk.ID, disk.Status),
+		slotKey := strconv.Itoa(disk.Slot)
+
+		// Disk status transition events.
+		lastStatusI, _ := p.diskStates.Load(slotKey)
+		lastStatus, _ := lastStatusI.(string)
+		if disk.Status != lastStatus {
+			p.diskStates.Store(slotKey, disk.Status)
+			if disk.Status == "warning" || disk.Status == "critical" {
+				severity := "warn"
+				displayText := fmt.Sprintf("Disk %d (%s) warning", disk.Slot, disk.Model)
+				if disk.Status == "critical" {
+					severity = "error"
+					displayText = fmt.Sprintf("Disk %d (%s) critical", disk.Slot, disk.Model)
+				}
+				rawPayload, _ := json.Marshal(disk)
+				event := &models.Event{
+					ID:          uuid.New().String(),
+					ReceivedAt:  now,
+					Severity:    severity,
+					DisplayText: displayText,
+					RawPayload:  string(rawPayload),
+					Fields:      fmt.Sprintf(`{"source":"synology","component_id":%q,"disk_slot":%d,"model":%q,"status":%q}`, p.componentID, disk.Slot, disk.Model, disk.Status),
+				}
+				if err := store.Events.Create(ctx, event); err != nil {
+					log.Printf("synology poller %s: create disk status event for slot %d: %v", p.componentID, disk.Slot, err)
+				}
+			}
 		}
-		if err := store.Events.Create(ctx, event); err != nil {
-			log.Printf("synology poller %s: create disk health event for %s: %v",
-				p.componentID, disk.ID, err)
+
+		// Temperature threshold events: fire once when crossing >50°C, reset on cool-down.
+		tempFlaggedI, _ := p.diskTempFlagged.Load(slotKey)
+		wasFlagged, _ := tempFlaggedI.(bool)
+		isFlagged := disk.Temp > 50
+		if isFlagged && !wasFlagged {
+			p.diskTempFlagged.Store(slotKey, true)
+			rawPayload, _ := json.Marshal(disk)
+			event := &models.Event{
+				ID:          uuid.New().String(),
+				ReceivedAt:  now,
+				Severity:    "warn",
+				DisplayText: fmt.Sprintf("Disk %d temp %d°C", disk.Slot, disk.Temp),
+				RawPayload:  string(rawPayload),
+				Fields:      fmt.Sprintf(`{"source":"synology","component_id":%q,"disk_slot":%d,"model":%q,"temp_c":%d}`, p.componentID, disk.Slot, disk.Model, disk.Temp),
+			}
+			if err := store.Events.Create(ctx, event); err != nil {
+				log.Printf("synology poller %s: create disk temp event for slot %d: %v", p.componentID, disk.Slot, err)
+			}
+		} else if !isFlagged && wasFlagged {
+			p.diskTempFlagged.Store(slotKey, false)
 		}
 	}
 	return degraded, nil
+}
+
+func (p *SynologyPoller) fetchUpdates(ctx context.Context, store *repo.Store, meta *SynologyMeta, now time.Time) error {
+	params := url.Values{}
+	params.Set("api", "SYNO.Core.Upgrade")
+	params.Set("version", "1")
+	params.Set("method", "check")
+
+	var upgrade synoUpgradeData
+	if err := p.get(ctx, params, &upgrade); err != nil {
+		return err
+	}
+
+	meta.Update = SynologyUpdate{
+		Available: upgrade.Available,
+		Version:   upgrade.Version,
+	}
+
+	// Fire one info event when a new available version is first seen.
+	if upgrade.Available && upgrade.Version != "" {
+		lastVerI, _ := p.lastUpdateVer.Load("ver")
+		lastVer, _ := lastVerI.(string)
+		if upgrade.Version != lastVer {
+			p.lastUpdateVer.Store("ver", upgrade.Version)
+			rawPayload, _ := json.Marshal(upgrade)
+			event := &models.Event{
+				ID:          uuid.New().String(),
+				ReceivedAt:  now,
+				Severity:    "info",
+				DisplayText: fmt.Sprintf("DSM update available: %s", upgrade.Version),
+				RawPayload:  string(rawPayload),
+				Fields:      fmt.Sprintf(`{"source":"synology","component_id":%q,"update_version":%q}`, p.componentID, upgrade.Version),
+			}
+			if err := store.Events.Create(ctx, event); err != nil {
+				log.Printf("synology poller %s: create update event: %v", p.componentID, err)
+			}
+		}
+	} else if !upgrade.Available {
+		// Reset so we fire again if a new update appears.
+		p.lastUpdateVer.Store("ver", "")
+	}
+	return nil
 }

--- a/internal/infra/synology_test.go
+++ b/internal/infra/synology_test.go
@@ -63,31 +63,45 @@ func createSynologyTestComponent(t *testing.T, store *repo.Store, id string) {
 	}
 }
 
-// synologyFakeServer handles DSM API requests.
+// synologyFakeServer handles DSM API requests matching the new API structure:
+// - Login/Logout: POST /webapi/entry.cgi with api=SYNO.API.Auth
+// - System info:  GET  /webapi/entry.cgi api=SYNO.Core.System method=info
+// - Utilization:  GET  /webapi/entry.cgi api=SYNO.Core.System.Utilization method=get
+// - Volumes:      GET  /webapi/entry.cgi api=SYNO.Core.System method=info type=storage
+// - Disks:        GET  /webapi/entry.cgi api=SYNO.Storage.CGI.Storage method=load_info
+// - Upgrade:      GET  /webapi/entry.cgi api=SYNO.Core.Upgrade method=check
 type synologyFakeServer struct {
 	sidToReturn     string
 	loginShouldFail bool
 
-	// expireFirstN causes the first N entry.cgi calls to return code 119.
+	// expireFirstN causes the first N entry.cgi non-auth calls to return code 119.
 	expireFirstN int
 	callCount    int
 
-	systemInfo synoSystemInfo
-	volumes    []synoVolume
-	disks      []synoDisk
+	systemInfo  synoCoreSystemInfo
+	utilization synoUtilization
+	volumes     []synoVolumeInfo
+	disks       []synoStorageDisk
+	upgrade     synoUpgradeData
 }
 
 func newSynologyFakeServer(t *testing.T) (*httptest.Server, *synologyFakeServer) {
 	t.Helper()
 	fs := &synologyFakeServer{
 		sidToReturn: "test-session-id",
-		systemInfo: synoSystemInfo{
-			CPUUserLoad: 25.0,
-			RAMTotal:    8192,
-			RAMUsed:     4096,
+		systemInfo: synoCoreSystemInfo{
+			Model:       "DS920+",
+			FirmwareVer: "7.2.1-69057",
+			HostName:    "synology",
+			UpTime:      86400,
+			Temperature: 38,
 		},
-		volumes: []synoVolume{
-			{VolPath: "/volume1", SizeTotalByte: "1000000000", SizeUsedByte: "500000000"},
+		utilization: synoUtilization{
+			CPU:    synoUtilCPU{UserLoad: 25.0},
+			Memory: synoUtilMemory{RealUsage: 50.0, RealTotal: 8192, AvailReal: 4096},
+		},
+		volumes: []synoVolumeInfo{
+			{VolPath: "/volume1", Status: "normal", TotalSize: "1000000000", UsedSize: "500000000"},
 		},
 	}
 	srv := httptest.NewServer(http.HandlerFunc(fs.handle))
@@ -113,8 +127,17 @@ func (fs *synologyFakeServer) apiError(w http.ResponseWriter, code int) {
 func (fs *synologyFakeServer) handle(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
-	if r.URL.Path == "/webapi/auth.cgi" {
-		switch q.Get("method") {
+	if r.URL.Path != "/webapi/entry.cgi" {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	apiName := q.Get("api")
+	method := q.Get("method")
+
+	// Auth calls (login/logout) go to entry.cgi.
+	if apiName == "SYNO.API.Auth" {
+		switch method {
 		case "login":
 			if fs.loginShouldFail {
 				fs.apiError(w, 400)
@@ -129,29 +152,31 @@ func (fs *synologyFakeServer) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.URL.Path == "/webapi/entry.cgi" {
-		// Simulate session expiry on the first N calls.
-		if fs.expireFirstN > 0 && fs.callCount < fs.expireFirstN {
-			fs.callCount++
-			fs.apiError(w, 119)
-			return
-		}
+	// Simulate session expiry on the first N non-auth entry.cgi calls.
+	if fs.expireFirstN > 0 && fs.callCount < fs.expireFirstN {
 		fs.callCount++
-
-		switch q.Get("api") {
-		case "SYNO.Core.System":
-			fs.ok(w, fs.systemInfo)
-		case "SYNO.Storage.CGI.Storage":
-			fs.ok(w, map[string]interface{}{"volumes": fs.volumes})
-		case "SYNO.Storage.CGI.DiskHealth":
-			fs.ok(w, map[string]interface{}{"disks": fs.disks})
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
+		fs.apiError(w, 119)
 		return
 	}
+	fs.callCount++
 
-	w.WriteHeader(http.StatusNotFound)
+	switch apiName {
+	case "SYNO.Core.System":
+		if q.Get("type") == "storage" {
+			fs.ok(w, map[string]interface{}{"vol_info": fs.volumes})
+		} else {
+			fs.ok(w, fs.systemInfo)
+		}
+	case "SYNO.Core.System.Utilization":
+		fs.ok(w, fs.utilization)
+	case "SYNO.Storage.CGI.Storage":
+		fs.ok(w, map[string]interface{}{"disks": fs.disks})
+	case "SYNO.Core.Upgrade":
+		fs.ok(w, fs.upgrade)
+	default:
+		// Unknown API — return empty success so the poller treats it as non-fatal.
+		fs.ok(w, map[string]interface{}{})
+	}
 }
 
 func makeSynologyCredentials(baseURL string) string {
@@ -221,13 +246,12 @@ func TestSynologyPoller_Poll_WritesResourceReadingsAndSetsOnline(t *testing.T) {
 
 func TestSynologyPoller_Poll_CPUMemValues(t *testing.T) {
 	srv, fs := newSynologyFakeServer(t)
-	fs.systemInfo = synoSystemInfo{
-		CPUUserLoad: 50.0,
-		RAMTotal:    8192,
-		RAMUsed:     4096, // 50%
+	fs.utilization = synoUtilization{
+		CPU:    synoUtilCPU{UserLoad: 50.0},
+		Memory: synoUtilMemory{RealUsage: 50.0, RealTotal: 8192, AvailReal: 4096},
 	}
-	fs.volumes = []synoVolume{
-		{VolPath: "/volume1", SizeTotalByte: "1000000000", SizeUsedByte: "500000000"}, // 50%
+	fs.volumes = []synoVolumeInfo{
+		{VolPath: "/volume1", Status: "normal", TotalSize: "1000000000", UsedSize: "500000000"},
 	}
 
 	ctx := context.Background()
@@ -248,17 +272,19 @@ func TestSynologyPoller_Poll_CPUMemValues(t *testing.T) {
 		if a.SourceID != compID {
 			continue
 		}
-		if a.Avg < 49 || a.Avg > 51 {
-			t.Errorf("metric %s: avg=%v, want ~50", a.Metric, a.Avg)
+		if a.Metric == "cpu_percent" || a.Metric == "mem_percent" {
+			if a.Avg < 49 || a.Avg > 51 {
+				t.Errorf("metric %s: avg=%v, want ~50", a.Metric, a.Avg)
+			}
 		}
 	}
 }
 
 func TestSynologyPoller_Poll_MultipleVolumes(t *testing.T) {
 	srv, fs := newSynologyFakeServer(t)
-	fs.volumes = []synoVolume{
-		{VolPath: "/volume1", SizeTotalByte: "1000000000", SizeUsedByte: "250000000"},  // 25%
-		{VolPath: "/volume2", SizeTotalByte: "2000000000", SizeUsedByte: "1000000000"}, // 50%
+	fs.volumes = []synoVolumeInfo{
+		{VolPath: "/volume1", Status: "normal", TotalSize: "1000000000", UsedSize: "250000000"},
+		{VolPath: "/volume2", Status: "normal", TotalSize: "2000000000", UsedSize: "1000000000"},
 	}
 
 	ctx := context.Background()
@@ -291,7 +317,7 @@ func TestSynologyPoller_Poll_MultipleVolumes(t *testing.T) {
 
 func TestSynologyPoller_Poll_DiskWarningFiresWarnEvent(t *testing.T) {
 	srv, fs := newSynologyFakeServer(t)
-	fs.disks = []synoDisk{{ID: "sda", Status: "warning"}}
+	fs.disks = []synoStorageDisk{{Slot: 1, Model: "WD Red", Status: "warning"}}
 
 	ctx := context.Background()
 	store := newSynologyTestStore(t)
@@ -317,18 +343,18 @@ func TestSynologyPoller_Poll_DiskWarningFiresWarnEvent(t *testing.T) {
 	}
 	found := false
 	for _, ev := range events {
-		if ev.Severity == "warn" && ev.DisplayText == "Synology disk sda status: warning" {
+		if ev.Severity == "warn" && ev.DisplayText == "Disk 1 (WD Red) warning" {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("expected warn event for sda warning; events: %v", events)
+		t.Errorf("expected warn event for disk 1 warning; events: %v", events)
 	}
 }
 
 func TestSynologyPoller_Poll_DiskCriticalFiresErrorEvent(t *testing.T) {
 	srv, fs := newSynologyFakeServer(t)
-	fs.disks = []synoDisk{{ID: "sdb", Status: "critical"}}
+	fs.disks = []synoStorageDisk{{Slot: 2, Model: "WD Red", Status: "critical"}}
 
 	ctx := context.Background()
 	store := newSynologyTestStore(t)
@@ -343,46 +369,20 @@ func TestSynologyPoller_Poll_DiskCriticalFiresErrorEvent(t *testing.T) {
 	events, _, _ := store.Events.List(ctx, repo.ListFilter{Limit: 50})
 	found := false
 	for _, ev := range events {
-		if ev.Severity == "error" && ev.DisplayText == "Synology disk sdb status: critical" {
+		if ev.Severity == "error" && ev.DisplayText == "Disk 2 (WD Red) critical" {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("expected error event for sdb critical; events: %v", events)
-	}
-}
-
-func TestSynologyPoller_Poll_DiskFailingFiresErrorEvent(t *testing.T) {
-	srv, fs := newSynologyFakeServer(t)
-	fs.disks = []synoDisk{{ID: "sdc", Status: "failing"}}
-
-	ctx := context.Background()
-	store := newSynologyTestStore(t)
-	compID := "syn-disk-fail"
-	createSynologyTestComponent(t, store, compID)
-
-	poller, _ := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
-	if err := poller.Poll(ctx, store); err != nil {
-		t.Fatalf("Poll: %v", err)
-	}
-
-	events, _, _ := store.Events.List(ctx, repo.ListFilter{Limit: 50})
-	found := false
-	for _, ev := range events {
-		if ev.Severity == "error" && ev.DisplayText == "Synology disk sdc status: failing" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected error event for sdc failing; events: %v", events)
+		t.Errorf("expected error event for disk 2 critical; events: %v", events)
 	}
 }
 
 func TestSynologyPoller_Poll_AllDisksNormal_NoEvent(t *testing.T) {
 	srv, fs := newSynologyFakeServer(t)
-	fs.disks = []synoDisk{
-		{ID: "sda", Status: "normal"},
-		{ID: "sdb", Status: "normal"},
+	fs.disks = []synoStorageDisk{
+		{Slot: 1, Model: "WD Red", Status: "normal"},
+		{Slot: 2, Model: "WD Red", Status: "normal"},
 	}
 
 	ctx := context.Background()
@@ -406,9 +406,39 @@ func TestSynologyPoller_Poll_AllDisksNormal_NoEvent(t *testing.T) {
 	}
 }
 
+func TestSynologyPoller_Poll_DiskStatusOnlyOnTransition(t *testing.T) {
+	srv, fs := newSynologyFakeServer(t)
+	fs.disks = []synoStorageDisk{{Slot: 1, Model: "WD Red", Status: "warning"}}
+
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-disk-transition"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, _ := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
+
+	// First poll — status transition from "" to "warning" should fire one event.
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll 1: %v", err)
+	}
+	_, total1, _ := store.Events.List(ctx, repo.ListFilter{Limit: 50})
+	if total1 != 1 {
+		t.Errorf("after first poll: expected 1 event, got %d", total1)
+	}
+
+	// Second poll — same status, no new event.
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll 2: %v", err)
+	}
+	_, total2, _ := store.Events.List(ctx, repo.ListFilter{Limit: 50})
+	if total2 != 1 {
+		t.Errorf("after second poll (same status): expected still 1 event, got %d", total2)
+	}
+}
+
 func TestSynologyPoller_Poll_SessionExpiryTriggersReauth(t *testing.T) {
 	srv, fs := newSynologyFakeServer(t)
-	// First entry.cgi call returns session-expired; poller should re-auth and retry.
+	// First entry.cgi non-auth call returns session-expired; poller should re-auth and retry.
 	fs.expireFirstN = 1
 
 	ctx := context.Background()
@@ -433,7 +463,12 @@ func TestSynologyPoller_Poll_SessionReusedAcrossCycles(t *testing.T) {
 		q := r.URL.Query()
 		w.Header().Set("Content-Type", "application/json")
 
-		if r.URL.Path == "/webapi/auth.cgi" && q.Get("method") == "login" {
+		if r.URL.Path != "/webapi/entry.cgi" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		if q.Get("api") == "SYNO.API.Auth" && q.Get("method") == "login" {
 			loginCount++
 			b, _ := json.Marshal(map[string]interface{}{
 				"success": true,
@@ -443,22 +478,26 @@ func TestSynologyPoller_Poll_SessionReusedAcrossCycles(t *testing.T) {
 			return
 		}
 
-		if r.URL.Path == "/webapi/entry.cgi" {
-			var data interface{}
-			switch q.Get("api") {
-			case "SYNO.Core.System":
-				data = synoSystemInfo{CPUUserLoad: 10, RAMTotal: 1024, RAMUsed: 512}
-			case "SYNO.Storage.CGI.Storage":
-				data = map[string]interface{}{"volumes": []interface{}{}}
-			case "SYNO.Storage.CGI.DiskHealth":
-				data = map[string]interface{}{"disks": []interface{}{}}
+		// All other calls succeed with minimal data.
+		var data interface{}
+		switch q.Get("api") {
+		case "SYNO.Core.System":
+			if q.Get("type") == "storage" {
+				data = map[string]interface{}{"vol_info": []interface{}{}}
+			} else {
+				data = synoCoreSystemInfo{Model: "DS920+"}
 			}
-			b, _ := json.Marshal(map[string]interface{}{"success": true, "data": data})
-			w.Write(b) //nolint:errcheck
-			return
+		case "SYNO.Core.System.Utilization":
+			data = synoUtilization{}
+		case "SYNO.Storage.CGI.Storage":
+			data = map[string]interface{}{"disks": []interface{}{}}
+		case "SYNO.Core.Upgrade":
+			data = synoUpgradeData{}
+		default:
+			data = map[string]interface{}{}
 		}
-
-		w.WriteHeader(http.StatusNotFound)
+		b, _ := json.Marshal(map[string]interface{}{"success": true, "data": data})
+		w.Write(b) //nolint:errcheck
 	}))
 	defer srv.Close()
 
@@ -508,5 +547,103 @@ func TestSynologyPoller_Poll_ConnectionRefused_ReturnsError(t *testing.T) {
 	}
 	if err := poller.Poll(ctx, store); err == nil {
 		t.Error("expected error for unreachable host, got nil")
+	}
+}
+
+func TestSynologyPoller_Poll_VolumeStatusChangeFiresEvent(t *testing.T) {
+	srv, fs := newSynologyFakeServer(t)
+	fs.volumes = []synoVolumeInfo{
+		{VolPath: "/volume1", Status: "normal", TotalSize: "1000000000", UsedSize: "500000000"},
+	}
+
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-vol-event"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, _ := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
+
+	// First poll with normal status — no event.
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll 1: %v", err)
+	}
+	_, total1, _ := store.Events.List(ctx, repo.ListFilter{Limit: 50})
+	if total1 != 0 {
+		t.Errorf("expected 0 events after normal poll, got %d", total1)
+	}
+
+	// Transition to degraded — event should fire.
+	fs.volumes[0].Status = "degraded"
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll 2: %v", err)
+	}
+	events, _, _ := store.Events.List(ctx, repo.ListFilter{Limit: 50})
+	found := false
+	for _, ev := range events {
+		if ev.Severity == "warn" && ev.DisplayText == "Volume /volume1 degraded" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warn event for /volume1 degraded; events: %v", events)
+	}
+}
+
+func TestSynologyPoller_Poll_DSMUpdateFiresEvent(t *testing.T) {
+	srv, fs := newSynologyFakeServer(t)
+	fs.upgrade = synoUpgradeData{Available: true, Version: "7.3.0-69999"}
+
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-update"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, _ := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	events, _, _ := store.Events.List(ctx, repo.ListFilter{Limit: 50})
+	found := false
+	for _, ev := range events {
+		if ev.Severity == "info" && ev.DisplayText == "DSM update available: 7.3.0-69999" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected info event for DSM update; events: %v", events)
+	}
+}
+
+func TestSynologyPoller_Poll_MetaStored(t *testing.T) {
+	srv, _ := newSynologyFakeServer(t)
+
+	ctx := context.Background()
+	store := newSynologyTestStore(t)
+	compID := "syn-meta"
+	createSynologyTestComponent(t, store, compID)
+
+	poller, _ := NewSynologyPoller(compID, makeSynologyCredentials(srv.URL))
+	if err := poller.Poll(ctx, store); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	comp, _ := store.InfraComponents.Get(ctx, compID)
+	if comp.SynologyMeta == nil || *comp.SynologyMeta == "" {
+		t.Fatal("synology_meta should be non-empty after a successful poll")
+	}
+
+	var meta SynologyMeta
+	if err := json.Unmarshal([]byte(*comp.SynologyMeta), &meta); err != nil {
+		t.Fatalf("unmarshal synology_meta: %v", err)
+	}
+	if meta.Model != "DS920+" {
+		t.Errorf("model: got %q, want \"DS920+\"", meta.Model)
+	}
+	if meta.CPUPercent != 25.0 {
+		t.Errorf("cpu_percent: got %v, want 25.0", meta.CPUPercent)
+	}
+	if len(meta.Volumes) != 1 {
+		t.Errorf("volumes: got %d, want 1", len(meta.Volumes))
 	}
 }

--- a/internal/models/infrastructure.go
+++ b/internal/models/infrastructure.go
@@ -16,6 +16,10 @@ type InfrastructureComponent struct {
 	// SNMPMeta holds the latest SNMP system identity + resource snapshot as JSON.
 	// Written by the SNMP poller on each poll cycle; never returned directly in API responses.
 	SNMPMeta         *string `db:"snmp_meta"          json:"-"`
+	// SynologyMeta holds the latest Synology DSM snapshot (model, version, CPU, memory,
+	// volumes, disks, update status) as JSON. Written by the Synology poller on each
+	// poll cycle; never returned directly in API responses.
+	SynologyMeta     *string `db:"synology_meta"      json:"-"`
 	Notes            string  `db:"notes"              json:"notes"`
 	Enabled          bool    `db:"enabled"            json:"enabled"`
 	LastPolledAt     *string `db:"last_polled_at"     json:"last_polled_at,omitempty"`

--- a/internal/repo/infrastructure.go
+++ b/internal/repo/infrastructure.go
@@ -31,6 +31,9 @@ type InfraComponentRepo interface {
 	// UpdateSNMPMeta stores the latest SNMP system identity + resource snapshot JSON
 	// on the component without touching any other fields.
 	UpdateSNMPMeta(ctx context.Context, id, metaJSON string) error
+	// UpdateSynologyMeta stores the latest Synology DSM snapshot JSON on the component
+	// without touching any other fields.
+	UpdateSynologyMeta(ctx context.Context, id, metaJSON string) error
 }
 
 type sqliteInfraComponentRepo struct{ db *sqlx.DB }
@@ -44,7 +47,7 @@ func (r *sqliteInfraComponentRepo) List(ctx context.Context) ([]models.Infrastru
 	var rows []models.InfrastructureComponent
 	err := r.db.SelectContext(ctx, &rows, `
 		SELECT id, name, COALESCE(ip,'') AS ip, type, collection_method,
-		       parent_id, credentials, snmp_config, snmp_meta,
+		       parent_id, credentials, snmp_config, snmp_meta, synology_meta,
 		       COALESCE(notes,'') AS notes, enabled,
 		       last_polled_at, COALESCE(last_status,'unknown') AS last_status,
 		       created_at
@@ -63,7 +66,7 @@ func (r *sqliteInfraComponentRepo) ListByParent(ctx context.Context, parentID st
 	var rows []models.InfrastructureComponent
 	err := r.db.SelectContext(ctx, &rows, `
 		SELECT id, name, COALESCE(ip,'') AS ip, type, collection_method,
-		       parent_id, credentials, snmp_config, snmp_meta,
+		       parent_id, credentials, snmp_config, snmp_meta, synology_meta,
 		       COALESCE(notes,'') AS notes, enabled,
 		       last_polled_at, COALESCE(last_status,'unknown') AS last_status,
 		       created_at
@@ -83,7 +86,7 @@ func (r *sqliteInfraComponentRepo) Get(ctx context.Context, id string) (*models.
 	var c models.InfrastructureComponent
 	err := r.db.GetContext(ctx, &c, `
 		SELECT id, name, COALESCE(ip,'') AS ip, type, collection_method,
-		       parent_id, credentials, snmp_config, snmp_meta,
+		       parent_id, credentials, snmp_config, snmp_meta, synology_meta,
 		       COALESCE(notes,'') AS notes, enabled,
 		       last_polled_at, COALESCE(last_status,'unknown') AS last_status,
 		       created_at
@@ -162,6 +165,19 @@ func (r *sqliteInfraComponentRepo) UpdateSNMPMeta(ctx context.Context, id, metaJ
 		metaJSON, id)
 	if err != nil {
 		return fmt.Errorf("update snmp_meta: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *sqliteInfraComponentRepo) UpdateSynologyMeta(ctx context.Context, id, metaJSON string) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE infrastructure_components SET synology_meta = ? WHERE id = ?`,
+		metaJSON, id)
+	if err != nil {
+		return fmt.Errorf("update synology_meta: %w", err)
 	}
 	if n, _ := res.RowsAffected(); n == 0 {
 		return ErrNotFound

--- a/migrations/019_synology_meta.sql
+++ b/migrations/019_synology_meta.sql
@@ -1,0 +1,7 @@
+-- 019_synology_meta.sql
+-- Adds synology_meta TEXT column to infrastructure_components for storing the
+-- last-polled Synology DSM snapshot (model, DSM version, hostname, uptime,
+-- temperature, CPU, memory, volumes, disks, update status) as JSON.
+-- Follows the same pattern as snmp_meta (migration 018).
+
+ALTER TABLE infrastructure_components ADD COLUMN synology_meta TEXT;


### PR DESCRIPTION
## What
Full Synology DSM poller with rich metadata, five-section detail page, and transition-based event generation.

## Why
Closes Infra-9. The Synology integration previously showed basic connectivity only. This adds the full DSM API polling pipeline: system identity, CPU/memory utilization, per-volume storage health with status, per-disk physical health with temperature, and DSM update availability.

## How
- **Migration 019**: adds  column to  (mirrors the  pattern from migration 018)
- **Poller rewrite** (): five API calls per cycle —  (identity),  (CPU/mem),  with  (volumes + status),  (disks),  (update check)
- **Session management**: SID cached with  timestamp; proactive re-auth after 6 days; retry once on auth error codes 105/106/119; logout on clean shutdown
- **Events**: volume degraded/crashed, disk warning/critical, disk temp >50°C, DSM update available — all transition-only using  state tracking, no event storms
- **Metadata**: full  JSON snapshot stored to  after every poll cycle
- **Repo**:  method added to  interface and implementation; all SELECT queries updated to include 
- **API**:  returns the cached  snapshot, or a no_data response before the first poll
- **Frontend**:  page with 5 sections (System Info, CPU & Memory, Volumes, Disks, Updates); temperature color coding; status badges with row accents for degraded/crashed/warning/critical; pending state renders all sections before first poll
- **Tests**: rewrote  to match new API structure; added new tests for state-transition events, metadata storage, DSM update event, and volume status changes

## Test coverage
- ?   	github.com/digitalcheffe/nora/appprofiles	[no test files]
?   	github.com/digitalcheffe/nora/cmd/nora	[no test files]
?   	github.com/digitalcheffe/nora/frontend/node_modules/flatted/golang/pkg/flatted	[no test files]
ok  	github.com/digitalcheffe/nora/internal/api	(cached)
ok  	github.com/digitalcheffe/nora/internal/apptemplate	(cached)
?   	github.com/digitalcheffe/nora/internal/auth	[no test files]
?   	github.com/digitalcheffe/nora/internal/config	[no test files]
?   	github.com/digitalcheffe/nora/internal/crypto	[no test files]
ok  	github.com/digitalcheffe/nora/internal/docker	(cached)
?   	github.com/digitalcheffe/nora/internal/frontend	[no test files]
ok  	github.com/digitalcheffe/nora/internal/infra	(cached)
ok  	github.com/digitalcheffe/nora/internal/ingest	(cached)
ok  	github.com/digitalcheffe/nora/internal/jobs	(cached)
?   	github.com/digitalcheffe/nora/internal/models	[no test files]
ok  	github.com/digitalcheffe/nora/internal/monitor	(cached)
ok  	github.com/digitalcheffe/nora/internal/push	(cached)
ok  	github.com/digitalcheffe/nora/internal/repo	(cached)
?   	github.com/digitalcheffe/nora/migrations	[no test files] — all packages pass
-  — zero TypeScript errors
-  — clean

## Closes
Closes #Infra-9