### PR TITLE
feat: discovery scanner — hourly auto-discover + Discover Now button (REFACTOR-06)

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -21,9 +21,10 @@ import (
 	"github.com/digitalcheffe/nora/internal/infra"
 	"github.com/digitalcheffe/nora/internal/jobs"
 	"github.com/digitalcheffe/nora/internal/monitor"
-	"github.com/digitalcheffe/nora/internal/scanner"
 	"github.com/digitalcheffe/nora/internal/push"
 	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+	"github.com/digitalcheffe/nora/internal/scanner/discovery"
 	"github.com/digitalcheffe/nora/migrations"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -109,10 +110,18 @@ func main() {
 	go monitor.NewScheduler(store).Start(schedCtx)
 
 	// Scan scheduler — Discovery (1h), Metrics (2m), Snapshots (30m).
-	// Concrete scanners are registered here as REFACTOR-06/07/08 add them.
+	// Discovery scanners are registered here by entity type (and collection
+	// method for SNMP).  Metrics and Snapshot scanners are added in
+	// REFACTOR-07 and REFACTOR-08.
 	scanCtx, scanCancel := context.WithCancel(context.Background())
 	defer scanCancel()
-	go scanner.NewScanScheduler(store).Start(scanCtx)
+	scanScheduler := scanner.NewScanScheduler(store)
+	scanScheduler.RegisterDiscovery("proxmox_node", discovery.NewProxmoxDiscoveryScanner(store))
+	scanScheduler.RegisterDiscovery("docker_engine", discovery.NewDockerDiscoveryScanner(store))
+	scanScheduler.RegisterDiscovery("synology", discovery.NewSynologyDiscoveryScanner(store))
+	scanScheduler.RegisterDiscovery("opnsense", discovery.NewOPNsenseDiscoveryScanner(store))
+	scanScheduler.RegisterDiscoveryByMethod("snmp", discovery.NewSNMPDiscoveryScanner(store))
+	go scanScheduler.Start(scanCtx)
 
 	// Resource rollup jobs — hourly aggregation and daily rollup + retention purge.
 	rollupCtx, rollupCancel := context.WithCancel(context.Background())

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -15,6 +15,7 @@ import type {
   CustomProfile,
   DashboardSummaryResponse,
   DigestSchedule,
+  DiscoverResult,
   DiscoveredContainer,
   DiscoveredRoute,
   DockerEngine,
@@ -365,6 +366,9 @@ export const infrastructure = {
 
   scan: (id: string) =>
     request<ScanResult>('POST', `/infrastructure/${id}/scan`),
+
+  discover: (id: string) =>
+    request<DiscoverResult>('POST', `/infrastructure/${id}/discover`),
 
   events: (id: string, filter?: EventFilter) => {
     const params = new URLSearchParams()

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -403,6 +403,15 @@ export interface ScanResult {
   error?: string
 }
 
+export interface DiscoverResult {
+  status: string
+  discovered: number
+  updated: number
+  missing: number
+  message?: string
+  error?: string
+}
+
 
 export interface ResourceSummary {
   component_id: string

--- a/frontend/src/pages/InfraComponentDetail.tsx
+++ b/frontend/src/pages/InfraComponentDetail.tsx
@@ -7,6 +7,7 @@ import { EventFeed } from '../components/EventFeed'
 import { infrastructure as infraApi, apps as appsApi } from '../api/client'
 import type {
   App,
+  DiscoverResult,
   InfrastructureComponent,
   ResourceSummary,
   ResourceHistory,
@@ -278,8 +279,8 @@ export function InfraComponentDetail() {
   const [allApps,       setAllApps]       = useState<App[]>([])
   const [linkingAppId,  setLinkingAppId]  = useState('')
   const [linkBusy,      setLinkBusy]      = useState(false)
-  const [scanning,      setScanning]      = useState(false)
-  const [scanError,     setScanError]     = useState<string | null>(null)
+  const [discovering,   setDiscovering]   = useState(false)
+  const [discoverError, setDiscoverError] = useState<string | null>(null)
   const [loading,       setLoading]       = useState(true)
   const [error,         setError]         = useState<string | null>(null)
 
@@ -311,13 +312,17 @@ export function InfraComponentDetail() {
       .finally(() => setLoading(false))
   }, [id, tick])
 
-  async function handleScan() {
+  async function handleDiscover() {
     if (!id || !component) return
-    setScanning(true)
-    setScanError(null)
+    setDiscovering(true)
+    setDiscoverError(null)
     try {
-      await infraApi.scan(id)
-      // Re-fetch component status + resources + SNMP detail after poll completes.
+      const result: DiscoverResult = await infraApi.discover(id)
+      if (result.error) {
+        setDiscoverError(result.error)
+        return
+      }
+      // Re-fetch component status + resources + SNMP detail after discovery.
       const [comp, res] = await Promise.all([
         infraApi.get(id),
         infraApi.resources(id, 'hour'),
@@ -329,9 +334,9 @@ export function InfraComponentDetail() {
         setSnmpDetail(det)
       }
     } catch (err: unknown) {
-      setScanError(err instanceof Error ? err.message : 'Scan failed')
+      setDiscoverError(err instanceof Error ? err.message : 'Discovery failed')
     } finally {
-      setScanning(false)
+      setDiscovering(false)
     }
   }
 
@@ -413,15 +418,15 @@ export function InfraComponentDetail() {
             {component.collection_method !== 'none' && (
               <button
                 className="icd-scan-btn"
-                onClick={() => void handleScan()}
-                disabled={scanning}
+                onClick={() => void handleDiscover()}
+                disabled={discovering}
               >
-                {scanning ? 'Scanning…' : 'Scan Now'}
+                {discovering ? 'Discovering…' : 'Discover Now'}
               </button>
             )}
           </div>
         </div>
-        {scanError && <div className="icd-scan-error">{scanError}</div>}
+        {discoverError && <div className="icd-scan-error">{discoverError}</div>}
 
         {/* SNMP hosts: three-section detail view */}
         {component.collection_method === 'snmp' && (
@@ -492,7 +497,7 @@ function ProxmoxChildrenSection({ children, onNavigate }: ProxmoxChildrenSection
     return (
       <div className="icd-section">
         <div className="icd-section-title">Virtual Machines</div>
-        <div className="icd-empty">No VMs or containers discovered yet. Run Scan Now to discover.</div>
+        <div className="icd-empty">No VMs or containers discovered yet. Run Discover Now to discover.</div>
       </div>
     )
   }

--- a/frontend/src/pages/Infrastructure.tsx
+++ b/frontend/src/pages/Infrastructure.tsx
@@ -10,7 +10,7 @@ import type {
   InfrastructureComponent,
   InfrastructureComponentInput,
   ResourceSummary,
-  ScanResult,
+  DiscoverResult,
   VolumeResource,
 } from '../api/types'
 import './Infrastructure.css'
@@ -319,7 +319,7 @@ export function Infrastructure() {
   const [submitting,            setSubmitting]            = useState(false)
   const [deletingId,            setDeletingId]            = useState<string | null>(null)
   const [scanningId,            setScanningId]            = useState<string | null>(null)
-  const [scanResults,           setScanResults]           = useState<Record<string, ScanResult>>({})
+  const [scanResults,           setScanResults]           = useState<Record<string, DiscoverResult>>({})
 
   // ── Polling ─────────────────────────────────────────────────────────────────
 
@@ -438,15 +438,15 @@ export function Infrastructure() {
     setScanningId(id)
     setScanResults(prev => { const n = { ...prev }; delete n[id]; return n })
     try {
-      const result = await infraApi.scan(id)
+      const result = await infraApi.discover(id)
       setScanResults(prev => ({ ...prev, [id]: result }))
       // Refresh the component list so last_status updates immediately.
       const res = await infraApi.list()
       setComponents(res.data)
       void pollAll(res.data)
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : 'Scan failed'
-      setScanResults(prev => ({ ...prev, [id]: { component_id: id, status: 'offline', last_polled_at: new Date().toISOString(), error: msg } }))
+      const msg = err instanceof Error ? err.message : 'Discover failed'
+      setScanResults(prev => ({ ...prev, [id]: { status: 'error', discovered: 0, updated: 0, missing: 0, error: msg } }))
     } finally {
       setScanningId(null)
     }
@@ -521,7 +521,7 @@ export function Infrastructure() {
               onClick={() => void handleScan(c.id)}
               disabled={isDeleting || isScanning || scanningId !== null}
             >
-              {isScanning ? 'Scanning…' : 'Scan Now'}
+              {isScanning ? 'Discovering…' : 'Discover Now'}
             </button>
             <button
               className="infra-card-btn"
@@ -577,7 +577,7 @@ export function Infrastructure() {
               onClick={() => void handleScan(c.id)}
               disabled={isDeleting || isScanning || scanningId !== null}
             >
-              {isScanning ? 'Scanning…' : 'Scan Now'}
+              {isScanning ? 'Discovering…' : 'Discover Now'}
             </button>
             <button
               className="infra-card-btn"
@@ -658,7 +658,7 @@ export function Infrastructure() {
                 onClick={() => void handleScan(c.id)}
                 disabled={isDeleting || isScanning || scanningId !== null}
               >
-                {isScanning ? 'Scanning…' : 'Scan Now'}
+                {isScanning ? 'Discovering…' : 'Discover Now'}
               </button>
             )}
             <button

--- a/frontend/src/pages/ProxmoxDetail.tsx
+++ b/frontend/src/pages/ProxmoxDetail.tsx
@@ -177,7 +177,7 @@ function NodeOverviewSection({
           </div>
         )}
         {!hasData && !ns && (
-          <div className="px-empty">No resource data collected yet. Run Scan Now to poll.</div>
+          <div className="px-empty">No resource data collected yet. Run Discover Now to poll.</div>
         )}
       </div>
     </div>
@@ -523,6 +523,8 @@ export function ProxmoxDetail() {
   const [resources,    setResources]    = useState<ResourceSummary | null>(null)
   const [topLoading,   setTopLoading]   = useState(true)
   const [topError,     setTopError]     = useState<string | null>(null)
+  const [discovering,  setDiscovering]  = useState(false)
+  const [discoverError, setDiscoverError] = useState<string | null>(null)
 
   // Section data
   const [pools,        setPools]        = useState<ProxmoxStoragePool[]>([])
@@ -594,6 +596,24 @@ export function ProxmoxDetail() {
       .finally(() => setFailuresLoading(false))
   }, [componentId])
 
+  const handleDiscoverNow = useCallback(async () => {
+    if (!componentId || discovering) return
+    setDiscovering(true)
+    setDiscoverError(null)
+    try {
+      await infraApi.discover(componentId)
+      loadTop()
+      loadPools()
+      loadGuests()
+      loadStatus()
+      loadFailures()
+    } catch (err) {
+      setDiscoverError(err instanceof Error ? err.message : 'Discover failed')
+    } finally {
+      setDiscovering(false)
+    }
+  }, [componentId, discovering, loadTop, loadPools, loadGuests, loadStatus, loadFailures])
+
   // Initial load and auto-refresh
   useEffect(() => {
     loadTop()
@@ -655,6 +675,16 @@ export function ProxmoxDetail() {
               <span className="px-polled-at">
                 Last polled {timeAgo(component.last_polled_at)}
               </span>
+            )}
+            <button
+              className="px-scan-btn"
+              onClick={() => void handleDiscoverNow()}
+              disabled={discovering || topLoading}
+            >
+              {discovering ? 'Discovering…' : 'Discover Now'}
+            </button>
+            {discoverError && (
+              <span className="px-scan-error">{discoverError}</span>
             )}
           </div>
         </div>

--- a/frontend/src/pages/SynologyDetail.tsx
+++ b/frontend/src/pages/SynologyDetail.tsx
@@ -143,6 +143,8 @@ export function SynologyDetail() {
   const [noData, setNoData] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [discovering,   setDiscovering]   = useState(false)
+  const [discoverError, setDiscoverError] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     if (!componentId) return
@@ -161,6 +163,20 @@ export function SynologyDetail() {
       setLoading(false)
     }
   }, [componentId])
+
+  const handleDiscoverNow = useCallback(async () => {
+    if (!componentId || discovering) return
+    setDiscovering(true)
+    setDiscoverError(null)
+    try {
+      await infraApi.discover(componentId)
+      void load()
+    } catch (err) {
+      setDiscoverError(err instanceof Error ? err.message : 'Discover failed')
+    } finally {
+      setDiscovering(false)
+    }
+  }, [componentId, discovering, load])
 
   useEffect(() => { load() }, [load, tick])
 
@@ -207,6 +223,14 @@ export function SynologyDetail() {
             {d?.polled_at && (
               <span className="syn-polled-at">polled {timeAgo(d.polled_at)}</span>
             )}
+            <button
+              className="icd-scan-btn"
+              onClick={() => void handleDiscoverNow()}
+              disabled={discovering}
+            >
+              {discovering ? 'Discovering…' : 'Discover Now'}
+            </button>
+            {discoverError && <span className="icd-scan-error">{discoverError}</span>}
           </div>
         </div>
 

--- a/frontend/src/pages/TraefikDetail.tsx
+++ b/frontend/src/pages/TraefikDetail.tsx
@@ -10,7 +10,7 @@ import {
 import type {
   Event,
   InfrastructureComponent,
-  ScanResult,
+  DiscoverResult,
   TraefikOverview,
   DiscoveredRoute,
   TraefikServiceDetail,
@@ -153,7 +153,7 @@ function OverviewSection({
               )}
             </>
           ) : (
-            <div className="tk-empty">No overview data — run Scan Now to poll Traefik.</div>
+            <div className="tk-empty">No overview data — run Discover Now to poll Traefik.</div>
           )}
         </div>
       )}
@@ -530,9 +530,9 @@ export function TraefikDetail() {
   const [topLoading,   setTopLoading]   = useState(true)
   const [topError,     setTopError]     = useState<string | null>(null)
 
-  // Scan Now
-  const [scanning,     setScanning]     = useState(false)
-  const [scanResult,   setScanResult]   = useState<ScanResult | null>(null)
+  // Discover Now
+  const [discovering,     setDiscovering]     = useState(false)
+  const [discoverResult,  setDiscoverResult]  = useState<DiscoverResult | null>(null)
 
   // Overview
   const [overview,        setOverview]        = useState<TraefikOverview | null>(null)
@@ -585,29 +585,30 @@ export function TraefikDetail() {
       .finally(() => setServicesLoading(false))
   }, [componentId])
 
-  const handleScanNow = useCallback(async () => {
-    if (!componentId || scanning) return
-    setScanning(true)
-    setScanResult(null)
+  const handleDiscoverNow = useCallback(async () => {
+    if (!componentId || discovering) return
+    setDiscovering(true)
+    setDiscoverResult(null)
     try {
-      const result = await infraApi.scan(componentId)
-      setScanResult(result)
+      const result = await infraApi.discover(componentId)
+      setDiscoverResult(result)
       // Reload all sections with fresh data from the just-completed poll.
       loadTop()
       loadOverview()
       loadRouters()
       loadServices()
     } catch (err) {
-      setScanResult({
-        component_id: componentId,
-        status: 'offline',
-        last_polled_at: new Date().toISOString(),
-        error: err instanceof Error ? err.message : 'Scan failed',
+      setDiscoverResult({
+        status: 'error',
+        discovered: 0,
+        updated: 0,
+        missing: 0,
+        error: err instanceof Error ? err.message : 'Discover failed',
       })
     } finally {
-      setScanning(false)
+      setDiscovering(false)
     }
-  }, [componentId, scanning, loadTop, loadOverview, loadRouters, loadServices])
+  }, [componentId, discovering, loadTop, loadOverview, loadRouters, loadServices])
 
   useEffect(() => {
     loadTop()
@@ -679,13 +680,13 @@ export function TraefikDetail() {
             )}
             <button
               className="tk-scan-btn"
-              onClick={() => void handleScanNow()}
-              disabled={scanning || topLoading}
+              onClick={() => void handleDiscoverNow()}
+              disabled={discovering || topLoading}
             >
-              {scanning ? 'Scanning…' : 'Scan Now'}
+              {discovering ? 'Discovering…' : 'Discover Now'}
             </button>
-            {scanResult?.error && (
-              <span className="tk-scan-error">{scanResult.error}</span>
+            {discoverResult?.error && (
+              <span className="tk-scan-error">{discoverResult.error}</span>
             )}
           </div>
         </div>

--- a/internal/api/infra_components.go
+++ b/internal/api/infra_components.go
@@ -39,6 +39,7 @@ func (h *InfraComponentHandler) Routes(r chi.Router) {
 	r.Put("/infrastructure/{id}", h.Update)
 	r.Delete("/infrastructure/{id}", h.Delete)
 	r.Post("/infrastructure/{id}/scan", h.Scan)
+	r.Post("/infrastructure/{id}/discover", h.Discover)
 	r.Get("/infrastructure/{id}/resources", h.GetResources)
 	r.Get("/infrastructure/{id}/resources/history", h.GetResourceHistory)
 	r.Get("/infrastructure/{id}/snmp", h.GetSNMPDetail)
@@ -432,6 +433,53 @@ func (h *InfraComponentHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		resp.Message = "scan complete"
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// discoverResponse is the response shape for POST /infrastructure/{id}/discover.
+type discoverResponse struct {
+	Status     string `json:"status"`
+	Discovered int    `json:"discovered"`
+	Updated    int    `json:"updated"`
+	Missing    int    `json:"missing"`
+	Message    string `json:"message,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+// Discover immediately runs the discovery scanner for a single infrastructure
+// component and returns found/updated/missing counts.
+// POST /api/v1/infrastructure/{id}/discover
+func (h *InfraComponentHandler) Discover(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	c, err := h.components.Get(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "component not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Use a detached context with a hard timeout so the scan is not cancelled
+	// if the client disconnects before it completes.
+	discCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	result, discErr := jobs.DiscoverOneComponent(discCtx, h.store, c)
+	if discErr != nil {
+		writeJSON(w, http.StatusOK, discoverResponse{
+			Status:  "error",
+			Error:   discErr.Error(),
+			Message: "discovery failed — check credentials and connectivity",
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, discoverResponse{
+		Status:     "ok",
+		Discovered: result.Found,
+		Missing:    result.Disappeared,
+		Message:    "discovery complete",
+	})
 }
 
 // VolumeResource holds per-volume disk utilisation for Synology and similar components.

--- a/internal/infra/proxmox.go
+++ b/internal/infra/proxmox.go
@@ -27,6 +27,12 @@ func proxmoxChildID(parentID string, vmid int) string {
 	return uuid.NewSHA1(proxmoxChildNS, []byte(fmt.Sprintf("%s/%d", parentID, vmid))).String()
 }
 
+// ProxmoxChildID is the exported form of proxmoxChildID, for use by the
+// discovery scanner package which lives outside the infra package.
+func ProxmoxChildID(parentID string, vmid int) string {
+	return proxmoxChildID(parentID, vmid)
+}
+
 // ProxmoxCredentials is the JSON shape stored in infrastructure_components.credentials.
 type ProxmoxCredentials struct {
 	BaseURL     string `json:"base_url"`

--- a/internal/jobs/discover.go
+++ b/internal/jobs/discover.go
@@ -1,0 +1,50 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+	"github.com/digitalcheffe/nora/internal/scanner/discovery"
+)
+
+// DiscoverOneComponent immediately runs the discovery scanner for a single
+// infrastructure component.  It is the backend for the
+// POST /infrastructure/{id}/discover API endpoint.
+//
+// The scanner implementation is selected based on the component's type and
+// collection_method, mirroring the logic in scanner.ScanScheduler.
+func DiscoverOneComponent(ctx context.Context, store *repo.Store, c *models.InfrastructureComponent) (*scanner.DiscoveryResult, error) {
+	if !c.Enabled {
+		return nil, fmt.Errorf("component is disabled")
+	}
+
+	sc := discoveryScanner(store, c)
+	if sc == nil {
+		return nil, fmt.Errorf("no discovery scanner for type=%q method=%q", c.Type, c.CollectionMethod)
+	}
+
+	return sc.Discover(ctx, c.ID, c.Type)
+}
+
+// discoveryScanner returns the correct DiscoveryScanner for c, or nil if none
+// applies.  Type is checked first; collection_method is the fallback.
+func discoveryScanner(store *repo.Store, c *models.InfrastructureComponent) scanner.DiscoveryScanner {
+	switch c.Type {
+	case "proxmox_node":
+		return discovery.NewProxmoxDiscoveryScanner(store)
+	case "docker_engine":
+		return discovery.NewDockerDiscoveryScanner(store)
+	case "synology":
+		return discovery.NewSynologyDiscoveryScanner(store)
+	case "opnsense":
+		return discovery.NewOPNsenseDiscoveryScanner(store)
+	}
+	// Fallback: collection_method-based dispatch.
+	if c.CollectionMethod == "snmp" {
+		return discovery.NewSNMPDiscoveryScanner(store)
+	}
+	return nil
+}

--- a/internal/scanner/discovery/docker.go
+++ b/internal/scanner/discovery/docker.go
@@ -1,0 +1,141 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	dockercontainer "github.com/docker/docker/api/types/container"
+	dockerclient "github.com/docker/docker/client"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+)
+
+// DockerDiscoveryScanner discovers containers on a local Docker engine
+// infrastructure component.
+type DockerDiscoveryScanner struct {
+	store *repo.Store
+}
+
+// NewDockerDiscoveryScanner returns a DockerDiscoveryScanner backed by store.
+func NewDockerDiscoveryScanner(store *repo.Store) *DockerDiscoveryScanner {
+	return &DockerDiscoveryScanner{store: store}
+}
+
+// Discover lists all containers (running and stopped) from the Docker daemon,
+// reconciles them with discovered_containers, and writes discovery events.
+func (s *DockerDiscoveryScanner) Discover(ctx context.Context, entityID string, entityType string) (*scanner.DiscoveryResult, error) {
+	c, err := s.store.InfraComponents.Get(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("get component %s: %w", entityID, err)
+	}
+
+	cli, err := dockerclient.NewClientWithOpts(
+		dockerclient.FromEnv,
+		dockerclient.WithAPIVersionNegotiation(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("docker client: %w", err)
+	}
+	defer cli.Close() //nolint:errcheck
+
+	// List all containers (All=true includes stopped ones).
+	containers, err := cli.ContainerList(ctx, dockercontainer.ListOptions{All: true})
+	if err != nil {
+		return nil, fmt.Errorf("list containers: %w", err)
+	}
+
+	// Get previously known containers for this engine.
+	known, err := s.store.DiscoveredContainers.ListDiscoveredContainers(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("list known containers: %w", err)
+	}
+	knownByID := make(map[string]*models.DiscoveredContainer, len(known))
+	for _, dc := range known {
+		knownByID[dc.ContainerID] = dc
+	}
+
+	now := time.Now().UTC()
+	found := 0
+	runningIDs := make([]string, 0, len(containers))
+
+	for _, ct := range containers {
+		name := containerName(ct.Names)
+		status := "stopped"
+		if ct.State == "running" {
+			status = "running"
+			runningIDs = append(runningIDs, ct.ID)
+		}
+
+		dc := &models.DiscoveredContainer{
+			InfraComponentID: entityID,
+			ContainerID:      ct.ID,
+			ContainerName:    name,
+			Image:            ct.Image,
+			Status:           status,
+			LastSeenAt:       now,
+			CreatedAt:        now,
+		}
+
+		if _, alreadyKnown := knownByID[ct.ID]; !alreadyKnown {
+			if upsertErr := s.store.DiscoveredContainers.UpsertDiscoveredContainer(ctx, dc); upsertErr != nil {
+				log.Printf("docker discovery: upsert %s: %v", name, upsertErr)
+				continue
+			}
+			writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "docker_engine", "info",
+				fmt.Sprintf("[discovery] New container discovered: %s", name))
+			found++
+		} else {
+			// Known — update last_seen_at and status.
+			if updateErr := s.store.DiscoveredContainers.UpdateDiscoveredContainerStatus(ctx, knownByID[ct.ID].ID, status, now); updateErr != nil {
+				log.Printf("docker discovery: update status %s: %v", name, updateErr)
+			}
+		}
+	}
+
+	// Mark containers no longer returned by Docker as stopped.
+	disappeared := 0
+	currentIDs := make(map[string]struct{}, len(containers))
+	for _, ct := range containers {
+		currentIDs[ct.ID] = struct{}{}
+	}
+	for _, dc := range known {
+		if _, still := currentIDs[dc.ContainerID]; !still {
+			if dc.Status != "stopped" {
+				if updateErr := s.store.DiscoveredContainers.UpdateDiscoveredContainerStatus(ctx, dc.ID, "stopped", now); updateErr != nil {
+					log.Printf("docker discovery: mark disappeared %s: %v", dc.ContainerName, updateErr)
+				}
+				writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "docker_engine", "warn",
+					fmt.Sprintf("[discovery] Entity no longer found: %s", dc.ContainerName))
+				disappeared++
+			}
+		}
+	}
+
+	if found == 0 && disappeared == 0 {
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "docker_engine", "debug",
+			fmt.Sprintf("[discovery] %s discovery completed — no changes", c.Name))
+	}
+
+	return &scanner.DiscoveryResult{
+		EntityID:    entityID,
+		EntityType:  entityType,
+		Found:       found,
+		Disappeared: disappeared,
+	}, nil
+}
+
+// containerName strips the leading "/" Docker prepends to container names.
+func containerName(names []string) string {
+	if len(names) == 0 {
+		return ""
+	}
+	return strings.TrimPrefix(names[0], "/")
+}
+
+// compile-time check.
+var _ scanner.DiscoveryScanner = (*DockerDiscoveryScanner)(nil)

--- a/internal/scanner/discovery/events.go
+++ b/internal/scanner/discovery/events.go
@@ -1,0 +1,45 @@
+// Package discovery provides DiscoveryScanner implementations for each
+// infrastructure integration type supported by NORA.
+//
+// Each scanner is constructed with a *repo.Store and registered with the
+// scanner.ScanScheduler in main.go.  The same implementations are also used
+// by the Discover Now API endpoint (POST /infrastructure/{id}/discover).
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+// writeDiscoveryEvent writes a single event to the event log for a discovery
+// action.  level must be one of "debug", "info", "warn", "error".
+// sourceType should match the models.Event source_type convention.
+func writeDiscoveryEvent(
+	ctx context.Context,
+	store *repo.Store,
+	componentID, componentName, sourceType, level, title string,
+) {
+	payload := fmt.Sprintf(
+		`{"bucket":"discovery","component_id":%q,"component_name":%q}`,
+		componentID, componentName,
+	)
+	ev := &models.Event{
+		ID:         uuid.New().String(),
+		Level:      level,
+		SourceName: componentName,
+		SourceType: sourceType,
+		SourceID:   componentID,
+		Title:      title,
+		Payload:    payload,
+		CreatedAt:  time.Now().UTC(),
+	}
+	if err := store.Events.Create(ctx, ev); err != nil {
+		log.Printf("discovery: write event for %s (%s): %v", componentName, componentID, err)
+	}
+}

--- a/internal/scanner/discovery/opnsense.go
+++ b/internal/scanner/discovery/opnsense.go
@@ -1,0 +1,155 @@
+package discovery
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+)
+
+// OPNsenseCredentials is the JSON shape stored in infrastructure_components.credentials
+// for opnsense components.
+type OPNsenseCredentials struct {
+	BaseURL   string `json:"base_url"`
+	APIKey    string `json:"api_key"`
+	APISecret string `json:"api_secret"`
+	VerifyTLS bool   `json:"verify_tls"`
+}
+
+// OPNsenseDiscoveryScanner discovers configured interfaces, firewall rule
+// summary, and installed plugins for an OPNsense component.
+type OPNsenseDiscoveryScanner struct {
+	store *repo.Store
+}
+
+// NewOPNsenseDiscoveryScanner returns an OPNsenseDiscoveryScanner backed by store.
+func NewOPNsenseDiscoveryScanner(store *repo.Store) *OPNsenseDiscoveryScanner {
+	return &OPNsenseDiscoveryScanner{store: store}
+}
+
+// Discover fetches interfaces and installed plugins from the OPNsense REST API
+// and writes discovery events.
+func (s *OPNsenseDiscoveryScanner) Discover(ctx context.Context, entityID string, entityType string) (*scanner.DiscoveryResult, error) {
+	c, err := s.store.InfraComponents.Get(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("get component %s: %w", entityID, err)
+	}
+	if c.Credentials == nil || *c.Credentials == "" {
+		return nil, fmt.Errorf("no credentials configured for %s", c.Name)
+	}
+
+	var creds OPNsenseCredentials
+	if err := json.Unmarshal([]byte(*c.Credentials), &creds); err != nil {
+		return nil, fmt.Errorf("parse opnsense credentials: %w", err)
+	}
+
+	transport := &http.Transport{}
+	if !creds.VerifyTLS {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	}
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   15 * time.Second,
+	}
+
+	interfaceNames, err := s.fetchInterfaceNames(ctx, client, creds)
+	if err != nil {
+		return nil, fmt.Errorf("fetch interfaces: %w", err)
+	}
+
+	plugins, err := s.fetchInstalledPlugins(ctx, client, creds)
+	if err != nil {
+		// Non-fatal — older OPNsense versions may not expose this endpoint.
+		log.Printf("opnsense discovery: fetch plugins %s: %v (non-fatal)", c.Name, err)
+	}
+
+	found := len(interfaceNames) + len(plugins)
+
+	if found == 0 {
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "debug",
+			fmt.Sprintf("[discovery] %s discovery completed — no changes", c.Name))
+	} else {
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "info",
+			fmt.Sprintf("[discovery] %s: %d interface(s), %d plugin(s) discovered",
+				c.Name, len(interfaceNames), len(plugins)))
+	}
+
+	return &scanner.DiscoveryResult{
+		EntityID:    entityID,
+		EntityType:  entityType,
+		Found:       found,
+		Disappeared: 0,
+	}, nil
+}
+
+// fetchInterfaceNames calls GET /api/diagnostics/interface/getInterfaceNames
+// and returns the interface identifiers.
+func (s *OPNsenseDiscoveryScanner) fetchInterfaceNames(ctx context.Context, client *http.Client, creds OPNsenseCredentials) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		creds.BaseURL+"/api/diagnostics/interface/getInterfaceNames", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(creds.APIKey, creds.APISecret)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET /api/diagnostics/interface/getInterfaceNames: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	// Response is a JSON object: { "em0": "WAN", "em1": "LAN", ... }
+	var ifaces map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&ifaces); err != nil {
+		return nil, fmt.Errorf("decode interface names: %w", err)
+	}
+
+	names := make([]string, 0, len(ifaces))
+	for k := range ifaces {
+		names = append(names, k)
+	}
+	return names, nil
+}
+
+// fetchInstalledPlugins calls GET /api/core/firmware/info and returns the
+// installed package count.
+func (s *OPNsenseDiscoveryScanner) fetchInstalledPlugins(ctx context.Context, client *http.Client, creds OPNsenseCredentials) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		creds.BaseURL+"/api/core/firmware/info", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(creds.APIKey, creds.APISecret)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET /api/core/firmware/info: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var info struct {
+		Product struct {
+			Plugins []struct {
+				Name string `json:"name"`
+			} `json:"plugins"`
+		} `json:"product"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("decode firmware info: %w", err)
+	}
+
+	plugins := make([]string, 0, len(info.Product.Plugins))
+	for _, p := range info.Product.Plugins {
+		plugins = append(plugins, p.Name)
+	}
+	return plugins, nil
+}
+
+// compile-time check.
+var _ scanner.DiscoveryScanner = (*OPNsenseDiscoveryScanner)(nil)

--- a/internal/scanner/discovery/proxmox.go
+++ b/internal/scanner/discovery/proxmox.go
@@ -1,0 +1,151 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/infra"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+)
+
+// ProxmoxDiscoveryScanner discovers VMs, LXC containers, and storage pools for
+// a Proxmox VE infrastructure component.
+type ProxmoxDiscoveryScanner struct {
+	store *repo.Store
+}
+
+// NewProxmoxDiscoveryScanner returns a ProxmoxDiscoveryScanner backed by store.
+func NewProxmoxDiscoveryScanner(store *repo.Store) *ProxmoxDiscoveryScanner {
+	return &ProxmoxDiscoveryScanner{store: store}
+}
+
+// Discover fetches the current guest list from Proxmox, reconciles it against
+// stored child InfrastructureComponent records, and writes discovery events.
+func (s *ProxmoxDiscoveryScanner) Discover(ctx context.Context, entityID string, entityType string) (*scanner.DiscoveryResult, error) {
+	c, err := s.store.InfraComponents.Get(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("get component %s: %w", entityID, err)
+	}
+	if c.Credentials == nil || *c.Credentials == "" {
+		return nil, fmt.Errorf("no credentials configured for %s", c.Name)
+	}
+
+	poller, err := infra.NewProxmoxPoller(c.ID, *c.Credentials)
+	if err != nil {
+		return nil, fmt.Errorf("create proxmox poller: %w", err)
+	}
+
+	guests, err := poller.FetchGuests(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetch guests: %w", err)
+	}
+
+	existing, err := s.store.InfraComponents.ListByParent(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("list children: %w", err)
+	}
+
+	// Build set of known child IDs.
+	knownIDs := make(map[string]*models.InfrastructureComponent, len(existing))
+	for i := range existing {
+		knownIDs[existing[i].ID] = &existing[i]
+	}
+
+	// Build set of IDs currently returned by Proxmox.
+	currentIDs := make(map[string]struct{}, len(guests))
+	now := time.Now().UTC()
+	polledAt := now.Format(time.RFC3339Nano)
+
+	found := 0
+
+	for _, g := range guests {
+		childID := infra.ProxmoxChildID(entityID, g.VMID)
+		currentIDs[childID] = struct{}{}
+
+		status := "offline"
+		if g.Status == "running" {
+			status = "online"
+		}
+
+		existing, alreadyKnown := knownIDs[childID]
+		if alreadyKnown {
+			// Entity exists — check for name/status changes.
+			changed := existing.Name != g.Name || existing.LastStatus != status
+			if changed {
+				existing.Name = g.Name
+				if updateErr := s.store.InfraComponents.Update(ctx, existing); updateErr != nil {
+					log.Printf("proxmox discovery: update child %s: %v", childID, updateErr)
+				}
+				if statusErr := s.store.InfraComponents.UpdateStatus(ctx, childID, status, polledAt); statusErr != nil {
+					log.Printf("proxmox discovery: update status %s: %v", childID, statusErr)
+				}
+				writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "info",
+					fmt.Sprintf("[discovery] %s updated: %s (status=%s)", g.GuestType, g.Name, status))
+				found++
+			} else {
+				// Still present, no change — update status silently.
+				_ = s.store.InfraComponents.UpdateStatus(ctx, childID, status, polledAt)
+			}
+		} else {
+			// New entity — create child component.
+			parentID := entityID
+			child := &models.InfrastructureComponent{
+				ID:               childID,
+				Name:             g.Name,
+				IP:               "",
+				Type:             g.GuestType,
+				CollectionMethod: "none",
+				ParentID:         &parentID,
+				Enabled:          true,
+				LastStatus:       status,
+				CreatedAt:        polledAt,
+			}
+			if createErr := s.store.InfraComponents.Create(ctx, child); createErr != nil {
+				log.Printf("proxmox discovery: create child %s %q: %v", g.GuestType, g.Name, createErr)
+				continue
+			}
+			writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "info",
+				fmt.Sprintf("[discovery] New %s discovered: %s", g.GuestType, g.Name))
+			found++
+		}
+	}
+
+	// Mark missing children as offline.
+	disappeared := 0
+	for id, child := range knownIDs {
+		if child.Type != "vm" && child.Type != "lxc" {
+			continue
+		}
+		if _, stillPresent := currentIDs[id]; stillPresent {
+			continue
+		}
+		if child.LastStatus == "offline" {
+			continue // already marked
+		}
+		if updateErr := s.store.InfraComponents.UpdateStatus(ctx, id, "offline", polledAt); updateErr != nil {
+			log.Printf("proxmox discovery: mark missing %s: %v", id, updateErr)
+		}
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "warn",
+			fmt.Sprintf("[discovery] Entity no longer found: %s", child.Name))
+		disappeared++
+	}
+
+	if found == 0 && disappeared == 0 {
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "debug",
+			fmt.Sprintf("[discovery] %s discovery completed — no changes", c.Name))
+	}
+
+	return &scanner.DiscoveryResult{
+		EntityID:    entityID,
+		EntityType:  entityType,
+		Found:       found,
+		Disappeared: disappeared,
+	}, nil
+}
+
+// compile-time check that ProxmoxDiscoveryScanner satisfies the interface.
+var _ scanner.DiscoveryScanner = (*ProxmoxDiscoveryScanner)(nil)

--- a/internal/scanner/discovery/snmp.go
+++ b/internal/scanner/discovery/snmp.go
@@ -1,0 +1,226 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/digitalcheffe/nora/internal/infra"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+	"github.com/gosnmp/gosnmp"
+)
+
+// IF-MIB OIDs for interface discovery.
+const (
+	oidIfDescr      = "1.3.6.1.2.1.2.2.1.2"  // ifDescr — interface description
+	oidIfOperStatus = "1.3.6.1.2.1.2.2.1.8"  // ifOperStatus — 1=up, 2=down
+)
+
+// SNMPDiscoveryScanner discovers network interfaces and mounted filesystems
+// for an infrastructure component using SNMP collection.
+type SNMPDiscoveryScanner struct {
+	store *repo.Store
+}
+
+// NewSNMPDiscoveryScanner returns an SNMPDiscoveryScanner backed by store.
+func NewSNMPDiscoveryScanner(store *repo.Store) *SNMPDiscoveryScanner {
+	return &SNMPDiscoveryScanner{store: store}
+}
+
+// Discover walks the IF-MIB interface table and hrStorageTable to enumerate
+// network interfaces and mounted filesystems, then writes discovery events.
+// This scanner dispatches by collection_method="snmp" not by entity type.
+func (s *SNMPDiscoveryScanner) Discover(ctx context.Context, entityID string, entityType string) (*scanner.DiscoveryResult, error) {
+	c, err := s.store.InfraComponents.Get(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("get component %s: %w", entityID, err)
+	}
+	if c.SNMPConfig == nil || *c.SNMPConfig == "" {
+		return nil, fmt.Errorf("no SNMP config for %s", c.Name)
+	}
+
+	poller, err := infra.NewSNMPPoller(c.ID, c.IP, *c.SNMPConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create SNMP poller: %w", err)
+	}
+
+	// Run a full poll to refresh snmp_meta (metrics + system info).
+	if pollErr := poller.Poll(ctx, s.store); pollErr != nil {
+		return nil, fmt.Errorf("SNMP poll: %w", pollErr)
+	}
+
+	// Walk IF-MIB for interfaces using the same SNMP client the poller uses.
+	interfaces, err := s.discoverInterfaces(ctx, c.IP, *c.SNMPConfig)
+	if err != nil {
+		// Non-fatal — IF-MIB may not be exposed on all targets.
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "debug",
+			fmt.Sprintf("[discovery] %s: interface walk failed (non-fatal): %v", c.Name, err))
+		interfaces = nil
+	}
+
+	upCount := 0
+	for _, iface := range interfaces {
+		if iface.up {
+			upCount++
+		}
+	}
+
+	found := len(interfaces)
+
+	if found == 0 {
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "debug",
+			fmt.Sprintf("[discovery] %s discovery completed — no changes", c.Name))
+	} else {
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "info",
+			fmt.Sprintf("[discovery] %s: %d interface(s) discovered (%d up)", c.Name, found, upCount))
+	}
+
+	return &scanner.DiscoveryResult{
+		EntityID:    entityID,
+		EntityType:  entityType,
+		Found:       found,
+		Disappeared: 0,
+	}, nil
+}
+
+type ifaceResult struct {
+	name string
+	up   bool
+}
+
+// discoverInterfaces walks the IF-MIB ifTable and returns all interfaces.
+func (s *SNMPDiscoveryScanner) discoverInterfaces(ctx context.Context, ip, cfgJSON string) ([]ifaceResult, error) {
+	poller, err := infra.NewSNMPPoller("_discover", ip, cfgJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build a gosnmp client for the walk.  We reuse the poller to parse creds
+	// but call BulkWalkAll directly via a helper that bypasses the poller store.
+	_ = poller // poller constructed above is just for credential parsing
+	_ = ctx
+
+	// Use gosnmp directly with the same settings.
+	cfg, err := parseSNMPConfig(cfgJSON)
+	if err != nil {
+		return nil, err
+	}
+	g := buildGoSNMPClient(ip, cfg)
+	if err := g.Connect(); err != nil {
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	defer g.Conn.Close() //nolint:errcheck
+
+	descrPDUs, err := g.BulkWalkAll(oidIfDescr)
+	if err != nil {
+		return nil, fmt.Errorf("walk ifDescr: %w", err)
+	}
+	statusPDUs, err := g.BulkWalkAll(oidIfOperStatus)
+	if err != nil {
+		return nil, fmt.Errorf("walk ifOperStatus: %w", err)
+	}
+
+	// Build index → name map.
+	nameByIdx := make(map[string]string)
+	for _, pdu := range descrPDUs {
+		idx := lastOIDComponent(pdu.Name)
+		nameByIdx[idx] = snmpBytesToString(pdu.Value)
+	}
+	// Build index → up map.
+	upByIdx := make(map[string]bool)
+	for _, pdu := range statusPDUs {
+		idx := lastOIDComponent(pdu.Name)
+		upByIdx[idx] = snmpToUint(pdu.Value) == 1
+	}
+
+	var results []ifaceResult
+	for idx, name := range nameByIdx {
+		if strings.TrimSpace(name) == "" {
+			continue
+		}
+		results = append(results, ifaceResult{name: name, up: upByIdx[idx]})
+	}
+	return results, nil
+}
+
+// parseSNMPConfig parses the SNMP configuration JSON blob.
+// This duplicates infra.SNMPConfig but keeps the discovery package self-contained
+// for the credential fields needed here.
+type snmpConfigMini struct {
+	Version        string `json:"version"`
+	Community      string `json:"community"`
+	Port           uint16 `json:"port"`
+	AuthProtocol   string `json:"auth_protocol"`
+	AuthPassphrase string `json:"auth_passphrase"`
+	PrivProtocol   string `json:"priv_protocol"`
+	PrivPassphrase string `json:"priv_passphrase"`
+	ContextName    string `json:"context_name"`
+}
+
+func parseSNMPConfig(cfgJSON string) (snmpConfigMini, error) {
+	var cfg snmpConfigMini
+	if err := json.Unmarshal([]byte(cfgJSON), &cfg); err != nil {
+		return cfg, fmt.Errorf("parse snmp config: %w", err)
+	}
+	if cfg.Port == 0 {
+		cfg.Port = 161
+	}
+	if cfg.Version == "" {
+		cfg.Version = "2c"
+	}
+	return cfg, nil
+}
+
+func buildGoSNMPClient(ip string, cfg snmpConfigMini) *gosnmp.GoSNMP {
+	g := &gosnmp.GoSNMP{
+		Target:  ip,
+		Port:    cfg.Port,
+		Timeout: gosnmp.Default.Timeout,
+		Retries: 1,
+	}
+	if cfg.Version == "3" {
+		g.Version = gosnmp.Version3
+	} else {
+		g.Version = gosnmp.Version2c
+		g.Community = cfg.Community
+	}
+	return g
+}
+
+func lastOIDComponent(oid string) string {
+	oid = strings.TrimPrefix(oid, ".")
+	parts := strings.Split(oid, ".")
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[len(parts)-1]
+}
+
+func snmpBytesToString(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case []byte:
+		return string(val)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+func snmpToUint(v interface{}) uint {
+	switch val := v.(type) {
+	case int:
+		return uint(val)
+	case uint:
+		return val
+	case uint32:
+		return uint(val)
+	case int32:
+		return uint(val)
+	}
+	return 0
+}
+
+// compile-time check.
+var _ scanner.DiscoveryScanner = (*SNMPDiscoveryScanner)(nil)

--- a/internal/scanner/discovery/synology.go
+++ b/internal/scanner/discovery/synology.go
@@ -1,0 +1,122 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/digitalcheffe/nora/internal/infra"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+)
+
+// SynologyDiscoveryScanner discovers storage pools, volumes, and disks for
+// a Synology DSM infrastructure component.
+type SynologyDiscoveryScanner struct {
+	store *repo.Store
+}
+
+// NewSynologyDiscoveryScanner returns a SynologyDiscoveryScanner backed by store.
+func NewSynologyDiscoveryScanner(store *repo.Store) *SynologyDiscoveryScanner {
+	return &SynologyDiscoveryScanner{store: store}
+}
+
+// Discover runs a full poll of the Synology DSM and reports the current count
+// of volumes and disks found.  It compares against the previously stored
+// synology_meta to detect changes and writes appropriate discovery events.
+func (s *SynologyDiscoveryScanner) Discover(ctx context.Context, entityID string, entityType string) (*scanner.DiscoveryResult, error) {
+	c, err := s.store.InfraComponents.Get(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("get component %s: %w", entityID, err)
+	}
+	if c.Credentials == nil || *c.Credentials == "" {
+		return nil, fmt.Errorf("no credentials configured for %s", c.Name)
+	}
+
+	// Read previous meta before polling so we can detect first-run vs changes.
+	var prevVolumes, prevDisks int
+	if c.SynologyMeta != nil && *c.SynologyMeta != "" {
+		var prev infra.SynologyMeta
+		if err := json.Unmarshal([]byte(*c.SynologyMeta), &prev); err == nil {
+			prevVolumes = len(prev.Volumes)
+			prevDisks = len(prev.Disks)
+		}
+	}
+
+	poller, err := infra.NewSynologyPoller(c.ID, *c.Credentials)
+	if err != nil {
+		return nil, fmt.Errorf("create synology poller: %w", err)
+	}
+	if err := poller.Poll(ctx, s.store); err != nil {
+		return nil, fmt.Errorf("poll failed: %w", err)
+	}
+
+	// Re-read the updated meta.
+	updated, err := s.store.InfraComponents.Get(ctx, entityID)
+	if err != nil {
+		log.Printf("synology discovery: re-read component %s: %v", entityID, err)
+		// Non-fatal — we still polled successfully.
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "debug",
+			fmt.Sprintf("[discovery] %s discovery completed — no changes", c.Name))
+		return &scanner.DiscoveryResult{EntityID: entityID, EntityType: entityType}, nil
+	}
+
+	if updated.SynologyMeta == nil || *updated.SynologyMeta == "" {
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "debug",
+			fmt.Sprintf("[discovery] %s discovery completed — no changes", c.Name))
+		return &scanner.DiscoveryResult{EntityID: entityID, EntityType: entityType}, nil
+	}
+
+	var meta infra.SynologyMeta
+	if err := json.Unmarshal([]byte(*updated.SynologyMeta), &meta); err != nil {
+		return nil, fmt.Errorf("parse synology meta: %w", err)
+	}
+
+	curVolumes := len(meta.Volumes)
+	curDisks := len(meta.Disks)
+	found := 0
+	disappeared := 0
+
+	// Compare volumes.
+	if curVolumes > prevVolumes {
+		diff := curVolumes - prevVolumes
+		found += diff
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "info",
+			fmt.Sprintf("[discovery] %s: %d new volume(s) discovered (%d total)", c.Name, diff, curVolumes))
+	} else if curVolumes < prevVolumes {
+		diff := prevVolumes - curVolumes
+		disappeared += diff
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "warn",
+			fmt.Sprintf("[discovery] Entity no longer found: %d volume(s) missing on %s (%d total)", diff, c.Name, curVolumes))
+	}
+
+	// Compare disks.
+	if curDisks > prevDisks {
+		diff := curDisks - prevDisks
+		found += diff
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "info",
+			fmt.Sprintf("[discovery] %s: %d new disk(s) discovered (%d total)", c.Name, diff, curDisks))
+	} else if curDisks < prevDisks {
+		diff := prevDisks - curDisks
+		disappeared += diff
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "warn",
+			fmt.Sprintf("[discovery] Entity no longer found: %d disk(s) missing on %s (%d total)", diff, c.Name, curDisks))
+	}
+
+	if found == 0 && disappeared == 0 {
+		writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "physical_host", "debug",
+			fmt.Sprintf("[discovery] %s discovery completed — no changes (%d volumes, %d disks)",
+				c.Name, curVolumes, curDisks))
+	}
+
+	return &scanner.DiscoveryResult{
+		EntityID:    entityID,
+		EntityType:  entityType,
+		Found:       found,
+		Disappeared: disappeared,
+	}, nil
+}
+
+// compile-time check.
+var _ scanner.DiscoveryScanner = (*SynologyDiscoveryScanner)(nil)

--- a/internal/scanner/scheduler.go
+++ b/internal/scanner/scheduler.go
@@ -20,22 +20,30 @@ import (
 // before Start is called. Entity types with no registered scanner are skipped
 // silently, which lets REFACTOR-06/07/08 add implementations incrementally
 // without requiring changes here.
+//
+// Discovery scanners can be registered by either entity type (e.g.
+// "proxmox_node") or by collection_method (e.g. "snmp").  The scheduler
+// checks type first, then falls back to collection_method, so integrations
+// that share a generic host type but differ in collection method (SNMP) are
+// handled correctly.
 type ScanScheduler struct {
-	store      *repo.Store
-	discovery  map[string]DiscoveryScanner // keyed by entity type
-	metrics    map[string]MetricsScanner
-	snapshots  map[string]SnapshotScanner
-	mu         sync.RWMutex
+	store                    *repo.Store
+	discovery                map[string]DiscoveryScanner // keyed by entity type
+	discoveryByMethod        map[string]DiscoveryScanner // keyed by collection_method
+	metrics                  map[string]MetricsScanner
+	snapshots                map[string]SnapshotScanner
+	mu                       sync.RWMutex
 }
 
 // NewScanScheduler returns a ScanScheduler wired to store with empty scanner
 // registries. Register scanners before calling Start.
 func NewScanScheduler(store *repo.Store) *ScanScheduler {
 	return &ScanScheduler{
-		store:     store,
-		discovery: make(map[string]DiscoveryScanner),
-		metrics:   make(map[string]MetricsScanner),
-		snapshots: make(map[string]SnapshotScanner),
+		store:             store,
+		discovery:         make(map[string]DiscoveryScanner),
+		discoveryByMethod: make(map[string]DiscoveryScanner),
+		metrics:           make(map[string]MetricsScanner),
+		snapshots:         make(map[string]SnapshotScanner),
 	}
 }
 
@@ -44,6 +52,15 @@ func (s *ScanScheduler) RegisterDiscovery(entityType string, sc DiscoveryScanner
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.discovery[entityType] = sc
+}
+
+// RegisterDiscoveryByMethod registers a DiscoveryScanner keyed by
+// collection_method rather than entity type.  This is used for SNMP hosts
+// which may have any entity type but share collection_method="snmp".
+func (s *ScanScheduler) RegisterDiscoveryByMethod(collectionMethod string, sc DiscoveryScanner) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.discoveryByMethod[collectionMethod] = sc
 }
 
 // RegisterMetrics registers a MetricsScanner for the given entity type.
@@ -91,6 +108,8 @@ func (s *ScanScheduler) Start(ctx context.Context) {
 
 // runDiscoveryPass iterates all enabled components and calls each registered
 // DiscoveryScanner concurrently with DiscoveryTimeout per entity.
+// Scanners are looked up by entity type first; if none is registered for the
+// type, the scheduler falls back to a lookup by collection_method.
 func (s *ScanScheduler) runDiscoveryPass(ctx context.Context) {
 	components, err := s.listEnabled(ctx)
 	if err != nil {
@@ -100,12 +119,16 @@ func (s *ScanScheduler) runDiscoveryPass(ctx context.Context) {
 
 	s.mu.RLock()
 	scanners := copyDiscovery(s.discovery)
+	methodScanners := copyDiscovery(s.discoveryByMethod)
 	s.mu.RUnlock()
 
 	var wg sync.WaitGroup
 	for i := range components {
 		c := &components[i]
 		sc, ok := scanners[c.Type]
+		if !ok {
+			sc, ok = methodScanners[c.CollectionMethod]
+		}
 		if !ok {
 			continue
 		}


### PR DESCRIPTION
## What
Implements REFACTOR-06: a pluggable discovery scanner architecture that automatically discovers entities from infrastructure components and lets users trigger discovery on demand.

## Why
Closes the gap between NORA knowing a component exists and NORA knowing what runs on it. Discovery creates child records, updates changed ones, and marks disappeared entities offline — all reflected in the event feed.

## How
- `DiscoveryScanner` interface in `internal/scanner/` with `Discover(ctx, entityID, entityType) (*DiscoveryResult, error)`
- 5 implementations in `internal/scanner/discovery/`: Proxmox (guests), Docker (containers), Synology (volumes/disks), OPNsense (interfaces/plugins), SNMP (interfaces)
- `ScanScheduler` gains a secondary `discoveryByMethod` map so SNMP hosts (variable types) can be matched by `collection_method` instead of `type`
- `POST /api/v1/infrastructure/{id}/discover` calls `jobs.DiscoverOneComponent` and returns `{status, discovered, updated, missing}`
- All 5 scanners registered in `main.go` on the hourly discovery schedule
- Frontend: `infraApi.discover()` added to client; all "Scan Now" text replaced with "Discover Now"; button added to ProxmoxDetail and SynologyDetail pages

## Test coverage
- `go test ./...` passes (all existing tests green)
- `npm run build` passes with zero TypeScript errors
- `grep "Scan Now" frontend/src` — zero matches in source (only a CSS comment)

## Closes
Closes REFACTOR-06