### PR TITLE
fix: dashboard empty state caused by stale /hosts/physical route

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -9,8 +9,8 @@ import { SSLRow } from '../components/SSLRow'
 import { EventRow } from '../components/EventRow'
 import { HostWidget } from '../components/HostWidget'
 import type { HostData } from '../components/HostWidget'
-import { dashboard as dashboardApi, events as eventsApi, topology as topoApi } from '../api/client'
-import type { DashboardSummaryResponse, Event, PhysicalHost } from '../api/types'
+import { dashboard as dashboardApi, events as eventsApi, infrastructure as infraApi } from '../api/client'
+import type { DashboardSummaryResponse, Event, InfrastructureComponent } from '../api/types'
 import './Dashboard.css'
 
 type TimeFilter = 'day' | 'week' | 'month'
@@ -21,7 +21,7 @@ export function Dashboard() {
   const [timeFilter, setTimeFilter] = useState<TimeFilter>('week')
   const [data, setData] = useState<DashboardSummaryResponse | null>(null)
   const [recentEvents, setRecentEvents] = useState<Event[]>([])
-  const [physicalHosts, setPhysicalHosts] = useState<PhysicalHost[]>([])
+  const [physicalHosts, setPhysicalHosts] = useState<InfrastructureComponent[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -29,7 +29,7 @@ export function Dashboard() {
     Promise.all([
       dashboardApi.summary(timeFilter),
       eventsApi.list({ limit: 5 }),
-      topoApi.physicalHosts.list(),
+      infraApi.list().catch(() => ({ data: [], total: 0 })),
     ])
       .then(([summary, evts, hosts]) => {
         setData(summary)
@@ -78,7 +78,7 @@ export function Dashboard() {
   }
 
   // ── Empty state ───────────────────────────────────────────────────────────
-  if (!data || data.apps.length === 0) {
+  if (!data || (data.apps.length === 0 && data.checks.length === 0 && physicalHosts.length === 0)) {
     return (
       <>
         <Topbar title="Dashboard" timeFilter={timeFilter} onTimeFilter={setTimeFilter} />


### PR DESCRIPTION
## What
Fix dashboard always showing the empty state ("No apps configured yet") even when apps and infrastructure are configured.

## Why
Closes #149 (if tracked) — the root cause was a stale API call in `Dashboard.tsx` that hit `GET /hosts/physical`, a route removed when physical hosts were migrated to `InfraComponentHandler` at `/api/v1/infrastructure`. Because `Promise.all` rejects if any promise rejects, the 404 from `/hosts/physical` caused the entire fetch to fail silently (`.catch(console.error)`), leaving `data = null` and permanently triggering the empty state guard.

A secondary issue: the empty state condition only checked `data.apps.length === 0`, meaning users with only infrastructure or monitor checks configured would also always see the empty state.

## How
- Replace `topoApi.physicalHosts.list()` (→ `GET /hosts/physical`, 404) with `infraApi.list()` (→ `GET /infrastructure`, 200)
- Wrap the infra fetch in its own `.catch(() => ({ data: [], total: 0 }))` so an infra failure cannot kill the whole dashboard load
- Update `physicalHosts` state type from `PhysicalHost[]` to `InfrastructureComponent[]` (same shape, correct type)
- Widen the empty state guard: only show when apps **and** checks **and** infra are all empty

Note: `Topology.tsx` has the same stale `physicalHosts`/`virtualHosts` route problem but requires a larger page-level refactor — tracked separately.

## Test coverage
- TypeScript build passes with zero errors (`npm run build`)
- Verified in browser preview: dashboard renders apps, summary bar, recent events, monitor checks, and infrastructure cards with real data from the backend
- Backend logs confirm `GET /api/v1/infrastructure → 200` replacing the former `GET /api/v1/hosts/physical → 404`

## Closes
Closes #149