### PR TITLE
feat: scanning architecture — Discovery, Metrics, Snapshot buckets (REFACTOR-05)

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/digitalcheffe/nora/internal/infra"
 	"github.com/digitalcheffe/nora/internal/jobs"
 	"github.com/digitalcheffe/nora/internal/monitor"
+	"github.com/digitalcheffe/nora/internal/scanner"
 	"github.com/digitalcheffe/nora/internal/push"
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/digitalcheffe/nora/migrations"
@@ -106,6 +107,12 @@ func main() {
 	schedCtx, schedCancel := context.WithCancel(context.Background())
 	defer schedCancel()
 	go monitor.NewScheduler(store).Start(schedCtx)
+
+	// Scan scheduler — Discovery (1h), Metrics (2m), Snapshots (30m).
+	// Concrete scanners are registered here as REFACTOR-06/07/08 add them.
+	scanCtx, scanCancel := context.WithCancel(context.Background())
+	defer scanCancel()
+	go scanner.NewScanScheduler(store).Start(scanCtx)
 
 	// Resource rollup jobs — hourly aggregation and daily rollup + retention purge.
 	rollupCtx, rollupCancel := context.WithCancel(context.Background())

--- a/internal/scanner/interfaces.go
+++ b/internal/scanner/interfaces.go
@@ -1,0 +1,65 @@
+// Package scanner defines the three scan bucket interfaces used by NORA to
+// collect data from infrastructure entities.
+//
+// Discovery — "What exists?" — finds and registers entities, updates topology.
+// Metrics   — "What is the current measured state?" — collects numeric readings.
+// Snapshots — "What is the current condition?" — captures slowly-changing state.
+//
+// Concrete implementations are provided by REFACTOR-06 (Discovery),
+// REFACTOR-07 (Metrics), and REFACTOR-08 (Snapshots). This package establishes
+// the interfaces and result types only.
+package scanner
+
+import "context"
+
+// DiscoveryResult is returned by a DiscoveryScanner after a discovery pass.
+type DiscoveryResult struct {
+	// EntityID is the stable ID of the scanned entity.
+	EntityID string
+	// EntityType is the type string (e.g. "proxmox_node", "vm", "container").
+	EntityType string
+	// Found is the number of new or changed entities discovered.
+	Found int
+	// Disappeared is the number of previously-known entities that were not seen.
+	Disappeared int
+}
+
+// MetricsResult is returned by a MetricsScanner after one collection pass.
+type MetricsResult struct {
+	// EntityID is the stable ID of the scanned entity.
+	EntityID string
+	// EntityType is the type string.
+	EntityType string
+	// Readings is the number of metric values collected and written.
+	Readings int
+}
+
+// SnapshotResult is returned by a SnapshotScanner after one snapshot pass.
+type SnapshotResult struct {
+	// EntityID is the stable ID of the scanned entity.
+	EntityID string
+	// EntityType is the type string.
+	EntityType string
+	// Changed indicates whether any snapshot values differ from the previous pass.
+	Changed bool
+}
+
+// DiscoveryScanner finds and registers entities for a single infrastructure
+// target. Implementations must be safe to call concurrently.
+type DiscoveryScanner interface {
+	Discover(ctx context.Context, entityID string, entityType string) (*DiscoveryResult, error)
+}
+
+// MetricsScanner collects current numeric readings for a single infrastructure
+// target and writes them to the metrics / resource-readings tables.
+// Implementations must be safe to call concurrently.
+type MetricsScanner interface {
+	CollectMetrics(ctx context.Context, entityID string, entityType string) (*MetricsResult, error)
+}
+
+// SnapshotScanner captures the current condition of slowly-changing attributes
+// for a single infrastructure target and writes them as point-in-time snapshots.
+// Implementations must be safe to call concurrently.
+type SnapshotScanner interface {
+	TakeSnapshot(ctx context.Context, entityID string, entityType string) (*SnapshotResult, error)
+}

--- a/internal/scanner/intervals.go
+++ b/internal/scanner/intervals.go
@@ -1,0 +1,17 @@
+package scanner
+
+import "time"
+
+// Scan bucket intervals. These are the canonical frequencies for each bucket
+// type. The scheduler in Scheduler.Start uses these as its ticker durations.
+const (
+	DiscoveryInterval = 1 * time.Hour
+	MetricsInterval   = 2 * time.Minute
+	SnapshotInterval  = 30 * time.Minute
+
+	// Per-scan timeouts — individual entity scans are cancelled after these
+	// durations so a single stuck target cannot block the scheduler.
+	DiscoveryTimeout = 30 * time.Second
+	MetricsTimeout   = 10 * time.Second
+	SnapshotTimeout  = 15 * time.Second
+)

--- a/internal/scanner/scheduler.go
+++ b/internal/scanner/scheduler.go
@@ -1,0 +1,280 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+// ScanScheduler runs the three scan buckets — Discovery, Metrics, and
+// Snapshots — on their canonical intervals. Each tick fans out to all enabled
+// infrastructure components concurrently with a per-entity timeout.
+//
+// Concrete scanner implementations are registered via the Register* methods
+// before Start is called. Entity types with no registered scanner are skipped
+// silently, which lets REFACTOR-06/07/08 add implementations incrementally
+// without requiring changes here.
+type ScanScheduler struct {
+	store      *repo.Store
+	discovery  map[string]DiscoveryScanner // keyed by entity type
+	metrics    map[string]MetricsScanner
+	snapshots  map[string]SnapshotScanner
+	mu         sync.RWMutex
+}
+
+// NewScanScheduler returns a ScanScheduler wired to store with empty scanner
+// registries. Register scanners before calling Start.
+func NewScanScheduler(store *repo.Store) *ScanScheduler {
+	return &ScanScheduler{
+		store:     store,
+		discovery: make(map[string]DiscoveryScanner),
+		metrics:   make(map[string]MetricsScanner),
+		snapshots: make(map[string]SnapshotScanner),
+	}
+}
+
+// RegisterDiscovery registers a DiscoveryScanner for the given entity type.
+func (s *ScanScheduler) RegisterDiscovery(entityType string, sc DiscoveryScanner) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.discovery[entityType] = sc
+}
+
+// RegisterMetrics registers a MetricsScanner for the given entity type.
+func (s *ScanScheduler) RegisterMetrics(entityType string, sc MetricsScanner) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.metrics[entityType] = sc
+}
+
+// RegisterSnapshot registers a SnapshotScanner for the given entity type.
+func (s *ScanScheduler) RegisterSnapshot(entityType string, sc SnapshotScanner) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.snapshots[entityType] = sc
+}
+
+// Start launches the three ticker loops and blocks until ctx is cancelled.
+// Each ticker fires independently; slow discovery scans will not delay metrics
+// collection.
+func (s *ScanScheduler) Start(ctx context.Context) {
+	log.Printf("scan scheduler: starting (discovery=%s, metrics=%s, snapshots=%s)",
+		DiscoveryInterval, MetricsInterval, SnapshotInterval)
+
+	discoveryTicker := time.NewTicker(DiscoveryInterval)
+	metricsTicker := time.NewTicker(MetricsInterval)
+	snapshotTicker := time.NewTicker(SnapshotInterval)
+	defer discoveryTicker.Stop()
+	defer metricsTicker.Stop()
+	defer snapshotTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("scan scheduler: context cancelled — stopping")
+			return
+		case <-discoveryTicker.C:
+			go s.runDiscoveryPass(ctx)
+		case <-metricsTicker.C:
+			go s.runMetricsPass(ctx)
+		case <-snapshotTicker.C:
+			go s.runSnapshotPass(ctx)
+		}
+	}
+}
+
+// runDiscoveryPass iterates all enabled components and calls each registered
+// DiscoveryScanner concurrently with DiscoveryTimeout per entity.
+func (s *ScanScheduler) runDiscoveryPass(ctx context.Context) {
+	components, err := s.listEnabled(ctx)
+	if err != nil {
+		log.Printf("scan scheduler: discovery: list components: %v", err)
+		return
+	}
+
+	s.mu.RLock()
+	scanners := copyDiscovery(s.discovery)
+	s.mu.RUnlock()
+
+	var wg sync.WaitGroup
+	for i := range components {
+		c := &components[i]
+		sc, ok := scanners[c.Type]
+		if !ok {
+			continue
+		}
+		wg.Add(1)
+		go func(c *models.InfrastructureComponent, sc DiscoveryScanner) {
+			defer wg.Done()
+			tctx, cancel := context.WithTimeout(ctx, DiscoveryTimeout)
+			defer cancel()
+			result, err := sc.Discover(tctx, c.ID, c.Type)
+			if err != nil {
+				log.Printf("scan scheduler: discovery: %s (%s): %v", c.Name, c.ID, err)
+				s.writeErrorEvent(ctx, c, "discovery", err)
+				return
+			}
+			logDiscovery(c, result)
+		}(c, sc)
+	}
+	wg.Wait()
+}
+
+// runMetricsPass iterates all enabled components and calls each registered
+// MetricsScanner concurrently with MetricsTimeout per entity.
+func (s *ScanScheduler) runMetricsPass(ctx context.Context) {
+	components, err := s.listEnabled(ctx)
+	if err != nil {
+		log.Printf("scan scheduler: metrics: list components: %v", err)
+		return
+	}
+
+	s.mu.RLock()
+	scanners := copyMetrics(s.metrics)
+	s.mu.RUnlock()
+
+	var wg sync.WaitGroup
+	for i := range components {
+		c := &components[i]
+		sc, ok := scanners[c.Type]
+		if !ok {
+			continue
+		}
+		wg.Add(1)
+		go func(c *models.InfrastructureComponent, sc MetricsScanner) {
+			defer wg.Done()
+			tctx, cancel := context.WithTimeout(ctx, MetricsTimeout)
+			defer cancel()
+			_, err := sc.CollectMetrics(tctx, c.ID, c.Type)
+			if err != nil {
+				log.Printf("scan scheduler: metrics: %s (%s): %v", c.Name, c.ID, err)
+				s.writeErrorEvent(ctx, c, "metrics", err)
+			}
+		}(c, sc)
+	}
+	wg.Wait()
+}
+
+// runSnapshotPass iterates all enabled components and calls each registered
+// SnapshotScanner concurrently with SnapshotTimeout per entity.
+func (s *ScanScheduler) runSnapshotPass(ctx context.Context) {
+	components, err := s.listEnabled(ctx)
+	if err != nil {
+		log.Printf("scan scheduler: snapshot: list components: %v", err)
+		return
+	}
+
+	s.mu.RLock()
+	scanners := copySnapshots(s.snapshots)
+	s.mu.RUnlock()
+
+	var wg sync.WaitGroup
+	for i := range components {
+		c := &components[i]
+		sc, ok := scanners[c.Type]
+		if !ok {
+			continue
+		}
+		wg.Add(1)
+		go func(c *models.InfrastructureComponent, sc SnapshotScanner) {
+			defer wg.Done()
+			tctx, cancel := context.WithTimeout(ctx, SnapshotTimeout)
+			defer cancel()
+			_, err := sc.TakeSnapshot(tctx, c.ID, c.Type)
+			if err != nil {
+				log.Printf("scan scheduler: snapshot: %s (%s): %v", c.Name, c.ID, err)
+				s.writeErrorEvent(ctx, c, "snapshot", err)
+			}
+		}(c, sc)
+	}
+	wg.Wait()
+}
+
+// listEnabled returns all enabled infrastructure components from the store.
+func (s *ScanScheduler) listEnabled(ctx context.Context) ([]models.InfrastructureComponent, error) {
+	all, err := s.store.InfraComponents.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := all[:0]
+	for _, c := range all {
+		if c.Enabled {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+// writeErrorEvent writes an error-level event to the event log for a scan
+// failure. The scheduler continues running after a failed scan.
+func (s *ScanScheduler) writeErrorEvent(
+	ctx context.Context,
+	c *models.InfrastructureComponent,
+	bucket string,
+	scanErr error,
+) {
+	ev := &models.Event{
+		ID:         uuid.New().String(),
+		Level:      "error",
+		SourceName: c.Name,
+		SourceType: "physical_host",
+		SourceID:   c.ID,
+		Title:      fmt.Sprintf("%s scan failed — %s: %v", bucket, c.Name, scanErr),
+		Payload: fmt.Sprintf(
+			`{"bucket":%q,"entity_id":%q,"entity_type":%q,"error":%q}`,
+			bucket, c.ID, c.Type, scanErr.Error(),
+		),
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := s.store.Events.Create(ctx, ev); err != nil {
+		log.Printf("scan scheduler: write error event for %s (%s): %v", c.Name, c.ID, err)
+	}
+}
+
+// logDiscovery emits structured log lines based on what the discovery pass found.
+func logDiscovery(c *models.InfrastructureComponent, r *DiscoveryResult) {
+	if r.Found == 0 && r.Disappeared == 0 {
+		log.Printf("scan scheduler: discovery: %s (%s): no changes", c.Name, c.ID)
+		return
+	}
+	if r.Found > 0 {
+		log.Printf("scan scheduler: discovery: %s (%s): %d new/updated entities",
+			c.Name, c.ID, r.Found)
+	}
+	if r.Disappeared > 0 {
+		log.Printf("scan scheduler: discovery: %s (%s): %d entities disappeared",
+			c.Name, c.ID, r.Disappeared)
+	}
+}
+
+// copyDiscovery returns a shallow copy of the scanner map so it can be
+// iterated without holding the lock.
+func copyDiscovery(m map[string]DiscoveryScanner) map[string]DiscoveryScanner {
+	out := make(map[string]DiscoveryScanner, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func copyMetrics(m map[string]MetricsScanner) map[string]MetricsScanner {
+	out := make(map[string]MetricsScanner, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func copySnapshots(m map[string]SnapshotScanner) map[string]SnapshotScanner {
+	out := make(map[string]SnapshotScanner, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}


### PR DESCRIPTION
## What
Establishes the foundational scanning architecture in `/internal/scanner/` — three distinct scan buckets with defined interfaces, frequency constants, and a scheduler that fans out concurrently to all registered entity types.

## Why
REFACTOR-05. All subsequent scanning tasks (REFACTOR-06 Discovery, REFACTOR-07 Metrics, REFACTOR-08 Snapshots) depend on these interfaces and the scheduler being in place first.

## How
- `/internal/scanner/interfaces.go` — `DiscoveryScanner`, `MetricsScanner`, `SnapshotScanner` interfaces plus `DiscoveryResult`, `MetricsResult`, `SnapshotResult` types
- `/internal/scanner/intervals.go` — canonical constants: `DiscoveryInterval=1h`, `MetricsInterval=2m`, `SnapshotInterval=30m`, plus per-scan timeouts (30s/10s/15s)
- `/internal/scanner/scheduler.go` — `ScanScheduler` with three independent tickers; each tick fans out concurrently per entity using `sync.WaitGroup` + per-entity context timeout; scan failures write error events to the event log and do not crash the scheduler
- `cmd/nora/main.go` — `scanner.NewScanScheduler(store).Start(scanCtx)` wired alongside the existing monitor scheduler; concrete scanner registrations added here as REFACTOR-06/07/08 land

Existing polling behavior (Proxmox, Synology, SNMP, Traefik, Docker) is entirely unaffected — the new scheduler starts with empty registries and is a no-op until scanners are registered.

## Test coverage
- `go build ./...` passes
- `go test ./...` passes (all existing tests still green)

## Closes
Closes REFACTOR-05