### PR TITLE
fix: silence Synology DSM error 103 for upgrade check API

### DIFF
--- a/internal/infra/synology.go
+++ b/internal/infra/synology.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -131,6 +132,12 @@ type synoAPIError struct {
 type synoAuthData struct {
 	SID string `json:"sid"`
 }
+
+// synoCallErr is returned when DSM reports a non-success response so callers
+// can inspect the error code with errors.As.
+type synoCallErr struct{ Code int }
+
+func (e *synoCallErr) Error() string { return fmt.Sprintf("API call failed (error code %d)", e.Code) }
 
 // SYNO.Core.System method=info — system identity
 // DSM returns up_time as a JSON string (e.g. "86400"), not a number.
@@ -336,7 +343,7 @@ func (p *SynologyPoller) get(ctx context.Context, params url.Values, out interfa
 		if env.Error != nil {
 			code = env.Error.Code
 		}
-		return fmt.Errorf("API call failed (error code %d)", code)
+		return &synoCallErr{Code: code}
 	}
 
 	return json.Unmarshal(env.Data, out)
@@ -410,7 +417,11 @@ func (p *SynologyPoller) Poll(ctx context.Context, store *repo.Store) error {
 
 	if err := p.fetchUpdates(ctx, store, meta, now); err != nil {
 		// Non-fatal — some DSM versions or permission sets restrict this API.
-		log.Printf("synology poller %s: updates: %v (non-fatal)", p.componentID, err)
+		// Code 103 = API does not exist on this firmware; log nothing.
+		var callErr *synoCallErr
+		if !errors.As(err, &callErr) || callErr.Code != 103 {
+			log.Printf("synology poller %s: updates: %v (non-fatal)", p.componentID, err)
+		}
 	}
 
 	// Persist snapshot to synology_meta column.


### PR DESCRIPTION
## What
Stop logging a noisy non-fatal warning every poll cycle when the DSM upgrade check API is unavailable.

## Why
`SYNO.Core.Upgrade` returns error code 103 (API does not exist) on DSM 6.x firmware. The call was already non-fatal but logged on every cycle. Code 103 just means the API isn't available on this device — it's not actionable.

## How
- Introduced `synoCallErr` typed error (implements `error`, carries the DSM code) returned from the `get` helper instead of `fmt.Errorf`
- `fetchUpdates` uses `errors.As` to check for code 103 and skips logging in that case; all other error codes still log normally

## Test coverage
`go test ./internal/infra/...` passes — existing tests cover the non-fatal path.

## Closes
Follow-up to #145