### PR TITLE
fix: Synology detail page alignment, API field names, disk degraded threshold

### DIFF
--- a/frontend/src/pages/SynologyDetail.css
+++ b/frontend/src/pages/SynologyDetail.css
@@ -1,93 +1,9 @@
-/* ── Synology Detail Page ────────────────────────────────────────────────── */
+/* ── Synology Detail — content-specific styles only ──────────────────────────
+   Structural classes (header, sections, back-btn, title, status dot, type badge)
+   are provided by InfraComponentDetail.css which is imported alongside this file.
+── */
 
-.syn-loading,
-.syn-error {
-  font-family: var(--mono);
-  font-size: 13px;
-  color: var(--text2);
-  padding: 24px 0;
-}
-
-/* ── Header ──────────────────────────────────────────────────────────────── */
-
-.syn-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  margin-bottom: 16px;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.syn-header-left {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.syn-back-btn {
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--text2);
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-}
-
-.syn-back-btn:hover { color: var(--text); }
-
-.syn-title {
-  font-family: var(--mono);
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text);
-  margin: 0;
-}
-
-.syn-header-right {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-  padding-top: 4px;
-}
-
-.syn-status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  display: inline-block;
-  flex-shrink: 0;
-}
-
-.syn-status-dot.online   { background: var(--green); }
-.syn-status-dot.degraded { background: var(--yellow, #eab308); }
-.syn-status-dot.offline  { background: var(--red); }
-.syn-status-dot.unknown  { background: var(--text3); }
-
-.syn-status-label {
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--text2);
-  text-transform: capitalize;
-}
-
-.syn-type-badge {
-  font-family: var(--mono);
-  font-size: 10px;
-  color: var(--text3);
-  background: var(--surface2, rgba(255,255,255,0.05));
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 2px 6px;
-}
-
-.syn-ip {
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--text3);
-}
+/* ── Polled-at timestamp (header-meta, Synology-specific) ─────────────────── */
 
 .syn-polled-at {
   font-family: var(--mono);
@@ -95,52 +11,20 @@
   color: var(--text3);
 }
 
-/* ── Card ────────────────────────────────────────────────────────────────── */
-
-.syn-card {
-  background: var(--surface, #1a1a2e);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 20px;
-}
-
-/* ── Section ─────────────────────────────────────────────────────────────── */
-
-.syn-section {
-  padding: 12px 0;
-}
-
-.syn-section:first-child { padding-top: 0; }
-.syn-section:last-child  { padding-bottom: 0; }
-
-.syn-divider {
-  height: 1px;
-  background: var(--border);
-  margin: 0 -20px;
-}
-
-.syn-section-label {
-  font-family: var(--mono);
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text3);
-  margin-bottom: 10px;
-}
-
-/* ── System Info grid ────────────────────────────────────────────────────── */
+/* ── System Info grid ─────────────────────────────────────────────────────── */
 
 .syn-info-grid {
   display: grid;
   grid-template-columns: 80px 1fr;
-  gap: 4px 12px;
+  gap: 6px 12px;
 }
 
 .syn-info-key {
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: 10px;
   color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
   align-self: center;
 }
 
@@ -150,12 +34,12 @@
   color: var(--text);
 }
 
-/* ── Resource bars ───────────────────────────────────────────────────────── */
+/* ── Resource bars ────────────────────────────────────────────────────────── */
 
 .syn-res-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
 .syn-res-row {
@@ -167,7 +51,7 @@
 .syn-res-label {
   font-family: var(--mono);
   font-size: 11px;
-  color: var(--text3);
+  color: var(--text2);
   width: 36px;
   flex-shrink: 0;
 }
@@ -175,7 +59,7 @@
 .syn-res-track {
   flex: 1;
   height: 6px;
-  background: var(--surface2, rgba(255,255,255,0.07));
+  background: var(--border);
   border-radius: 3px;
   overflow: hidden;
 }
@@ -196,12 +80,13 @@
 
 .syn-res-extra {
   font-family: var(--mono);
-  font-size: 11px;
+  font-size: 10px;
   color: var(--text3);
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
-/* ── Volumes ─────────────────────────────────────────────────────────────── */
+/* ── Volumes ──────────────────────────────────────────────────────────────── */
 
 .syn-vol-list {
   display: flex;
@@ -214,7 +99,7 @@
   align-items: center;
   gap: 8px;
   border-left: 2px solid transparent;
-  padding-left: 4px;
+  padding-left: 6px;
 }
 
 .syn-vol-row.syn-row-warn { border-left-color: var(--yellow, #eab308); }
@@ -250,7 +135,7 @@
   min-width: 70px;
 }
 
-/* ── Disks ───────────────────────────────────────────────────────────────── */
+/* ── Disks ────────────────────────────────────────────────────────────────── */
 
 .syn-disk-list {
   display: flex;
@@ -265,7 +150,7 @@
   font-family: var(--mono);
   font-size: 12px;
   border-left: 2px solid transparent;
-  padding-left: 4px;
+  padding-left: 6px;
 }
 
 .syn-disk-row.syn-row-warn { border-left-color: var(--yellow, #eab308); }
@@ -300,7 +185,7 @@
   min-width: 70px;
 }
 
-/* ── Status dots (inline) ────────────────────────────────────────────────── */
+/* ── Status dots (volume / disk inline indicators) ────────────────────────── */
 
 .syn-dot {
   width: 7px;
@@ -315,7 +200,7 @@
 .syn-dot.crit    { background: var(--red); }
 .syn-dot.unknown { background: var(--text3); }
 
-/* ── Updates ─────────────────────────────────────────────────────────────── */
+/* ── Updates ──────────────────────────────────────────────────────────────── */
 
 .syn-update-row {
   display: flex;
@@ -331,47 +216,15 @@
   flex-shrink: 0;
 }
 
-.syn-update-check {
-  color: var(--green);
-}
-
-.syn-update-arrow {
-  color: var(--yellow, #eab308);
-}
-
-.syn-update-value {
-  color: var(--text);
-}
+.syn-update-check  { color: var(--green); }
+.syn-update-arrow  { color: var(--yellow, #eab308); }
+.syn-update-value  { color: var(--text); }
 
 .syn-update-value.available {
   color: var(--yellow, #eab308);
   font-weight: 600;
 }
 
-.syn-update-current {
-  color: var(--text3);
-}
-
-.syn-update-current.muted,
-.syn-update-value.muted {
-  color: var(--text3);
-}
-
-/* ── Pending / awaiting ──────────────────────────────────────────────────── */
-
-.syn-pending-row {
-  font-family: var(--mono);
-  font-size: 12px;
-  color: var(--text3);
-  font-style: italic;
-}
-
-.syn-awaiting {
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--text3);
-  text-align: center;
-  padding-top: 16px;
-  margin-top: 8px;
-  border-top: 1px solid var(--border);
-}
+.syn-update-current       { color: var(--text3); }
+.syn-update-current.muted { color: var(--text3); }
+.syn-update-value.muted   { color: var(--text3); }

--- a/frontend/src/pages/SynologyDetail.tsx
+++ b/frontend/src/pages/SynologyDetail.tsx
@@ -9,6 +9,7 @@ import type {
   SynologyVolume,
   SynologyDisk,
 } from '../api/types'
+import './InfraComponentDetail.css'
 import './SynologyDetail.css'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -68,10 +69,6 @@ function hostStatusClass(s: string): string {
 }
 
 // ── Sub-components ────────────────────────────────────────────────────────────
-
-function SectionLabel({ children }: { children: React.ReactNode }) {
-  return <div className="syn-section-label">{children}</div>
-}
 
 function ResourceBar({
   label, value, color, extra,
@@ -171,7 +168,7 @@ export function SynologyDetail() {
     return (
       <>
         <Topbar title="Synology NAS" />
-        <div className="content"><div className="syn-loading">Loading…</div></div>
+        <div className="content"><div className="icd-loading">Loading…</div></div>
       </>
     )
   }
@@ -181,8 +178,8 @@ export function SynologyDetail() {
       <>
         <Topbar title="Synology NAS" />
         <div className="content">
-          <div className="syn-error">{error ?? 'Component not found'}</div>
-          <button className="syn-back-btn" onClick={() => navigate('/topology')}>← Back</button>
+          <div className="icd-error">{error ?? 'Component not found'}</div>
+          <button className="icd-back-btn" onClick={() => navigate('/topology')}>← Back</button>
         </div>
       </>
     )
@@ -197,28 +194,28 @@ export function SynologyDetail() {
       <div className="content">
 
         {/* Header */}
-        <div className="syn-header">
-          <div className="syn-header-left">
-            <button className="syn-back-btn" onClick={() => navigate('/topology')}>← Infrastructure</button>
-            <h1 className="syn-title">{component.name}</h1>
+        <div className="icd-header">
+          <div className="icd-header-left">
+            <button className="icd-back-btn" onClick={() => navigate('/topology')}>← Infrastructure</button>
+            <h1 className="icd-title">{component.name}</h1>
           </div>
-          <div className="syn-header-right">
-            <span className={`syn-status-dot ${statusCls}`} />
-            <span className="syn-status-label">{component.last_status}</span>
-            <span className="syn-type-badge">Synology NAS</span>
-            {component.ip && <span className="syn-ip">{component.ip}</span>}
+          <div className="icd-header-meta">
+            <span className={`icd-status-dot ${statusCls}`} />
+            <span className="icd-status-label">{component.last_status}</span>
+            <span className="icd-type-badge">Synology NAS</span>
+            {component.ip && <span className="icd-ip">{component.ip}</span>}
             {d?.polled_at && (
               <span className="syn-polled-at">polled {timeAgo(d.polled_at)}</span>
             )}
           </div>
         </div>
 
-        {/* Card */}
-        <div className="syn-card">
-
-          {/* Section 1 — System Info */}
-          <div className="syn-section">
-            <SectionLabel>System Info</SectionLabel>
+        {/* Section 1 — System Info */}
+        <div className="icd-section">
+          <div className="icd-section-title">System Info</div>
+          {noData ? (
+            <div className="snmp-pending">Awaiting first scan</div>
+          ) : (
             <div className="syn-info-grid">
               <span className="syn-info-key">Model</span>
               <span className="syn-info-val">{d?.model || '—'}</span>
@@ -236,99 +233,86 @@ export function SynologyDetail() {
                 {d?.temperature_c ? `${d.temperature_c}°C` : '—'}
               </span>
             </div>
-          </div>
-
-          <div className="syn-divider" />
-
-          {/* Section 2 — CPU & Memory */}
-          <div className="syn-section">
-            <SectionLabel>CPU &amp; Memory</SectionLabel>
-            <div className="syn-res-list">
-              <ResourceBar
-                label="CPU"
-                value={d?.cpu_percent ?? 0}
-                color={barFillColor(d?.cpu_percent ?? 0)}
-              />
-              <ResourceBar
-                label="MEM"
-                value={d?.memory?.percent ?? 0}
-                color={barFillColor(d?.memory?.percent ?? 0)}
-                extra={
-                  d?.memory?.total_bytes
-                    ? `${formatBytes(d.memory.used_bytes)} / ${formatBytes(d.memory.total_bytes)}`
-                    : undefined
-                }
-              />
-            </div>
-          </div>
-
-          <div className="syn-divider" />
-
-          {/* Section 3 — Volumes */}
-          <div className="syn-section">
-            <SectionLabel>Volumes</SectionLabel>
-            {!d || d.volumes.length === 0 ? (
-              <div className="syn-pending-row">Pending first scan</div>
-            ) : (
-              <div className="syn-vol-list">
-                {d.volumes.map(vol => (
-                  <VolumeRow key={vol.path} vol={vol} />
-                ))}
-              </div>
-            )}
-          </div>
-
-          <div className="syn-divider" />
-
-          {/* Section 4 — Disks */}
-          <div className="syn-section">
-            <SectionLabel>Disks</SectionLabel>
-            {!d || d.disks.length === 0 ? (
-              <div className="syn-pending-row">Pending first scan</div>
-            ) : (
-              <div className="syn-disk-list">
-                {d.disks.map(disk => (
-                  <DiskRow key={disk.slot} disk={disk} />
-                ))}
-              </div>
-            )}
-          </div>
-
-          <div className="syn-divider" />
-
-          {/* Section 5 — Updates */}
-          <div className="syn-section">
-            <SectionLabel>Updates</SectionLabel>
-            <div className="syn-update-row">
-              <span className="syn-update-label">DSM</span>
-              {!d ? (
-                <span className="syn-update-value muted">—</span>
-              ) : d.update?.available ? (
-                <>
-                  <span className="syn-update-arrow">↑</span>
-                  <span className="syn-update-value available">{d.update.version} available</span>
-                  {d.dsm_version && (
-                    <span className="syn-update-current">(currently {d.dsm_version})</span>
-                  )}
-                </>
-              ) : (
-                <>
-                  <span className="syn-update-check">✓</span>
-                  <span className="syn-update-value">Up to date</span>
-                  {d.dsm_version && (
-                    <span className="syn-update-current muted">{d.dsm_version}</span>
-                  )}
-                </>
-              )}
-            </div>
-          </div>
-
-          {/* Pending note */}
-          {noData && (
-            <div className="syn-awaiting">Awaiting first scan</div>
           )}
-
         </div>
+
+        {/* Section 2 — CPU & Memory */}
+        <div className="icd-section">
+          <div className="icd-section-title">CPU &amp; Memory</div>
+          <div className="syn-res-list">
+            <ResourceBar
+              label="CPU"
+              value={d?.cpu_percent ?? 0}
+              color={barFillColor(d?.cpu_percent ?? 0)}
+            />
+            <ResourceBar
+              label="MEM"
+              value={d?.memory?.percent ?? 0}
+              color={barFillColor(d?.memory?.percent ?? 0)}
+              extra={
+                d?.memory?.total_bytes
+                  ? `${formatBytes(d.memory.used_bytes)} / ${formatBytes(d.memory.total_bytes)}`
+                  : undefined
+              }
+            />
+          </div>
+        </div>
+
+        {/* Section 3 — Volumes */}
+        <div className="icd-section">
+          <div className="icd-section-title">Volumes</div>
+          {!d || d.volumes.length === 0 ? (
+            <div className="snmp-pending">Pending first scan</div>
+          ) : (
+            <div className="syn-vol-list">
+              {d.volumes.map(vol => (
+                <VolumeRow key={vol.path} vol={vol} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Section 4 — Disks */}
+        <div className="icd-section">
+          <div className="icd-section-title">Disks</div>
+          {!d || d.disks.length === 0 ? (
+            <div className="snmp-pending">Pending first scan</div>
+          ) : (
+            <div className="syn-disk-list">
+              {d.disks.map(disk => (
+                <DiskRow key={disk.slot} disk={disk} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Section 5 — Updates */}
+        <div className="icd-section">
+          <div className="icd-section-title">Updates</div>
+          <div className="syn-update-row">
+            <span className="syn-update-label">DSM</span>
+            {!d ? (
+              <span className="syn-update-value muted">—</span>
+            ) : d.update?.available ? (
+              <>
+                <span className="syn-update-arrow">↑</span>
+                <span className="syn-update-value available">{d.update.version} available</span>
+                {d.dsm_version && (
+                  <span className="syn-update-current">(currently {d.dsm_version})</span>
+                )}
+              </>
+            ) : (
+              <>
+                <span className="syn-update-check">✓</span>
+                <span className="syn-update-value">Up to date</span>
+                {d.dsm_version && (
+                  <span className="syn-update-current muted">{d.dsm_version}</span>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+
       </div>
     </>
   )

--- a/internal/infra/synology.go
+++ b/internal/infra/synology.go
@@ -141,12 +141,13 @@ func (e *synoCallErr) Error() string { return fmt.Sprintf("API call failed (erro
 
 // SYNO.Core.System method=info — system identity
 // DSM returns up_time as a JSON string (e.g. "86400"), not a number.
+// Field names match actual DSM 6/7 response keys (hostname, sys_temp).
 type synoCoreSystemInfo struct {
 	Model       string `json:"model"`
 	FirmwareVer string `json:"firmware_ver"`
-	HostName    string `json:"host_name"`
+	HostName    string `json:"hostname"`   // DSM uses "hostname", not "host_name"
 	UpTime      string `json:"up_time"`    // seconds, returned as string by DSM
-	Temperature int    `json:"temperature"` // Celsius
+	Temperature int    `json:"sys_temp"`   // DSM uses "sys_temp", not "temperature"
 }
 
 // SYNO.Core.System.Utilization method=get — CPU and memory utilization
@@ -626,7 +627,8 @@ func (p *SynologyPoller) fetchDisks(ctx context.Context, store *repo.Store, meta
 			Status:       disk.Status,
 		})
 
-		if disk.Status != "normal" {
+		// Only "critical" disk status degrades the component; "warning" is advisory.
+		if disk.Status == "critical" {
 			degraded = true
 		}
 
@@ -659,10 +661,10 @@ func (p *SynologyPoller) fetchDisks(ctx context.Context, store *repo.Store, meta
 			}
 		}
 
-		// Temperature threshold events: fire once when crossing >50°C, reset on cool-down.
+		// Temperature threshold events: fire once when crossing >55°C, reset on cool-down.
 		tempFlaggedI, _ := p.diskTempFlagged.Load(slotKey)
 		wasFlagged, _ := tempFlaggedI.(bool)
-		isFlagged := disk.Temp > 50
+		isFlagged := disk.Temp > 55
 		if isFlagged && !wasFlagged {
 			p.diskTempFlagged.Store(slotKey, true)
 			rawPayload, _ := json.Marshal(disk)

--- a/internal/infra/synology_test.go
+++ b/internal/infra/synology_test.go
@@ -63,8 +63,8 @@ func createSynologyTestComponent(t *testing.T, store *repo.Store, id string) {
 	}
 }
 
-// synologyFakeServer handles DSM API requests matching the new API structure:
-// - Login/Logout: POST /webapi/entry.cgi with api=SYNO.API.Auth
+// synologyFakeServer handles DSM API requests:
+// - Login/Logout: GET  /webapi/auth.cgi  api=SYNO.API.Auth
 // - System info:  GET  /webapi/entry.cgi api=SYNO.Core.System method=info
 // - Utilization:  GET  /webapi/entry.cgi api=SYNO.Core.System.Utilization method=get
 // - Volumes:      GET  /webapi/entry.cgi api=SYNO.Core.System method=info type=storage
@@ -329,9 +329,10 @@ func TestSynologyPoller_Poll_DiskWarningFiresWarnEvent(t *testing.T) {
 		t.Fatalf("Poll: %v", err)
 	}
 
+	// A "warning" disk no longer degrades the component — only "critical" does.
 	comp, _ := store.InfraComponents.Get(ctx, compID)
-	if comp.LastStatus != "degraded" {
-		t.Errorf("last_status: got %q, want \"degraded\"", comp.LastStatus)
+	if comp.LastStatus != "online" {
+		t.Errorf("last_status: got %q, want \"online\" (warning disk is advisory, not degrading)", comp.LastStatus)
 	}
 
 	events, total, err := store.Events.List(ctx, repo.ListFilter{Limit: 50})


### PR DESCRIPTION
## What
Several fixes to the Synology DSM integration based on runtime testing.

## Why / How

**UI — style alignment with other host pages**
The Synology detail page used a custom card/divider layout instead of the flat `icd-section` blocks used by every other host page. Replaced all structural `syn-*` classes with `icd-*` equivalents and imported `InfraComponentDetail.css`. Stripped `SynologyDetail.css` down to only Synology-specific content styles.

**Backend — DSM API field name corrections**
The `synoCoreSystemInfo` struct had wrong JSON field names for the actual DSM 6/7 API response:
- `"host_name"` → `"hostname"` (fixes Hostname not populating)
- `"temperature"` → `"sys_temp"` (fixes System Temp not populating)

**Backend — disk degraded threshold**
- Raised temp event threshold from 50°C → 55°C (50°C is within normal HDD range)
- A disk in `"warning"` status no longer marks the whole component as `"degraded"` — only `"critical"` does. Warning is advisory; the component stays online.

## Test coverage
`go test ./internal/infra/...` — all tests pass; updated `TestSynologyPoller_Poll_DiskWarningFiresWarnEvent` to expect `online` status (not `degraded`) when a disk is in warning state.

## Closes
Follow-up to #145