### PR TITLE
refactor: wire all internal NORA activity to the event pipeline

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -87,6 +87,9 @@ func main() {
 		webPushSubscriptionRepo,
 	)
 
+	// Startup event — written once so users can see when NORA last started.
+	jobs.EmitStartupEvent(context.Background(), store)
+
 	// Push notification sender
 	pushSender := push.NewSender(cfg, store)
 

--- a/internal/docker/watcher.go
+++ b/internal/docker/watcher.go
@@ -121,6 +121,7 @@ func (w *Watcher) handleEvent(ctx context.Context, msg events.Message) error {
 	}
 
 	containerName := msg.Actor.Attributes["name"]
+	image := msg.Actor.Attributes["image"]
 	exitCodeStr := msg.Actor.Attributes["exitCode"]
 
 	severity, displayText := severityAndText(action, containerName, exitCodeStr)
@@ -133,7 +134,6 @@ func (w *Watcher) handleEvent(ctx context.Context, msg events.Message) error {
 
 	// Notify the discovery worker so it can upsert into discovered_containers.
 	if w.discoveryHook != nil {
-		image := msg.Actor.Attributes["image"]
 		status := containerStatusFromAction(action)
 		cid := msg.Actor.ID
 		go w.discoveryHook(ctx, cid, containerName, image, status)
@@ -154,13 +154,13 @@ func (w *Watcher) handleEvent(ctx context.Context, msg events.Message) error {
 	}
 
 	fields := fmt.Sprintf(
-		`{"source_type":"docker_container","container_name":%s,"action":%s}`,
-		jsonStr(containerName), jsonStr(action),
+		`{"source_type":"docker_container","container_name":%s,"image":%s,"action":%s}`,
+		jsonStr(containerName), jsonStr(image), jsonStr(action),
 	)
 	if exitCodeStr != "" {
 		fields = fmt.Sprintf(
-			`{"source_type":"docker_container","container_name":%s,"action":%s,"exit_code":%s}`,
-			jsonStr(containerName), jsonStr(action), jsonStr(exitCodeStr),
+			`{"source_type":"docker_container","container_name":%s,"image":%s,"action":%s,"exit_code":%s}`,
+			jsonStr(containerName), jsonStr(image), jsonStr(action), jsonStr(exitCodeStr),
 		)
 	}
 

--- a/internal/jobs/infra_events.go
+++ b/internal/jobs/infra_events.go
@@ -11,42 +11,42 @@ import (
 	"github.com/google/uuid"
 )
 
-// emitInfraEvent writes a single informational event to the event log for an
+// emitInfraEvent writes a diagnostic event to the event log for an
 // infrastructure poll cycle. source is the poller name (e.g. "proxmox"),
 // trigger is "scheduled" or "manual", status is "ok" or "failed", and detail
 // carries an optional extra message (error text on failure, "" on success).
 //
-// source_type is set to "system" for all infra poll events. Future tasks will
-// update pollers to emit more specific source_type values (e.g. "physical_host").
+// Level is "debug" on success and "error" on failure.
+// source_type is "physical_host" for all infra poll events.
 func emitInfraEvent(
 	ctx context.Context,
 	store *repo.Store,
 	componentID, componentName, source, trigger, status, detail string,
 ) {
-	level := "info"
+	level := "debug"
 	var title string
 
 	if status == "ok" {
-		title = fmt.Sprintf("[%s] %s poll completed (%s)", source, componentName, trigger)
+		title = fmt.Sprintf("%s poll completed — %s", source, componentName)
 	} else {
-		level = "warn"
+		level = "error"
 		if detail != "" {
-			title = fmt.Sprintf("[%s] %s poll failed (%s): %s", source, componentName, trigger, detail)
+			title = fmt.Sprintf("%s poll failed — %s: %s", source, componentName, detail)
 		} else {
-			title = fmt.Sprintf("[%s] %s poll failed (%s)", source, componentName, trigger)
+			title = fmt.Sprintf("%s poll failed — %s", source, componentName)
 		}
 	}
 
 	payload := fmt.Sprintf(
-		`{"source":%q,"component_id":%q,"component_name":%q,"trigger":%q,"poll_status":%q}`,
-		source, componentID, componentName, trigger, status,
+		`{"source":%q,"component_id":%q,"component_name":%q,"trigger":%q,"poll_status":%q,"error":%q}`,
+		source, componentID, componentName, trigger, status, detail,
 	)
 
 	event := &models.Event{
 		ID:         uuid.New().String(),
 		Level:      level,
 		SourceName: componentName,
-		SourceType: "system",
+		SourceType: "physical_host",
 		SourceID:   componentID,
 		Title:      title,
 		Payload:    payload,

--- a/internal/jobs/startup.go
+++ b/internal/jobs/startup.go
@@ -1,0 +1,29 @@
+package jobs
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+// EmitStartupEvent writes a single info event to the event log recording that
+// NORA started successfully. source_type is "system", source_id is NULL.
+func EmitStartupEvent(ctx context.Context, store *repo.Store) {
+	ev := &models.Event{
+		ID:         uuid.New().String(),
+		Level:      "info",
+		SourceName: "NORA System",
+		SourceType: "system",
+		SourceID:   "",
+		Title:      "NORA started",
+		Payload:    `{"event":"startup"}`,
+		CreatedAt:  time.Now().UTC(),
+	}
+	if err := store.Events.Create(ctx, ev); err != nil {
+		log.Printf("startup event: %v", err)
+	}
+}

--- a/internal/jobs/traefik_expanded.go
+++ b/internal/jobs/traefik_expanded.go
@@ -216,7 +216,7 @@ func fireTraefikEvent(ctx context.Context, store *repo.Store, c models.Infrastru
 		ID:         uuid.New().String(),
 		Level:      severity,
 		SourceName: c.Name,
-		SourceType: "system",
+		SourceType: "physical_host",
 		SourceID:   c.ID,
 		Title:      text,
 		Payload:    fields,

--- a/internal/monitor/ping.go
+++ b/internal/monitor/ping.go
@@ -62,6 +62,7 @@ func (p *PingChecker) Run(ctx context.Context, check *models.MonitorCheck) error
 	var detailsBytes []byte
 	if downCount == attempts {
 		newStatus = "down"
+		latencyMs = 0
 		detailsBytes, _ = json.Marshal(pingDetails{})
 	} else {
 		detailsBytes, _ = json.Marshal(pingDetails{LatencyMs: latencyMs})
@@ -71,7 +72,7 @@ func (p *PingChecker) Run(ctx context.Context, check *models.MonitorCheck) error
 	// checks not linked to an app still generate events queryable by check_id.
 	prevStatus := check.LastStatus
 	if prevStatus != "" && prevStatus != newStatus {
-		if err := p.createStatusEvent(ctx, check, newStatus, now); err != nil {
+		if err := p.createStatusEvent(ctx, check, newStatus, latencyMs, now); err != nil {
 			log.Printf("ping checker: create event for check %s: %v", check.ID, err)
 		}
 	}
@@ -83,7 +84,7 @@ func (p *PingChecker) Run(ctx context.Context, check *models.MonitorCheck) error
 }
 
 // createStatusEvent persists a down or recovery event for a check.
-func (p *PingChecker) createStatusEvent(ctx context.Context, check *models.MonitorCheck, newStatus string, now time.Time) error {
+func (p *PingChecker) createStatusEvent(ctx context.Context, check *models.MonitorCheck, newStatus string, latencyMs int64, now time.Time) error {
 	var severity, displayText string
 	if newStatus == "down" {
 		severity = "error"
@@ -93,6 +94,9 @@ func (p *PingChecker) createStatusEvent(ctx context.Context, check *models.Monit
 		displayText = fmt.Sprintf("Ping restored — %s (%s)", check.Name, check.Target)
 	}
 
+	payload := fmt.Sprintf(`{"type":"ping","target":%q,"latency_ms":%d}`,
+		check.Target, latencyMs)
+
 	event := &models.Event{
 		ID:         uuid.New().String(),
 		Level:      severity,
@@ -100,7 +104,7 @@ func (p *PingChecker) createStatusEvent(ctx context.Context, check *models.Monit
 		SourceType: "monitor_check",
 		SourceID:   check.ID,
 		Title:      displayText,
-		Payload:    `{"type":"ping"}`,
+		Payload:    payload,
 		CreatedAt:  now,
 	}
 	return p.store.Events.Create(ctx, event)

--- a/internal/monitor/ssl.go
+++ b/internal/monitor/ssl.go
@@ -77,9 +77,9 @@ func (s *SSLChecker) runTraefikSSL(ctx context.Context, check *models.MonitorChe
 
 	daysRemaining := int(time.Until(*cert.ExpiresAt).Hours() / 24)
 
-	var issuerStr, subjectStr string
+	var certIssuer, subjectStr string
 	if cert.Issuer != nil {
-		issuerStr = *cert.Issuer
+		certIssuer = *cert.Issuer
 	}
 	subjectStr = cert.Domain
 	expiresAt := *cert.ExpiresAt
@@ -87,7 +87,7 @@ func (s *SSLChecker) runTraefikSSL(ctx context.Context, check *models.MonitorChe
 	details, _ := json.Marshal(sslDetails{
 		DaysRemaining: &daysRemaining,
 		ExpiresAt:     &expiresAt,
-		Issuer:        &issuerStr,
+		Issuer:        &certIssuer,
 		Subject:       &subjectStr,
 	})
 
@@ -103,7 +103,7 @@ func (s *SSLChecker) runTraefikSSL(ctx context.Context, check *models.MonitorChe
 
 	prevStatus := check.LastStatus
 	if prevStatus != "" && prevStatus != newStatus {
-		if evErr := s.createStatusEvent(ctx, check, newStatus, domain, daysRemaining, now); evErr != nil {
+		if evErr := s.createStatusEvent(ctx, check, newStatus, domain, daysRemaining, &expiresAt, certIssuer, now); evErr != nil {
 			log.Printf("ssl checker (traefik): create event for check %s: %v", check.ID, evErr)
 		}
 	}
@@ -142,7 +142,7 @@ func (s *SSLChecker) runStandaloneSSL(ctx context.Context, check *models.Monitor
 	newStatus := result.Status
 
 	if prevStatus != "" && prevStatus != newStatus {
-		if evErr := s.createStatusEvent(ctx, check, newStatus, domain, days, now); evErr != nil {
+		if evErr := s.createStatusEvent(ctx, check, newStatus, domain, days, parsed.ExpiresAt, issuerStr(parsed.Issuer), now); evErr != nil {
 			log.Printf("ssl checker: create event for check %s: %v", check.ID, evErr)
 		}
 	}
@@ -165,12 +165,22 @@ func extractDomain(target string) string {
 	return d
 }
 
+// issuerStr safely dereferences a *string, returning "" if nil.
+func issuerStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
 // createStatusEvent persists a status-change event for an SSL check.
 func (s *SSLChecker) createStatusEvent(
 	ctx context.Context,
 	check *models.MonitorCheck,
 	newStatus, domain string,
 	daysRemaining int,
+	expiresAt *time.Time,
+	issuer string,
 	now time.Time,
 ) error {
 	var severity, displayText string
@@ -189,6 +199,15 @@ func (s *SSLChecker) createStatusEvent(
 		displayText = fmt.Sprintf("SSL renewed — %s: %d days remaining", domain, daysRemaining)
 	}
 
+	expiresStr := ""
+	if expiresAt != nil {
+		expiresStr = expiresAt.UTC().Format(time.RFC3339)
+	}
+	payload := fmt.Sprintf(
+		`{"type":"ssl","domain":%q,"days_remaining":%d,"expires_at":%q,"issuer":%q}`,
+		domain, daysRemaining, expiresStr, issuer,
+	)
+
 	event := &models.Event{
 		ID:         uuid.New().String(),
 		Level:      severity,
@@ -196,7 +215,7 @@ func (s *SSLChecker) createStatusEvent(
 		SourceType: "monitor_check",
 		SourceID:   check.ID,
 		Title:      displayText,
-		Payload:    `{"type":"ssl"}`,
+		Payload:    payload,
 		CreatedAt:  now,
 	}
 	return s.store.Events.Create(ctx, event)

--- a/internal/monitor/url.go
+++ b/internal/monitor/url.go
@@ -115,7 +115,7 @@ func (u *URLChecker) Run(ctx context.Context, check *models.MonitorCheck) error 
 	// check is linked to an app.
 	prevStatus := check.LastStatus
 	if prevStatus != "" && prevStatus != newStatus {
-		if evErr := u.createStatusEvent(ctx, check, newStatus, resp.StatusCode, expected, now); evErr != nil {
+		if evErr := u.createStatusEvent(ctx, check, newStatus, resp.StatusCode, expected, latencyMs, now); evErr != nil {
 			log.Printf("url checker: create event for check %s: %v", check.ID, evErr)
 		}
 	}
@@ -143,7 +143,7 @@ func (u *URLChecker) recordError(ctx context.Context, check *models.MonitorCheck
 
 	prevStatus := check.LastStatus
 	if prevStatus != "" && prevStatus != newStatus {
-		if evErr := u.createStatusEvent(ctx, check, newStatus, 0, expected, now); evErr != nil {
+		if evErr := u.createStatusEvent(ctx, check, newStatus, 0, expected, 0, now); evErr != nil {
 			log.Printf("url checker: create event for check %s: %v", check.ID, evErr)
 		}
 	}
@@ -160,6 +160,7 @@ func (u *URLChecker) createStatusEvent(
 	check *models.MonitorCheck,
 	newStatus string,
 	gotStatus, expectedStatus int,
+	latencyMs int64,
 	now time.Time,
 ) error {
 	var severity, displayText string
@@ -172,6 +173,11 @@ func (u *URLChecker) createStatusEvent(
 		displayText = fmt.Sprintf("URL check restored — %s", check.Name)
 	}
 
+	payload := fmt.Sprintf(
+		`{"type":"url","url":%q,"status_code":%d,"expected_status":%d,"latency_ms":%d}`,
+		check.Target, gotStatus, expectedStatus, latencyMs,
+	)
+
 	event := &models.Event{
 		ID:         uuid.New().String(),
 		Level:      severity,
@@ -179,7 +185,7 @@ func (u *URLChecker) createStatusEvent(
 		SourceType: "monitor_check",
 		SourceID:   check.ID,
 		Title:      displayText,
-		Payload:    `{"type":"url"}`,
+		Payload:    payload,
 		CreatedAt:  now,
 	}
 	return u.store.Events.Create(ctx, event)


### PR DESCRIPTION
## What
Wires every internal NORA code path to emit structured events into the unified events table introduced in REFACTOR-01.

## Why
Closes REFACTOR-02. The event stream previously only reflected inbound webhook payloads. Users had no visibility into poller failures, container restarts, monitor check state changes, or when NORA itself started.

## How

**Level and source_type corrections across all internal event writers:**
- `emitInfraEvent` (Proxmox, Synology, SNMP, Traefik pollers): level changed from `info`/`warn` to `debug`/`error`; `source_type` changed from `system` to `physical_host`; error detail now included in payload
- `fireTraefikEvent`: `source_type` changed from `system` to `physical_host`

**Richer payloads for monitor check events:**
- Ping: payload now includes `target` and `latency_ms`
- URL: payload now includes `url`, `status_code`, `expected_status`, `latency_ms`
- SSL: payload now includes `domain`, `days_remaining`, `expires_at`, `issuer` (works for both standalone TLS dial and Traefik cert cache paths)

**Docker watcher payload:**
- `image` field added alongside `container_name` and `action`
- Extracted once and reused for the discovery hook (minor cleanup)

**Startup event:**
- `internal/jobs/startup.go` — `EmitStartupEvent` writes a single `info` event with `source_type=system`, `source_name=NORA System`, `source_id=NULL`, `title=NORA started`
- Called from `main.go` immediately after the store is ready

## Test coverage
- `go build ./...` — passes
- `go test ./...` — all packages pass; no test changes required (existing monitor checker tests verify level and source_type which are unchanged)

## Closes
Closes REFACTOR-02