### PR TITLE
feat: reusable EventFeed component for all detail pages (REFACTOR-04)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -151,6 +151,7 @@ export const events = {
   list: (filter?: EventFilter) => {
     const params = new URLSearchParams()
     if (filter?.source_type) params.set('source_type', filter.source_type)
+    if (filter?.source_id) params.set('source_id', filter.source_id)
     if (filter?.search) params.set('search', filter.search)
     if (filter?.level) params.set('level', filter.level)
     if (filter?.from) params.set('since', filter.from)

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -78,7 +78,8 @@ export interface Event {
 export type EventSort = 'newest' | 'oldest' | 'level_desc' | 'level_asc'
 
 export interface EventFilter {
-  source_type?: 'app' | 'infra' | 'check'
+  source_type?: string
+  source_id?: string
   search?: string
   level?: Severity
   from?: string

--- a/frontend/src/components/EventFeed.css
+++ b/frontend/src/components/EventFeed.css
@@ -1,0 +1,58 @@
+/* ── EventFeed component styles ──────────────────────────────────────────────
+   Self-contained panel rendered at the bottom of any detail page.
+   ──────────────────────────────────────────────────────────────────────────── */
+
+.event-feed {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  margin-top: 16px;
+}
+
+.event-feed-header {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.event-feed-count {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+}
+
+.event-feed-empty {
+  padding: 40px;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text3);
+}
+
+.event-feed-load-more {
+  display: block;
+  margin: 10px;
+  width: calc(100% - 20px);
+  padding: 10px;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text2);
+  font-family: var(--mono);
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.event-feed-load-more:hover:not(:disabled) {
+  border-color: var(--border2);
+  color: var(--text);
+}
+
+.event-feed-load-more:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/EventFeed.tsx
+++ b/frontend/src/components/EventFeed.tsx
@@ -1,0 +1,97 @@
+import { useState, useEffect } from 'react'
+import { useAutoRefresh } from '../context/AutoRefreshContext'
+import { events as eventsApi } from '../api/client'
+import { EventRow } from './EventRow'
+import type { Event } from '../api/types'
+import './EventFeed.css'
+import './EventRow.css'
+
+interface Props {
+  /** Optional source_type filter (e.g. "app", "docker_engine", "monitor_check"). */
+  sourceType?: string
+  /** The entity ID to filter events for. */
+  sourceId: string
+  /** Section title. Defaults to "RECENT EVENTS". */
+  title?: string
+}
+
+const DEFAULT_LIMIT = 50
+
+export function EventFeed({ sourceType, sourceId, title = 'RECENT EVENTS' }: Props) {
+  const { tick } = useAutoRefresh()
+  const [eventList, setEventList] = useState<Event[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [loadingMore, setLoadingMore] = useState(false)
+
+  function fetchEvents(offset: number, append: boolean) {
+    if (offset === 0) setLoading(true)
+    else setLoadingMore(true)
+    eventsApi
+      .list({
+        ...(sourceType ? { source_type: sourceType } : {}),
+        source_id: sourceId,
+        limit: DEFAULT_LIMIT,
+        offset,
+        sort: 'newest',
+      })
+      .then(res => {
+        setEventList(prev => append ? [...prev, ...res.data] : res.data)
+        setTotal(res.total)
+        setError(null)
+      })
+      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load events'))
+      .finally(() => { setLoading(false); setLoadingMore(false) })
+  }
+
+  useEffect(() => {
+    fetchEvents(0, false)
+  }, [sourceType, sourceId, tick]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const hasMore = eventList.length < total
+
+  return (
+    <div className="event-feed">
+      <div className="event-feed-header">
+        <span className="section-title">{title}</span>
+        {!loading && !error && total > 0 && (
+          <span className="event-feed-count">
+            {total} event{total !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+
+      {loading && <div className="event-feed-empty">Loading…</div>}
+      {error && <div className="event-feed-empty">Error: {error}</div>}
+      {!loading && !error && eventList.length === 0 && (
+        <div className="event-feed-empty">No events yet</div>
+      )}
+
+      {!loading && !error && eventList.length > 0 && (
+        <>
+          <div className="event-row events-col-header">
+            <span>Time</span>
+            <span />
+            <span>Source</span>
+            <span>Event</span>
+            <span>Severity</span>
+          </div>
+          {eventList.map(ev => (
+            <EventRow key={ev.id} event={ev} />
+          ))}
+        </>
+      )}
+
+      {!loading && !error && hasMore && (
+        <button
+          className="event-feed-load-more"
+          onClick={() => fetchEvents(eventList.length, true)}
+          disabled={loadingMore}
+        >
+          {loadingMore ? 'Loading…' : `Load more (${total - eventList.length} remaining)`}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/AppDetail.tsx
+++ b/frontend/src/pages/AppDetail.tsx
@@ -2,86 +2,13 @@ import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { Topbar } from '../components/Topbar'
+import { EventFeed } from '../components/EventFeed'
 import { apps as appsApi, dashboard as dashboardApi, appTemplates as templatesApi } from '../api/client'
-import type { App, AppSummary, AppTemplate, Event, Severity } from '../api/types'
-import { formatEventTime } from '../utils/formatTime'
+import type { App, AppSummary, AppTemplate } from '../api/types'
 import '../styles/Modal.css'
 import './AppDetail.css'
 
 type TimeFilter = 'day' | 'week' | 'month'
-
-// ── JSON Viewer ───────────────────────────────────────────────────────────────
-
-function JsonValue({ value, depth }: { value: unknown; depth: number }) {
-  const [open, setOpen] = useState(depth < 2)
-  const indent = '  '.repeat(depth)
-
-  if (value === null) return <span className="json-null">null</span>
-  if (typeof value === 'boolean') return <span className="json-bool">{String(value)}</span>
-  if (typeof value === 'number') return <span className="json-num">{value}</span>
-  if (typeof value === 'string') return <span className="json-str">"{value}"</span>
-
-  if (Array.isArray(value)) {
-    if (value.length === 0) return <span className="json-punct">[]</span>
-    return (
-      <span>
-        <span className="json-punct">[</span>
-        {open ? (
-          <>
-            {value.map((item, i) => (
-              <div key={i} style={{ paddingLeft: '16px' }}>
-                <JsonValue value={item} depth={depth + 1} />
-                {i < value.length - 1 && <span className="json-punct">,</span>}
-              </div>
-            ))}
-            <div>{indent}<span className="json-punct">]</span></div>
-          </>
-        ) : (
-          <span className="json-collapse" onClick={e => { e.stopPropagation(); setOpen(true) }}>
-            {value.length} items…
-          </span>
-        )}
-      </span>
-    )
-  }
-
-  if (typeof value === 'object') {
-    const entries = Object.entries(value as Record<string, unknown>)
-    if (entries.length === 0) return <span className="json-punct">{'{}'}</span>
-    return (
-      <span>
-        <span className="json-punct">{'{'}</span>
-        {open ? (
-          <>
-            {entries.map(([k, v], i) => (
-              <div key={k} style={{ paddingLeft: '16px' }}>
-                <span className="json-key">"{k}"</span>
-                <span className="json-punct">: </span>
-                <JsonValue value={v} depth={depth + 1} />
-                {i < entries.length - 1 && <span className="json-punct">,</span>}
-              </div>
-            ))}
-            <div>{indent}<span className="json-punct">{'}'}</span></div>
-          </>
-        ) : (
-          <span className="json-collapse" onClick={e => { e.stopPropagation(); setOpen(true) }}>
-            {entries.length} keys…
-          </span>
-        )}
-      </span>
-    )
-  }
-
-  return <span>{String(value)}</span>
-}
-
-function JsonViewer({ data }: { data: Record<string, unknown> }) {
-  return (
-    <div className="json-viewer">
-      <JsonValue value={data} depth={0} />
-    </div>
-  )
-}
 
 // ── Sparkline ─────────────────────────────────────────────────────────────────
 
@@ -100,65 +27,6 @@ function Sparkline({ data, color = 'var(--accent)' }: { data: number[]; color?: 
       <polyline points={pts} fill="none" stroke={color} strokeWidth="1.5" opacity="0.8" />
       <polyline points={closed} fill={color} stroke="none" opacity="0.08" />
     </svg>
-  )
-}
-
-// ── Expanded event detail ─────────────────────────────────────────────────────
-
-function EventDetail({ event, appName }: { event: Event; appName: string }) {
-  const createdDate = event.created_at ? new Date(event.created_at) : null
-  const received = createdDate && !isNaN(createdDate.getTime())
-    ? createdDate.toLocaleString('en-US', {
-        year: 'numeric', month: '2-digit', day: '2-digit',
-        hour: 'numeric', minute: '2-digit', second: '2-digit', hour12: false,
-      })
-    : '—'
-  return (
-    <div className="detail-event-expand">
-      <div className="detail-expand-meta">
-        <div className="detail-meta-row">
-          <span className="detail-meta-label">Severity</span>
-          <span className={`detail-meta-val sev-${event.level}`}>{event.level}</span>
-        </div>
-        <div className="detail-meta-row">
-          <span className="detail-meta-label">App</span>
-          <span className="detail-meta-val">{appName}</span>
-        </div>
-        <div className="detail-meta-row">
-          <span className="detail-meta-label">Received</span>
-          <span className="detail-meta-val">{received}</span>
-        </div>
-      </div>
-      <div className="detail-expand-payload-label">Raw Payload</div>
-      {event.payload && Object.keys(event.payload).length > 0 ? (
-        <JsonViewer data={event.payload} />
-      ) : (
-        <div className="json-viewer json-empty">No payload</div>
-      )}
-      <div className="detail-expand-actions">
-        <button className="detail-rule-btn" disabled title="Coming in v2">
-          Save as notification rule
-        </button>
-      </div>
-    </div>
-  )
-}
-
-// ── Event row ─────────────────────────────────────────────────────────────────
-
-function DetailEventRow({ event, appName, expanded, onToggle }: {
-  event: Event; appName: string; expanded: boolean; onToggle: () => void
-}) {
-  return (
-    <div className={`event-row-wrapper${expanded ? ' expanded' : ''}`}>
-      <div className="event-row" onClick={onToggle}>
-        <div className="event-time">{formatEventTime(event.created_at)}</div>
-        <div className={`severity-badge ${event.level}`} />
-        <div className="event-text">{event.title}</div>
-        <div className={`event-sev-label ${event.level}`}>{event.level}</div>
-      </div>
-      {expanded && <EventDetail event={event} appName={appName} />}
-    </div>
   )
 }
 
@@ -444,25 +312,15 @@ function AppSettingsModal({ app, onClose, onUpdated, onDeleted }: AppSettingsMod
 
 // ── AppDetail ─────────────────────────────────────────────────────────────────
 
-const SEVERITIES: Array<Severity | 'all'> = ['all', 'info', 'warn', 'error', 'critical']
-const PAGE_SIZE = 50
-
 export function AppDetail() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const { tick } = useAutoRefresh()
 
   const [timeFilter, setTimeFilter] = useState<TimeFilter>('week')
-  const [severityFilter, setSeverityFilter] = useState<Severity | 'all'>('all')
 
   const [app, setApp] = useState<App | null>(null)
   const [appSummary, setAppSummary] = useState<AppSummary | null>(null)
-  const [events, setEvents] = useState<Event[]>([])
-  const [total, setTotal] = useState(0)
-  const [offset, setOffset] = useState(0)
-  const [loading, setLoading] = useState(true)
-  const [loadingMore, setLoadingMore] = useState(false)
-  const [expandedId, setExpandedId] = useState<string | null>(null)
   const [showSettings, setShowSettings] = useState(false)
 
   const appId = id ?? ''
@@ -482,30 +340,10 @@ export function AppDetail() {
   }, [appId, timeFilter, tick])
 
   useEffect(() => {
-    if (!appId) return
-    setLoading(true); setOffset(0); setEvents([]); setExpandedId(null)
-    const filter = { limit: PAGE_SIZE, offset: 0, ...(severityFilter !== 'all' ? { level: severityFilter } : {}) }
-    appsApi.events(appId, filter)
-      .then(res => { setEvents(res.data); setTotal(res.total) })
-      .catch(console.error)
-      .finally(() => setLoading(false))
-  }, [appId, severityFilter, tick])
-
-  useEffect(() => {
     if (!id) navigate('/apps')
   }, [id, navigate])
 
   if (!id) return null
-
-  function handleLoadMore() {
-    const nextOffset = offset + PAGE_SIZE
-    setLoadingMore(true)
-    const filter = { limit: PAGE_SIZE, offset: nextOffset, ...(severityFilter !== 'all' ? { level: severityFilter } : {}) }
-    appsApi.events(appId, filter)
-      .then(res => { setEvents(prev => [...prev, ...res.data]); setOffset(nextOffset) })
-      .catch(console.error)
-      .finally(() => setLoadingMore(false))
-  }
 
   const appName = app?.name ?? appId
   const baseUrl = app?.config?.base_url as string | undefined
@@ -516,8 +354,6 @@ export function AppDetail() {
         month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true,
       })
     : null
-  const hasMore = events.length < total
-
   return (
     <>
       <Topbar title={appName} status={topbarStatus} timeFilter={timeFilter} onTimeFilter={setTimeFilter} />
@@ -578,50 +414,7 @@ export function AppDetail() {
         )}
 
         {/* ── Events section ── */}
-        <div className="detail-events-section">
-          <div className="section-header">
-            <div className="section-title">Events</div>
-            <div className="detail-sev-pills">
-              {SEVERITIES.map(s => (
-                <button
-                  key={s}
-                  className={`detail-sev-pill sev-pill-${s}${severityFilter === s ? ' active' : ''}`}
-                  onClick={() => setSeverityFilter(s)}
-                >
-                  {s === 'all' ? 'All' : s.charAt(0).toUpperCase() + s.slice(1)}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {loading ? (
-            <div className="detail-events-loading">
-              {[0, 1, 2, 3].map(i => (
-                <div key={i} className="skeleton" style={{ height: 40, marginBottom: 4 }} />
-              ))}
-            </div>
-          ) : events.length === 0 ? (
-            <div className="detail-events-empty">No events found</div>
-          ) : (
-            <div className="events-panel">
-              {events.map(event => (
-                <DetailEventRow
-                  key={event.id}
-                  event={event}
-                  appName={appName}
-                  expanded={expandedId === event.id}
-                  onToggle={() => setExpandedId(prev => prev === event.id ? null : event.id)}
-                />
-              ))}
-            </div>
-          )}
-
-          {!loading && hasMore && (
-            <button className="detail-load-more" onClick={handleLoadMore} disabled={loadingMore}>
-              {loadingMore ? 'Loading…' : `Load more (${total - events.length} remaining)`}
-            </button>
-          )}
-        </div>
+        <EventFeed sourceType="app" sourceId={appId} />
 
       </div>
 

--- a/frontend/src/pages/CheckDetail.tsx
+++ b/frontend/src/pages/CheckDetail.tsx
@@ -3,7 +3,8 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { Topbar } from '../components/Topbar'
 import { checks as checksApi, integrations as integrationsApi } from '../api/client'
-import type { MonitorCheck, Event, InfraIntegration, TraefikCert } from '../api/types'
+import { EventFeed } from '../components/EventFeed'
+import type { MonitorCheck, InfraIntegration, TraefikCert } from '../api/types'
 import {
   CheckForm,
   type FormFields,
@@ -17,10 +18,6 @@ import '../styles/Modal.css'
 import './CheckDetail.css'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function severityBadge(severity: string) {
-  return <span className={`event-severity-badge ${severity}`}>{severity}</span>
-}
 
 function statusLabel(check: MonitorCheck): string {
   if (check.type === 'ssl') {
@@ -162,8 +159,6 @@ export function CheckDetail() {
 
   const [check, setCheck] = useState<MonitorCheck | null>(null)
   const [loading, setLoading] = useState(true)
-  const [events, setEvents] = useState<Event[]>([])
-  const [eventsLoading, setEventsLoading] = useState(true)
   const [running, setRunning] = useState(false)
   const [showEdit, setShowEdit] = useState(false)
   const [traefikIntegrations, setTraefikIntegrations] = useState<InfraIntegration[]>([])
@@ -176,11 +171,6 @@ export function CheckDetail() {
       .then(setCheck)
       .catch(() => navigate('/checks'))
       .finally(() => setLoading(false))
-
-    checksApi.listEvents(id)
-      .then(res => setEvents(res.data))
-      .catch(() => {})
-      .finally(() => setEventsLoading(false))
 
     integrationsApi.list()
       .then(res => {
@@ -202,8 +192,6 @@ export function CheckDetail() {
       await checksApi.run(id)
       const updated = await checksApi.get(id)
       setCheck(updated)
-      const eventsRes = await checksApi.listEvents(id)
-      setEvents(eventsRes.data)
     } catch { /* noop */ }
     finally { setRunning(false) }
   }
@@ -340,30 +328,7 @@ export function CheckDetail() {
         </div>
 
         {/* History */}
-        <div className="check-detail-section">
-          <div className="check-detail-section-header">
-            <div className="check-detail-section-title">History</div>
-          </div>
-          <div className="check-detail-section-body">
-            {eventsLoading ? (
-              <div className="check-history-empty">Loading…</div>
-            ) : events.length === 0 ? (
-              <div className="check-history-empty">
-                No status-change events yet. Events are created on first status transition.
-              </div>
-            ) : (
-              <div className="check-history-list">
-                {events.map(ev => (
-                  <div key={ev.id} className="check-history-row">
-                    {severityBadge(ev.level)}
-                    <span className="check-history-text">{ev.title}</span>
-                    <span className="check-history-time">{formatEventTime(ev.created_at)}</span>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
+        <EventFeed sourceType="monitor_check" sourceId={id ?? ''} title="HISTORY" />
 
       </div>
 

--- a/frontend/src/pages/InfraComponentDetail.tsx
+++ b/frontend/src/pages/InfraComponentDetail.tsx
@@ -3,11 +3,10 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { Topbar } from '../components/Topbar'
 import { DockerEngineDetail } from '../components/DockerEngineDetail'
-import { EventRow } from '../components/EventRow'
+import { EventFeed } from '../components/EventFeed'
 import { infrastructure as infraApi, apps as appsApi } from '../api/client'
 import type {
   App,
-  Event,
   InfrastructureComponent,
   ResourceSummary,
   ResourceHistory,
@@ -263,58 +262,6 @@ function SNMPSection({ detail }: { detail: SNMPDetail | null }) {
   )
 }
 
-// ── Component events section ──────────────────────────────────────────────────
-
-function ComponentEventsSection({ componentId }: { componentId: string }) {
-  const [events, setEvents] = useState<Event[]>([])
-  const [total, setTotal] = useState(0)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  function load() {
-    setLoading(true)
-    infraApi.events(componentId, { limit: 25, sort: 'newest' })
-      .then(r => { setEvents(r.data); setTotal(r.total); setError(null) })
-      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load events'))
-      .finally(() => setLoading(false))
-  }
-
-  useEffect(() => { load() }, [componentId]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  return (
-    <div className="icd-section">
-      <div className="icd-section-header-row">
-        <div className="icd-section-title">Recent Events</div>
-        {!loading && !error && total > 0 && (
-          <span className="icd-section-count">{total} total</span>
-        )}
-      </div>
-      {error ? (
-        <div className="icd-events-error">
-          {error} — <button className="icd-retry-btn" onClick={load}>Retry</button>
-        </div>
-      ) : loading ? (
-        <div className="icd-empty">Loading…</div>
-      ) : events.length === 0 ? (
-        <div className="icd-empty">No events recorded for this component.</div>
-      ) : (
-        <div className="icd-events-list">
-          <div className="event-row events-col-header">
-            <span>Time</span>
-            <span />
-            <span>Source</span>
-            <span>Event</span>
-            <span>Severity</span>
-          </div>
-          {events.map(ev => (
-            <EventRow key={ev.id} event={ev} />
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
-
 // ── Main page ─────────────────────────────────────────────────────────────────
 
 export function InfraComponentDetail() {
@@ -511,7 +458,7 @@ export function InfraComponentDetail() {
         />
 
         {/* Recent Events */}
-        <ComponentEventsSection componentId={component.id} />
+        <EventFeed sourceId={component.id} />
 
       </div>
     </>


### PR DESCRIPTION
## What
Builds a single reusable `EventFeed` component that renders a filtered event feed at the bottom of any detail page, replacing three different bespoke event display implementations.

## Why
REFACTOR-04 — every entity detail page needs a consistent event feed. Without a shared component, each page had its own fetching logic, state, and markup that diverged over time.

## How
**Backend — no changes needed.** `GET /api/v1/events` already supports `source_type` and `source_id` query params.

**Frontend type/client changes:**
- `EventFilter.source_type` widened from `'app' | 'infra' | 'check'` to `string` — the backend stores and filters any value (e.g. `docker_engine`, `monitor_check`, `synology`)
- Added `source_id?: string` to `EventFilter`
- `events.list()` client now serialises `source_id` into the query string

**New `EventFeed` component (`/frontend/src/components/EventFeed.tsx`):**
- Props: `sourceType?: string`, `sourceId: string`, `title?: string` (default `"RECENT EVENTS"`)
- Self-contained: owns its own fetch, loading, error, and pagination state
- Subscribes to `useAutoRefresh` tick — stays live without external wiring
- Renders the same column layout as the Events page: TIME | dot | SOURCE | EVENT | SEVERITY using the existing `EventRow` component
- Empty state: "No events yet"
- Load-more control when total exceeds the 50-event default limit

**Pages migrated:**
- `AppDetail` — bespoke event section with severity pills, DetailEventRow, JsonViewer removed; replaced with `<EventFeed sourceType="app" sourceId={appId} />`
- `InfraComponentDetail` — `ComponentEventsSection` removed; replaced with `<EventFeed sourceId={component.id} />` (no sourceType, matching the existing `/infrastructure/{id}/events` filter-by-sourceId behaviour)
- `CheckDetail` — custom history list removed; replaced with `<EventFeed sourceType="monitor_check" sourceId={id} title="HISTORY" />`

## Test coverage
- `npm run build` passes with zero TypeScript errors
- Adding EventFeed to any new page requires only `sourceType` and `sourceId` props

## Closes
Closes REFACTOR-04