### PR TITLE
feat: metrics scanner — 2-minute collection with threshold events (REFACTOR-07)

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/digitalcheffe/nora/internal/scanner"
 	"github.com/digitalcheffe/nora/internal/scanner/discovery"
+	noraMetrics "github.com/digitalcheffe/nora/internal/scanner/metrics"
 	"github.com/digitalcheffe/nora/migrations"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -110,17 +111,31 @@ func main() {
 	go monitor.NewScheduler(store).Start(schedCtx)
 
 	// Scan scheduler — Discovery (1h), Metrics (2m), Snapshots (30m).
-	// Discovery scanners are registered here by entity type (and collection
-	// method for SNMP).  Metrics and Snapshot scanners are added in
-	// REFACTOR-07 and REFACTOR-08.
+	// Discovery scanners are registered by entity type (and collection method
+	// for SNMP).  Metrics scanners are registered here (REFACTOR-07).
+	// Snapshot scanners are added in REFACTOR-08.
+	//
+	// Note: the Docker MetricsScanner is wired to the ResourcePoller created
+	// below so they share the same poller instance; the poller's standalone
+	// Start() ticker is therefore NOT started — the scan scheduler drives it.
 	scanCtx, scanCancel := context.WithCancel(context.Background())
 	defer scanCancel()
 	scanScheduler := scanner.NewScanScheduler(store)
+
+	// Discovery
 	scanScheduler.RegisterDiscovery("proxmox_node", discovery.NewProxmoxDiscoveryScanner(store))
 	scanScheduler.RegisterDiscovery("docker_engine", discovery.NewDockerDiscoveryScanner(store))
 	scanScheduler.RegisterDiscovery("synology", discovery.NewSynologyDiscoveryScanner(store))
 	scanScheduler.RegisterDiscovery("opnsense", discovery.NewOPNsenseDiscoveryScanner(store))
 	scanScheduler.RegisterDiscoveryByMethod("snmp", discovery.NewSNMPDiscoveryScanner(store))
+
+	// Metrics (REFACTOR-07)
+	scanScheduler.RegisterMetrics("proxmox_node", noraMetrics.NewProxmoxMetricsScanner(store))
+	scanScheduler.RegisterMetrics("synology", noraMetrics.NewSynologyMetricsScanner(store))
+	scanScheduler.RegisterMetrics("opnsense", noraMetrics.NewOPNsenseMetricsScanner(store))
+	scanScheduler.RegisterMetricsByMethod("snmp", noraMetrics.NewSNMPMetricsScanner(store))
+	// Docker MetricsScanner is wired after the ResourcePoller is created below.
+
 	go scanScheduler.Start(scanCtx)
 
 	// Resource rollup jobs — hourly aggregation and daily rollup + retention purge.
@@ -204,10 +219,15 @@ func main() {
 		go watcher.Start(dockerCtx)
 	}
 
-	if poller, err := docker.NewResourcePoller(store, localEngineID); err != nil {
+	// Docker ResourcePoller — metrics collection is driven by the scan scheduler
+	// (every 2 minutes via DockerMetricsScanner) rather than a standalone ticker.
+	// The poller is registered with the scheduler so PollAll is called on the
+	// MetricsInterval instead of the legacy 60-second loop.
+	if resourcePoller, err := docker.NewResourcePoller(store, localEngineID); err != nil {
 		log.Printf("resource poller: socket not available, skipping (%v)", err)
 	} else {
-		go poller.Start(dockerCtx)
+		scanScheduler.RegisterMetrics("docker_engine",
+			noraMetrics.NewDockerMetricsScanner(store, localEngineID, resourcePoller))
 	}
 
 	// Router

--- a/internal/infra/proxmox.go
+++ b/internal/infra/proxmox.go
@@ -137,6 +137,81 @@ func (p *ProxmoxPoller) get(ctx context.Context, path string, out interface{}) e
 	return json.Unmarshal(env.Data, out)
 }
 
+// ── Metrics-only collection ───────────────────────────────────────────────────
+
+// ProxmoxNodeMetrics holds the raw metric values collected for one Proxmox node.
+// The caller (MetricsScanner) is responsible for writing these to resource_readings
+// and applying threshold rules.
+type ProxmoxNodeMetrics struct {
+	Node        string
+	CPUPercent  float64
+	MemPercent  float64
+	MemUsedGB   float64
+	MemTotalGB  float64
+	DiskPercent float64
+}
+
+// CollectNodeMetrics fetches CPU%, memory, and disk metrics for each node in the
+// cluster and returns them as raw values without writing to the database.
+// It returns the list of nodes found and any partial errors encountered.
+func (p *ProxmoxPoller) CollectNodeMetrics(ctx context.Context) ([]ProxmoxNodeMetrics, error) {
+	var nodes []proxmoxNode
+	if err := p.get(ctx, "/api2/json/nodes", &nodes); err != nil {
+		return nil, fmt.Errorf("list nodes: %w", err)
+	}
+
+	var results []ProxmoxNodeMetrics
+	for _, node := range nodes {
+		m, err := p.fetchNodeMetrics(ctx, node.Node)
+		if err != nil {
+			log.Printf("proxmox metrics %s: node %s: %v", p.componentID, node.Node, err)
+			continue
+		}
+		results = append(results, m)
+	}
+	return results, nil
+}
+
+func (p *ProxmoxPoller) fetchNodeMetrics(ctx context.Context, node string) (ProxmoxNodeMetrics, error) {
+	var status proxmoxNodeStatus
+	if err := p.get(ctx, fmt.Sprintf("/api2/json/nodes/%s/status", node), &status); err != nil {
+		return ProxmoxNodeMetrics{}, fmt.Errorf("node status: %w", err)
+	}
+
+	cpuPercent := status.CPU * 100
+	var memPercent, memUsedGB, memTotalGB float64
+	if status.Memory.Total > 0 {
+		memPercent = (status.Memory.Used / status.Memory.Total) * 100
+		memUsedGB = status.Memory.Used / (1024 * 1024 * 1024)
+		memTotalGB = status.Memory.Total / (1024 * 1024 * 1024)
+	}
+
+	var storages []proxmoxStorage
+	var diskPercent float64
+	if err := p.get(ctx, fmt.Sprintf("/api2/json/nodes/%s/storage", node), &storages); err == nil {
+		var usedTotal, sizeTotal float64
+		for _, s := range storages {
+			if s.Active == 0 {
+				continue
+			}
+			usedTotal += s.Used
+			sizeTotal += s.Total
+		}
+		if sizeTotal > 0 {
+			diskPercent = (usedTotal / sizeTotal) * 100
+		}
+	}
+
+	return ProxmoxNodeMetrics{
+		Node:        node,
+		CPUPercent:  cpuPercent,
+		MemPercent:  memPercent,
+		MemUsedGB:   memUsedGB,
+		MemTotalGB:  memTotalGB,
+		DiskPercent: diskPercent,
+	}, nil
+}
+
 // ── Poll ──────────────────────────────────────────────────────────────────────
 
 // Poll runs one full poll cycle: fetches all nodes, records metrics, and fires

--- a/internal/infra/snmp.go
+++ b/internal/infra/snmp.go
@@ -188,6 +188,68 @@ func snmpPrivProtocol(s string) gosnmp.SnmpV3PrivProtocol {
 	}
 }
 
+// ── Metrics-only collection ───────────────────────────────────────────────────
+
+// SNMPDiskReading holds the utilisation for a single disk from HOST-RESOURCES-MIB.
+type SNMPDiskReading struct {
+	Label   string  // original hrStorageDescr (e.g. "/", "C:")
+	Percent float64 // disk_percent value
+}
+
+// SNMPMetricsSnapshot holds the raw metric values collected in one SNMP pass.
+// The MetricsScanner uses this to write resource_readings and apply thresholds.
+type SNMPMetricsSnapshot struct {
+	CPUPercent float64
+	MemPercent float64
+	MemUsedGB  float64
+	MemTotalGB float64
+	Disks      []SNMPDiskReading
+	Uptime     string
+}
+
+// CollectMetrics opens an SNMP connection, reads CPU, memory, disk, and uptime,
+// and returns raw values without any database writes or status updates.
+func (p *SNMPPoller) CollectMetrics(ctx context.Context) (*SNMPMetricsSnapshot, error) {
+	client := p.newClient()
+	if err := client.Connect(); err != nil {
+		return nil, fmt.Errorf("snmp connect %s: %w", p.ip, err)
+	}
+	defer client.Close() //nolint:errcheck
+
+	snap := &SNMPMetricsSnapshot{}
+
+	// System info — uptime
+	if sysInfo, err := p.pollSystemInfo(client); err == nil {
+		snap.Uptime = sysInfo.Uptime
+	}
+
+	// CPU
+	if cpuPct, err := p.pollCPU(client); err != nil {
+		log.Printf("snmp metrics %s: cpu: %v", p.componentID, err)
+	} else {
+		snap.CPUPercent = cpuPct
+	}
+
+	// Storage (memory + disks)
+	if rows, err := p.walkStorageTable(client); err != nil {
+		log.Printf("snmp metrics %s: storage: %v", p.componentID, err)
+	} else {
+		if mem, ok := computeMemResult(rows); ok {
+			snap.MemPercent = mem.percent
+			snap.MemUsedGB = float64(mem.usedBytes) / (1024 * 1024 * 1024)
+			snap.MemTotalGB = float64(mem.totalBytes) / (1024 * 1024 * 1024)
+		}
+		for _, d := range computeDiskResults(rows) {
+			snap.Disks = append(snap.Disks, SNMPDiskReading{
+				Label:   d.label,
+				Percent: d.percent,
+			})
+		}
+	}
+
+	return snap, nil
+}
+
 // ── Poll ──────────────────────────────────────────────────────────────────────
 
 // Poll opens an SNMP connection, collects system identity + CPU / memory / disk
@@ -557,6 +619,12 @@ func snmpToString(v interface{}) string {
 
 // sanitizeDiskLabel converts a storage description to a safe metric-name suffix.
 // Examples: "/" → "root", "C:\\" → "c", "Label /dev/sda1" → "label__dev_sda1"
+// SanitizeDiskLabel is the exported form of sanitizeDiskLabel, used by the
+// metrics scanner package which lives outside the infra package.
+func SanitizeDiskLabel(s string) string {
+	return sanitizeDiskLabel(s)
+}
+
 func sanitizeDiskLabel(s string) string {
 	s = strings.TrimSpace(s)
 	if s == "/" {

--- a/internal/infra/synology.go
+++ b/internal/infra/synology.go
@@ -380,6 +380,97 @@ func (p *SynologyPoller) doGet(ctx context.Context, sid string, params url.Value
 	return &env, nil
 }
 
+// ── Metrics-only collection ───────────────────────────────────────────────────
+
+// SynologyMetricsSnapshot holds the raw metric values collected in one pass.
+// The MetricsScanner uses this to write resource_readings and apply thresholds.
+type SynologyMetricsSnapshot struct {
+	CPUPercent  float64
+	MemPercent  float64
+	MemUsedGB   float64
+	MemTotalGB  float64
+	TempC       int
+	VolumeStats []SynologyVolumeMetric
+}
+
+// SynologyVolumeMetric holds utilization for a single DSM volume.
+type SynologyVolumeMetric struct {
+	Key         string // sanitised vol_path used as metric suffix
+	DiskPercent float64
+}
+
+// CollectMetrics fetches CPU%, memory, temperature, and volume utilisation from
+// DSM and returns raw values without any database writes or status updates.
+// Uses the cached session, re-authenticating if the SID has expired.
+func (p *SynologyPoller) CollectMetrics(ctx context.Context) (*SynologyMetricsSnapshot, error) {
+	snap := &SynologyMetricsSnapshot{}
+
+	// System info — temperature
+	sysParams := url.Values{}
+	sysParams.Set("api", "SYNO.Core.System")
+	sysParams.Set("version", "1")
+	sysParams.Set("method", "info")
+	var info synoCoreSystemInfo
+	if err := p.get(ctx, sysParams, &info); err != nil {
+		return nil, fmt.Errorf("system info: %w", err)
+	}
+	snap.TempC = info.Temperature
+
+	// CPU + memory utilisation
+	utilParams := url.Values{}
+	utilParams.Set("api", "SYNO.Core.System.Utilization")
+	utilParams.Set("version", "1")
+	utilParams.Set("method", "get")
+	var util synoUtilization
+	if err := p.get(ctx, utilParams, &util); err != nil {
+		log.Printf("synology metrics %s: utilization: %v (non-fatal)", p.componentID, err)
+	} else {
+		snap.CPUPercent = util.CPU.UserLoad
+		snap.MemPercent = util.Memory.RealUsage
+		totalBytes := util.Memory.RealTotal * 1024
+		availBytes := util.Memory.AvailReal * 1024
+		usedBytes := totalBytes - availBytes
+		if usedBytes < 0 {
+			usedBytes = 0
+		}
+		snap.MemUsedGB = float64(usedBytes) / (1024 * 1024 * 1024)
+		snap.MemTotalGB = float64(totalBytes) / (1024 * 1024 * 1024)
+	}
+
+	// Volume utilisation
+	volParams := url.Values{}
+	volParams.Set("api", "SYNO.Core.System")
+	volParams.Set("version", "1")
+	volParams.Set("method", "info")
+	volParams.Set("type", "storage")
+	var storageData synoCoreSystemStorage
+	if err := p.get(ctx, volParams, &storageData); err != nil {
+		log.Printf("synology metrics %s: volumes: %v (non-fatal)", p.componentID, err)
+	} else {
+		for _, vol := range storageData.VolInfo {
+			total, err := strconv.ParseInt(vol.TotalSize, 10, 64)
+			if err != nil || total == 0 {
+				continue
+			}
+			used, err := strconv.ParseInt(vol.UsedSize, 10, 64)
+			if err != nil {
+				continue
+			}
+			pct := (float64(used) / float64(total)) * 100
+			volKey := strings.TrimLeft(vol.VolPath, "/")
+			if volKey == "" {
+				volKey = "unknown"
+			}
+			snap.VolumeStats = append(snap.VolumeStats, SynologyVolumeMetric{
+				Key:         volKey,
+				DiskPercent: pct,
+			})
+		}
+	}
+
+	return snap, nil
+}
+
 // ── Poll ──────────────────────────────────────────────────────────────────────
 
 // Poll runs one full cycle: system info, CPU/memory, volumes, disks, and updates.

--- a/internal/scanner/metrics/docker.go
+++ b/internal/scanner/metrics/docker.go
@@ -1,0 +1,56 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/digitalcheffe/nora/internal/docker"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+)
+
+// DockerMetricsScanner collects CPU% and memory metrics from all running
+// containers on a Docker engine. It delegates to docker.ResourcePoller which
+// already implements stable source IDs, threshold events, and per-container
+// readings. One scanner instance is created per docker_engine component.
+type DockerMetricsScanner struct {
+	store   *repo.Store
+	poller  *docker.ResourcePoller
+	engineID string
+}
+
+// NewDockerMetricsScanner returns a DockerMetricsScanner that uses the given
+// ResourcePoller. The engineID must match the infrastructure_components.id of
+// the docker_engine component so source IDs are derived consistently.
+func NewDockerMetricsScanner(store *repo.Store, engineID string, poller *docker.ResourcePoller) *DockerMetricsScanner {
+	return &DockerMetricsScanner{
+		store:    store,
+		poller:   poller,
+		engineID: engineID,
+	}
+}
+
+// CollectMetrics calls ResourcePoller.PollAll to collect CPU%, memory used,
+// and memory% for all running containers. Threshold events are emitted by the
+// ResourcePoller itself; the MetricsScanner does not add additional ones.
+func (s *DockerMetricsScanner) CollectMetrics(ctx context.Context, entityID string, entityType string) (*scanner.MetricsResult, error) {
+	if s.poller == nil {
+		return nil, fmt.Errorf("docker resource poller not available for %s", entityID)
+	}
+
+	s.poller.PollAll(ctx)
+	log.Printf("docker metrics: %s: poll complete", entityID)
+
+	// ResourcePoller.PollAll writes directly to resource_readings. We don't
+	// have a reading count from it, so return a sentinel value of 1 to signal
+	// that at least one pass completed successfully.
+	return &scanner.MetricsResult{
+		EntityID:   entityID,
+		EntityType: entityType,
+		Readings:   1,
+	}, nil
+}
+
+// compile-time interface check.
+var _ scanner.MetricsScanner = (*DockerMetricsScanner)(nil)

--- a/internal/scanner/metrics/events.go
+++ b/internal/scanner/metrics/events.go
@@ -1,0 +1,192 @@
+// Package metrics provides MetricsScanner implementations for each
+// infrastructure integration type supported by NORA.
+//
+// Each scanner is constructed with a *repo.Store and registered with the
+// scanner.ScanScheduler in main.go. Scanners run every 2 minutes
+// (scanner.MetricsInterval), write raw readings to resource_readings, and
+// fire threshold-crossing events at most once per crossing (no spam).
+//
+// Design rules:
+//   - Write to resource_readings ONLY — never to events on a successful reading.
+//   - Fire an event when a threshold is first crossed; do not re-fire on
+//     subsequent readings while the metric stays in breach.
+//   - Fire a recovery event when the metric drops back below the threshold.
+//   - Do NOT update infrastructure_components.last_status or meta columns.
+//     Status / snapshot updates are the responsibility of SnapshotScanner
+//     (REFACTOR-08) and the legacy pollers that are still running in parallel.
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+// thresholdLevel represents whether a metric is below its threshold,
+// in warning territory, or in error territory.
+type thresholdLevel int
+
+const (
+	levelNormal thresholdLevel = iota
+	levelWarn
+	levelError
+)
+
+func (l thresholdLevel) String() string {
+	switch l {
+	case levelWarn:
+		return "warn"
+	case levelError:
+		return "error"
+	default:
+		return ""
+	}
+}
+
+// ThresholdTracker tracks the last known threshold level per (entityID, metric)
+// pair so that events are only emitted on transitions, not on every reading.
+type ThresholdTracker struct {
+	mu    sync.RWMutex
+	state map[string]thresholdLevel // key: "entityID/metric"
+}
+
+func newThresholdTracker() ThresholdTracker {
+	return ThresholdTracker{state: make(map[string]thresholdLevel)}
+}
+
+// key returns the map key for a (entityID, metric) pair.
+func (t *ThresholdTracker) key(entityID, metric string) string {
+	return entityID + "/" + metric
+}
+
+// load returns the last known threshold level for (entityID, metric).
+func (t *ThresholdTracker) load(entityID, metric string) thresholdLevel {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.state[t.key(entityID, metric)]
+}
+
+// store saves the new threshold level for (entityID, metric).
+func (t *ThresholdTracker) store(entityID, metric string, level thresholdLevel) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.state[t.key(entityID, metric)] = level
+}
+
+// CheckAndFire compares current to previous threshold level and writes an event
+// if the level has changed. Returns the new level.
+func (t *ThresholdTracker) CheckAndFire(
+	ctx context.Context,
+	store *repo.Store,
+	entityID, entityName, sourceType, metric string,
+	current thresholdLevel,
+	eventTitle func(thresholdLevel) string,
+) thresholdLevel {
+	prev := t.load(entityID, metric)
+	t.store(entityID, metric, current)
+
+	if current == prev {
+		return current
+	}
+
+	// Level changed — emit an event.
+	var level, title string
+	switch current {
+	case levelError:
+		level = "error"
+		title = eventTitle(current)
+	case levelWarn:
+		level = "warn"
+		title = eventTitle(current)
+	case levelNormal:
+		// Recovery from a prior breach.
+		level = "info"
+		title = eventTitle(current)
+	}
+
+	writeMetricsEvent(ctx, store, entityID, entityName, sourceType, level, title)
+	return current
+}
+
+// cpuThreshold maps CPU% to a threshold level per the REFACTOR-07 spec.
+// CPU > 90% → warn (no error level for CPU).
+func cpuThreshold(pct float64) thresholdLevel {
+	if pct > 90 {
+		return levelWarn
+	}
+	return levelNormal
+}
+
+// memThreshold maps memory% to a threshold level.
+// Memory > 90% → warn.
+func memThreshold(pct float64) thresholdLevel {
+	if pct > 90 {
+		return levelWarn
+	}
+	return levelNormal
+}
+
+// tempThreshold maps temperature (Celsius) to a threshold level.
+// > 90°C → error; > 80°C → warn.
+func tempThreshold(tempC float64) thresholdLevel {
+	switch {
+	case tempC > 90:
+		return levelError
+	case tempC > 80:
+		return levelWarn
+	default:
+		return levelNormal
+	}
+}
+
+// writeMetricsEvent persists a single event for a threshold crossing.
+func writeMetricsEvent(
+	ctx context.Context,
+	store *repo.Store,
+	sourceID, sourceName, sourceType, level, title string,
+) {
+	payload := fmt.Sprintf(
+		`{"bucket":"metrics","source_id":%q,"source_name":%q}`,
+		sourceID, sourceName,
+	)
+	ev := &models.Event{
+		ID:         uuid.New().String(),
+		Level:      level,
+		SourceName: sourceName,
+		SourceType: sourceType,
+		SourceID:   sourceID,
+		Title:      title,
+		Payload:    payload,
+		CreatedAt:  time.Now().UTC(),
+	}
+	if err := store.Events.Create(ctx, ev); err != nil {
+		log.Printf("metrics: write event for %s (%s): %v", sourceName, sourceID, err)
+	}
+}
+
+// writeReading persists a single resource reading.
+func writeReading(
+	ctx context.Context,
+	store *repo.Store,
+	sourceID, sourceType, metric string,
+	value float64,
+	now time.Time,
+) {
+	r := &models.ResourceReading{
+		ID:         uuid.New().String(),
+		SourceID:   sourceID,
+		SourceType: sourceType,
+		Metric:     metric,
+		Value:      value,
+		RecordedAt: now,
+	}
+	if err := store.Resources.Create(ctx, r); err != nil {
+		log.Printf("metrics: write reading %s/%s: %v", sourceID, metric, err)
+	}
+}

--- a/internal/scanner/metrics/events_test.go
+++ b/internal/scanner/metrics/events_test.go
@@ -1,0 +1,193 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// ── Threshold function tests ──────────────────────────────────────────────────
+
+func TestCPUThreshold(t *testing.T) {
+	tests := []struct {
+		pct  float64
+		want thresholdLevel
+	}{
+		{0, levelNormal},
+		{50, levelNormal},
+		{90, levelNormal}, // exactly 90 is not above 90
+		{90.1, levelWarn},
+		{100, levelWarn},
+	}
+	for _, tc := range tests {
+		got := cpuThreshold(tc.pct)
+		if got != tc.want {
+			t.Errorf("cpuThreshold(%.1f) = %v, want %v", tc.pct, got, tc.want)
+		}
+	}
+}
+
+func TestMemThreshold(t *testing.T) {
+	tests := []struct {
+		pct  float64
+		want thresholdLevel
+	}{
+		{0, levelNormal},
+		{90, levelNormal},
+		{91, levelWarn},
+	}
+	for _, tc := range tests {
+		got := memThreshold(tc.pct)
+		if got != tc.want {
+			t.Errorf("memThreshold(%.1f) = %v, want %v", tc.pct, got, tc.want)
+		}
+	}
+}
+
+func TestTempThreshold(t *testing.T) {
+	tests := []struct {
+		tempC float64
+		want  thresholdLevel
+	}{
+		{20, levelNormal},
+		{80, levelNormal},
+		{80.1, levelWarn},
+		{90, levelWarn},
+		{90.1, levelError},
+		{100, levelError},
+	}
+	for _, tc := range tests {
+		got := tempThreshold(tc.tempC)
+		if got != tc.want {
+			t.Errorf("tempThreshold(%.1f) = %v, want %v", tc.tempC, got, tc.want)
+		}
+	}
+}
+
+// ── ThresholdTracker tests ────────────────────────────────────────────────────
+
+// stubEventRepo implements repo.EventRepo, recording only Create calls.
+type stubEventRepo struct {
+	events []*models.Event
+}
+
+func (r *stubEventRepo) Create(_ context.Context, ev *models.Event) error {
+	r.events = append(r.events, ev)
+	return nil
+}
+func (r *stubEventRepo) List(_ context.Context, _ repo.ListFilter) ([]models.Event, int, error) {
+	return nil, 0, nil
+}
+func (r *stubEventRepo) Get(_ context.Context, _ string) (*models.Event, error) { return nil, nil }
+func (r *stubEventRepo) Timeseries(_ context.Context, _, _ time.Time, _, _, _ string) ([]repo.TimeseriesBucket, error) {
+	return nil, nil
+}
+func (r *stubEventRepo) CountForCategory(_ context.Context, _ repo.CategoryFilter) (int, error) {
+	return 0, nil
+}
+func (r *stubEventRepo) SparklineBuckets(_ context.Context, _ repo.CategoryFilter, _ time.Time, _ time.Duration) ([7]int, error) {
+	return [7]int{}, nil
+}
+func (r *stubEventRepo) LatestPerApp(_ context.Context, _ []string) (map[string]*models.Event, error) {
+	return nil, nil
+}
+func (r *stubEventRepo) DeleteByLevelBefore(_ context.Context, _ string, _ time.Time) (int64, error) {
+	return 0, nil
+}
+func (r *stubEventRepo) GroupByTypeAndLevel(_ context.Context, _ string, _, _ time.Time) ([]repo.EventTypeCount, error) {
+	return nil, nil
+}
+func (r *stubEventRepo) MetricsForApp(_ context.Context, _ string, _, _ time.Time) (repo.EventMetrics, error) {
+	return repo.EventMetrics{}, nil
+}
+func (r *stubEventRepo) CountPerApp(_ context.Context, _ time.Time) ([]repo.AppEventCount, error) {
+	return nil, nil
+}
+
+func newStubStore() (*repo.Store, *stubEventRepo) {
+	evRepo := &stubEventRepo{}
+	return &repo.Store{Events: evRepo}, evRepo
+}
+
+func TestThresholdTracker_FiresOnCrossing(t *testing.T) {
+	store, evRepo := newStubStore()
+	tr := newThresholdTracker()
+
+	titleFn := func(l thresholdLevel) string {
+		if l == levelNormal {
+			return "recovered"
+		}
+		return "high"
+	}
+
+	// First call at levelNormal — no event emitted (no prior state transition).
+	tr.CheckAndFire(context.Background(), store, "e1", "host", "physical_host", "cpu_percent", levelNormal, titleFn)
+	if got := len(evRepo.events); got != 0 {
+		t.Fatalf("expected 0 events after first normal, got %d", got)
+	}
+
+	// Cross into warn — one warn event.
+	tr.CheckAndFire(context.Background(), store, "e1", "host", "physical_host", "cpu_percent", levelWarn, titleFn)
+	if got := len(evRepo.events); got != 1 {
+		t.Fatalf("expected 1 event after warn crossing, got %d", got)
+	}
+	if evRepo.events[0].Level != "warn" {
+		t.Errorf("expected warn level, got %s", evRepo.events[0].Level)
+	}
+
+	// Same level again — no additional event.
+	tr.CheckAndFire(context.Background(), store, "e1", "host", "physical_host", "cpu_percent", levelWarn, titleFn)
+	if got := len(evRepo.events); got != 1 {
+		t.Fatalf("expected still 1 event after second warn reading, got %d", got)
+	}
+
+	// Recovery → info event.
+	tr.CheckAndFire(context.Background(), store, "e1", "host", "physical_host", "cpu_percent", levelNormal, titleFn)
+	if got := len(evRepo.events); got != 2 {
+		t.Fatalf("expected 2 events after recovery, got %d", got)
+	}
+	if evRepo.events[1].Level != "info" {
+		t.Errorf("expected info level for recovery event, got %s", evRepo.events[1].Level)
+	}
+}
+
+func TestThresholdTracker_IndependentKeys(t *testing.T) {
+	store, evRepo := newStubStore()
+	tr := newThresholdTracker()
+	titleFn := func(_ thresholdLevel) string { return "t" }
+
+	// Two different entities crossing the same metric should each fire independently.
+	tr.CheckAndFire(context.Background(), store, "e1", "host1", "physical_host", "cpu_percent", levelWarn, titleFn)
+	tr.CheckAndFire(context.Background(), store, "e2", "host2", "physical_host", "cpu_percent", levelWarn, titleFn)
+	if got := len(evRepo.events); got != 2 {
+		t.Fatalf("expected 2 events for 2 entities, got %d", got)
+	}
+}
+
+func TestThresholdTracker_EscalatesFromWarnToError(t *testing.T) {
+	store, evRepo := newStubStore()
+	tr := newThresholdTracker()
+	titleFn := func(l thresholdLevel) string {
+		switch l {
+		case levelError:
+			return "error"
+		case levelWarn:
+			return "warn"
+		default:
+			return "ok"
+		}
+	}
+
+	// warn → error escalation fires an event.
+	tr.CheckAndFire(context.Background(), store, "e1", "h", "physical_host", "temp", levelWarn, titleFn)
+	tr.CheckAndFire(context.Background(), store, "e1", "h", "physical_host", "temp", levelError, titleFn)
+	if got := len(evRepo.events); got != 2 {
+		t.Fatalf("expected 2 events (warn + error), got %d", got)
+	}
+	if evRepo.events[1].Level != "error" {
+		t.Errorf("expected error level, got %s", evRepo.events[1].Level)
+	}
+}

--- a/internal/scanner/metrics/opnsense.go
+++ b/internal/scanner/metrics/opnsense.go
@@ -1,0 +1,219 @@
+package metrics
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+)
+
+// opnsenseCreds is the JSON shape stored in infrastructure_components.credentials
+// for opnsense components (shared with the discovery scanner).
+type opnsenseCreds struct {
+	BaseURL   string `json:"base_url"`
+	APIKey    string `json:"api_key"`
+	APISecret string `json:"api_secret"`
+	VerifyTLS bool   `json:"verify_tls"`
+}
+
+// OPNsenseMetricsScanner collects CPU%, memory%, and interface statistics from
+// an OPNsense firewall via its REST API every MetricsInterval.
+type OPNsenseMetricsScanner struct {
+	store   *repo.Store
+	tracker ThresholdTracker
+}
+
+// NewOPNsenseMetricsScanner returns an OPNsenseMetricsScanner backed by store.
+func NewOPNsenseMetricsScanner(store *repo.Store) *OPNsenseMetricsScanner {
+	return &OPNsenseMetricsScanner{
+		store:   store,
+		tracker: newThresholdTracker(),
+	}
+}
+
+// CollectMetrics fetches CPU%, memory%, and interface rx/tx from OPNsense and
+// writes them to resource_readings. Fires threshold events on CPU > 90% and
+// memory > 90%.
+func (s *OPNsenseMetricsScanner) CollectMetrics(ctx context.Context, entityID string, entityType string) (*scanner.MetricsResult, error) {
+	c, err := s.store.InfraComponents.Get(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("get component %s: %w", entityID, err)
+	}
+	if c.Credentials == nil || *c.Credentials == "" {
+		return nil, fmt.Errorf("no credentials configured for %s", c.Name)
+	}
+
+	var creds opnsenseCreds
+	if err := json.Unmarshal([]byte(*c.Credentials), &creds); err != nil {
+		return nil, fmt.Errorf("parse opnsense credentials: %w", err)
+	}
+
+	transport := &http.Transport{}
+	if !creds.VerifyTLS {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	}
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   10 * time.Second,
+	}
+
+	now := time.Now().UTC()
+	readings := 0
+
+	// ── System resources (CPU load + memory) ──────────────────────────────────
+	cpuPct, memPct, err := s.fetchSystemResources(ctx, client, creds)
+	if err != nil {
+		log.Printf("opnsense metrics %s: system resources: %v (non-fatal)", c.Name, err)
+	} else {
+		writeReading(ctx, s.store, entityID, "opnsense", "cpu_percent", cpuPct, now)
+		writeReading(ctx, s.store, entityID, "opnsense", "mem_percent", memPct, now)
+		readings += 2
+
+		s.tracker.CheckAndFire(ctx, s.store, entityID, c.Name, "physical_host", "cpu_percent",
+			cpuThreshold(cpuPct),
+			func(l thresholdLevel) string {
+				if l == levelNormal {
+					return fmt.Sprintf("[metrics] CPU recovered — %s: %.1f%%", c.Name, cpuPct)
+				}
+				return fmt.Sprintf("[metrics] High CPU — %s: %.1f%%", c.Name, cpuPct)
+			},
+		)
+		s.tracker.CheckAndFire(ctx, s.store, entityID, c.Name, "physical_host", "mem_percent",
+			memThreshold(memPct),
+			func(l thresholdLevel) string {
+				if l == levelNormal {
+					return fmt.Sprintf("[metrics] Memory recovered — %s: %.1f%%", c.Name, memPct)
+				}
+				return fmt.Sprintf("[metrics] High memory — %s: %.1f%%", c.Name, memPct)
+			},
+		)
+	}
+
+	// ── Interface statistics (rx/tx bytes) ────────────────────────────────────
+	ifaceStats, err := s.fetchInterfaceStats(ctx, client, creds)
+	if err != nil {
+		log.Printf("opnsense metrics %s: interface stats: %v (non-fatal)", c.Name, err)
+	} else {
+		var totalRx, totalTx float64
+		for _, iface := range ifaceStats {
+			totalRx += iface.rxBytes
+			totalTx += iface.txBytes
+		}
+		writeReading(ctx, s.store, entityID, "opnsense", "net_rx_bytes", totalRx, now)
+		writeReading(ctx, s.store, entityID, "opnsense", "net_tx_bytes", totalTx, now)
+		readings += 2
+	}
+
+	log.Printf("opnsense metrics: %s: %d readings", c.Name, readings)
+
+	return &scanner.MetricsResult{
+		EntityID:   entityID,
+		EntityType: entityType,
+		Readings:   readings,
+	}, nil
+}
+
+// opnsenseSystemResources is the JSON shape from GET /api/diagnostics/system/systemResources.
+// Field names are best-effort based on OPNsense 23.x+ API.
+type opnsenseSystemResources struct {
+	CPU struct {
+		Usage float64 `json:"usage"` // 0–100 on some versions
+	} `json:"cpu"`
+	Memory struct {
+		Used  float64 `json:"used"`  // bytes
+		Total float64 `json:"total"` // bytes
+	} `json:"memory"`
+	// Older firmware returns load averages instead of a direct usage field.
+	LoadAverages []string `json:"load_averages"`
+}
+
+func (s *OPNsenseMetricsScanner) fetchSystemResources(ctx context.Context, client *http.Client, creds opnsenseCreds) (cpuPct, memPct float64, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		creds.BaseURL+"/api/diagnostics/system/systemResources", nil)
+	if err != nil {
+		return 0, 0, err
+	}
+	req.SetBasicAuth(creds.APIKey, creds.APISecret)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, 0, fmt.Errorf("GET systemResources: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var res opnsenseSystemResources
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return 0, 0, fmt.Errorf("decode systemResources: %w", err)
+	}
+
+	// CPU usage — use direct field if present, otherwise derive from 1-min load average.
+	cpuPct = res.CPU.Usage
+	if cpuPct == 0 && len(res.LoadAverages) > 0 {
+		// Approximate: load avg / 1 CPU (conservative estimate; better than 0).
+		var load float64
+		fmt.Sscanf(res.LoadAverages[0], "%f", &load)
+		cpuPct = load * 100
+		if cpuPct > 100 {
+			cpuPct = 100
+		}
+	}
+
+	// Memory percent
+	if res.Memory.Total > 0 {
+		memPct = (res.Memory.Used / res.Memory.Total) * 100
+	}
+
+	return cpuPct, memPct, nil
+}
+
+// opnsenseIfaceStat holds rx/tx bytes for a single interface.
+type opnsenseIfaceStat struct {
+	name    string
+	rxBytes float64
+	txBytes float64
+}
+
+// opnsenseIfaceStatResponse is the JSON from GET /api/diagnostics/interface/getInterfaceStatistics.
+type opnsenseIfaceStatResponse map[string]struct {
+	BytesReceived  float64 `json:"bytes_received"`
+	BytesSent      float64 `json:"bytes_sent"`
+}
+
+func (s *OPNsenseMetricsScanner) fetchInterfaceStats(ctx context.Context, client *http.Client, creds opnsenseCreds) ([]opnsenseIfaceStat, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		creds.BaseURL+"/api/diagnostics/interface/getInterfaceStatistics", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(creds.APIKey, creds.APISecret)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET getInterfaceStatistics: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var raw opnsenseIfaceStatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode interface stats: %w", err)
+	}
+
+	var stats []opnsenseIfaceStat
+	for name, s := range raw {
+		stats = append(stats, opnsenseIfaceStat{
+			name:    name,
+			rxBytes: s.BytesReceived,
+			txBytes: s.BytesSent,
+		})
+	}
+	return stats, nil
+}
+
+// compile-time interface check.
+var _ scanner.MetricsScanner = (*OPNsenseMetricsScanner)(nil)

--- a/internal/scanner/metrics/proxmox.go
+++ b/internal/scanner/metrics/proxmox.go
@@ -1,0 +1,119 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/infra"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+)
+
+// ProxmoxMetricsScanner collects CPU%, memory, and disk metrics from Proxmox
+// VE nodes every MetricsInterval. One scanner instance serves all
+// proxmox_node infrastructure components.
+type ProxmoxMetricsScanner struct {
+	store    *repo.Store
+	pollers  sync.Map // componentID → *infra.ProxmoxPoller
+	tracker  ThresholdTracker
+}
+
+// NewProxmoxMetricsScanner returns a ProxmoxMetricsScanner backed by store.
+func NewProxmoxMetricsScanner(store *repo.Store) *ProxmoxMetricsScanner {
+	return &ProxmoxMetricsScanner{
+		store:   store,
+		tracker: newThresholdTracker(),
+	}
+}
+
+// CollectMetrics fetches node metrics for entityID and writes them to
+// resource_readings. It fires threshold events on CPU > 90%, memory > 90%.
+func (s *ProxmoxMetricsScanner) CollectMetrics(ctx context.Context, entityID string, entityType string) (*scanner.MetricsResult, error) {
+	c, err := s.store.InfraComponents.Get(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("get component %s: %w", entityID, err)
+	}
+	if c.Credentials == nil || *c.Credentials == "" {
+		return nil, fmt.Errorf("no credentials configured for %s", c.Name)
+	}
+
+	poller, err := s.getOrCreatePoller(entityID, *c.Credentials)
+	if err != nil {
+		return nil, fmt.Errorf("create proxmox poller: %w", err)
+	}
+
+	nodeMetrics, err := poller.CollectNodeMetrics(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("collect node metrics: %w", err)
+	}
+
+	now := time.Now().UTC()
+	readings := 0
+
+	for _, nm := range nodeMetrics {
+		// Use a per-node sub-key so multi-node clusters have distinct readings.
+		nodeID := entityID + "/" + nm.Node
+
+		for _, m := range []struct {
+			metric string
+			value  float64
+		}{
+			{"cpu_percent", nm.CPUPercent},
+			{"mem_percent", nm.MemPercent},
+			{"mem_used_gb", nm.MemUsedGB},
+			{"mem_total_gb", nm.MemTotalGB},
+			{"disk_percent", nm.DiskPercent},
+		} {
+			writeReading(ctx, s.store, nodeID, "proxmox_node", m.metric, m.value, now)
+			readings++
+		}
+
+		// Threshold checks (per spec: CPU>90%→warn, mem>90%→warn)
+		s.tracker.CheckAndFire(ctx, s.store, nodeID, c.Name, "physical_host", "cpu_percent",
+			cpuThreshold(nm.CPUPercent),
+			func(l thresholdLevel) string {
+				if l == levelNormal {
+					return fmt.Sprintf("[metrics] CPU recovered — %s/%s: %.1f%%", c.Name, nm.Node, nm.CPUPercent)
+				}
+				return fmt.Sprintf("[metrics] High CPU — %s/%s: %.1f%%", c.Name, nm.Node, nm.CPUPercent)
+			},
+		)
+		s.tracker.CheckAndFire(ctx, s.store, nodeID, c.Name, "physical_host", "mem_percent",
+			memThreshold(nm.MemPercent),
+			func(l thresholdLevel) string {
+				if l == levelNormal {
+					return fmt.Sprintf("[metrics] Memory recovered — %s/%s: %.1f%%", c.Name, nm.Node, nm.MemPercent)
+				}
+				return fmt.Sprintf("[metrics] High memory — %s/%s: %.1f%%", c.Name, nm.Node, nm.MemPercent)
+			},
+		)
+	}
+
+	if len(nodeMetrics) > 0 {
+		log.Printf("proxmox metrics: %s: %d readings from %d node(s)", c.Name, readings, len(nodeMetrics))
+	}
+
+	return &scanner.MetricsResult{
+		EntityID:   entityID,
+		EntityType: entityType,
+		Readings:   readings,
+	}, nil
+}
+
+func (s *ProxmoxMetricsScanner) getOrCreatePoller(componentID, credJSON string) (*infra.ProxmoxPoller, error) {
+	if v, ok := s.pollers.Load(componentID); ok {
+		return v.(*infra.ProxmoxPoller), nil
+	}
+	p, err := infra.NewProxmoxPoller(componentID, credJSON)
+	if err != nil {
+		return nil, err
+	}
+	s.pollers.Store(componentID, p)
+	return p, nil
+}
+
+// compile-time interface check.
+var _ scanner.MetricsScanner = (*ProxmoxMetricsScanner)(nil)

--- a/internal/scanner/metrics/snmp.go
+++ b/internal/scanner/metrics/snmp.go
@@ -1,0 +1,114 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/infra"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+)
+
+// SNMPMetricsScanner collects CPU%, memory%, and per-disk utilisation from
+// hosts using SNMP. It is registered by collection_method="snmp" rather than
+// by entity type, so it covers physical_host and any other type that uses SNMP.
+type SNMPMetricsScanner struct {
+	store   *repo.Store
+	pollers sync.Map // componentID → *infra.SNMPPoller
+	tracker ThresholdTracker
+}
+
+// NewSNMPMetricsScanner returns an SNMPMetricsScanner backed by store.
+func NewSNMPMetricsScanner(store *repo.Store) *SNMPMetricsScanner {
+	return &SNMPMetricsScanner{
+		store:   store,
+		tracker: newThresholdTracker(),
+	}
+}
+
+// CollectMetrics reads CPU%, memory, disk, and uptime via SNMP and writes them
+// to resource_readings. Fires threshold events on CPU > 90%, memory > 90%.
+func (s *SNMPMetricsScanner) CollectMetrics(ctx context.Context, entityID string, entityType string) (*scanner.MetricsResult, error) {
+	c, err := s.store.InfraComponents.Get(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("get component %s: %w", entityID, err)
+	}
+	if c.SNMPConfig == nil || *c.SNMPConfig == "" {
+		return nil, fmt.Errorf("no SNMP config for %s", c.Name)
+	}
+
+	poller, err := s.getOrCreatePoller(entityID, c.IP, *c.SNMPConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create SNMP poller: %w", err)
+	}
+
+	snap, err := poller.CollectMetrics(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("collect metrics: %w", err)
+	}
+
+	now := time.Now().UTC()
+	readings := 0
+
+	writeReading(ctx, s.store, entityID, "snmp_host", "cpu_percent", snap.CPUPercent, now)
+	readings++
+	writeReading(ctx, s.store, entityID, "snmp_host", "mem_percent", snap.MemPercent, now)
+	readings++
+	writeReading(ctx, s.store, entityID, "snmp_host", "mem_used_gb", snap.MemUsedGB, now)
+	readings++
+	writeReading(ctx, s.store, entityID, "snmp_host", "mem_total_gb", snap.MemTotalGB, now)
+	readings++
+
+	for _, d := range snap.Disks {
+		label := infra.SanitizeDiskLabel(d.Label)
+		writeReading(ctx, s.store, entityID, "snmp_host", "disk_percent_"+label, d.Percent, now)
+		readings++
+	}
+
+	// Threshold checks
+	s.tracker.CheckAndFire(ctx, s.store, entityID, c.Name, "physical_host", "cpu_percent",
+		cpuThreshold(snap.CPUPercent),
+		func(l thresholdLevel) string {
+			if l == levelNormal {
+				return fmt.Sprintf("[metrics] CPU recovered — %s: %.1f%%", c.Name, snap.CPUPercent)
+			}
+			return fmt.Sprintf("[metrics] High CPU — %s: %.1f%%", c.Name, snap.CPUPercent)
+		},
+	)
+	s.tracker.CheckAndFire(ctx, s.store, entityID, c.Name, "physical_host", "mem_percent",
+		memThreshold(snap.MemPercent),
+		func(l thresholdLevel) string {
+			if l == levelNormal {
+				return fmt.Sprintf("[metrics] Memory recovered — %s: %.1f%%", c.Name, snap.MemPercent)
+			}
+			return fmt.Sprintf("[metrics] High memory — %s: %.1f%%", c.Name, snap.MemPercent)
+		},
+	)
+
+	log.Printf("snmp metrics: %s: %d readings (cpu=%.1f%% mem=%.1f%%)",
+		c.Name, readings, snap.CPUPercent, snap.MemPercent)
+
+	return &scanner.MetricsResult{
+		EntityID:   entityID,
+		EntityType: entityType,
+		Readings:   readings,
+	}, nil
+}
+
+func (s *SNMPMetricsScanner) getOrCreatePoller(componentID, ip, cfgJSON string) (*infra.SNMPPoller, error) {
+	if v, ok := s.pollers.Load(componentID); ok {
+		return v.(*infra.SNMPPoller), nil
+	}
+	p, err := infra.NewSNMPPoller(componentID, ip, cfgJSON)
+	if err != nil {
+		return nil, err
+	}
+	s.pollers.Store(componentID, p)
+	return p, nil
+}
+
+// compile-time interface check.
+var _ scanner.MetricsScanner = (*SNMPMetricsScanner)(nil)

--- a/internal/scanner/metrics/synology.go
+++ b/internal/scanner/metrics/synology.go
@@ -1,0 +1,130 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/infra"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+)
+
+// SynologyMetricsScanner collects CPU%, memory, temperature, and volume
+// utilisation metrics from Synology DSM every MetricsInterval.
+type SynologyMetricsScanner struct {
+	store   *repo.Store
+	pollers sync.Map // componentID → *infra.SynologyPoller
+	tracker ThresholdTracker
+}
+
+// NewSynologyMetricsScanner returns a SynologyMetricsScanner backed by store.
+func NewSynologyMetricsScanner(store *repo.Store) *SynologyMetricsScanner {
+	return &SynologyMetricsScanner{
+		store:   store,
+		tracker: newThresholdTracker(),
+	}
+}
+
+// CollectMetrics fetches Synology metrics and writes them to resource_readings.
+// Fires threshold events on CPU > 90%, memory > 90%, temperature > 80°C / > 90°C.
+func (s *SynologyMetricsScanner) CollectMetrics(ctx context.Context, entityID string, entityType string) (*scanner.MetricsResult, error) {
+	c, err := s.store.InfraComponents.Get(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("get component %s: %w", entityID, err)
+	}
+	if c.Credentials == nil || *c.Credentials == "" {
+		return nil, fmt.Errorf("no credentials configured for %s", c.Name)
+	}
+
+	poller, err := s.getOrCreatePoller(entityID, *c.Credentials)
+	if err != nil {
+		return nil, fmt.Errorf("create synology poller: %w", err)
+	}
+
+	snap, err := poller.CollectMetrics(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("collect metrics: %w", err)
+	}
+
+	now := time.Now().UTC()
+	readings := 0
+
+	for _, m := range []struct {
+		metric string
+		value  float64
+	}{
+		{"cpu_percent", snap.CPUPercent},
+		{"mem_percent", snap.MemPercent},
+		{"mem_used_gb", snap.MemUsedGB},
+		{"mem_total_gb", snap.MemTotalGB},
+		{"temperature_c", float64(snap.TempC)},
+	} {
+		writeReading(ctx, s.store, entityID, "synology", m.metric, m.value, now)
+		readings++
+	}
+
+	for _, vol := range snap.VolumeStats {
+		writeReading(ctx, s.store, entityID, "synology", "disk_percent_"+vol.Key, vol.DiskPercent, now)
+		readings++
+	}
+
+	// Threshold checks
+	s.tracker.CheckAndFire(ctx, s.store, entityID, c.Name, "physical_host", "cpu_percent",
+		cpuThreshold(snap.CPUPercent),
+		func(l thresholdLevel) string {
+			if l == levelNormal {
+				return fmt.Sprintf("[metrics] CPU recovered — %s: %.1f%%", c.Name, snap.CPUPercent)
+			}
+			return fmt.Sprintf("[metrics] High CPU — %s: %.1f%%", c.Name, snap.CPUPercent)
+		},
+	)
+	s.tracker.CheckAndFire(ctx, s.store, entityID, c.Name, "physical_host", "mem_percent",
+		memThreshold(snap.MemPercent),
+		func(l thresholdLevel) string {
+			if l == levelNormal {
+				return fmt.Sprintf("[metrics] Memory recovered — %s: %.1f%%", c.Name, snap.MemPercent)
+			}
+			return fmt.Sprintf("[metrics] High memory — %s: %.1f%%", c.Name, snap.MemPercent)
+		},
+	)
+	s.tracker.CheckAndFire(ctx, s.store, entityID, c.Name, "physical_host", "temperature_c",
+		tempThreshold(float64(snap.TempC)),
+		func(l thresholdLevel) string {
+			switch l {
+			case levelError:
+				return fmt.Sprintf("[metrics] Critical temperature — %s: %d°C", c.Name, snap.TempC)
+			case levelWarn:
+				return fmt.Sprintf("[metrics] High temperature — %s: %d°C", c.Name, snap.TempC)
+			default:
+				return fmt.Sprintf("[metrics] Temperature recovered — %s: %d°C", c.Name, snap.TempC)
+			}
+		},
+	)
+
+	log.Printf("synology metrics: %s: %d readings (cpu=%.1f%% mem=%.1f%% temp=%d°C)",
+		c.Name, readings, snap.CPUPercent, snap.MemPercent, snap.TempC)
+
+	return &scanner.MetricsResult{
+		EntityID:   entityID,
+		EntityType: entityType,
+		Readings:   readings,
+	}, nil
+}
+
+func (s *SynologyMetricsScanner) getOrCreatePoller(componentID, credJSON string) (*infra.SynologyPoller, error) {
+	if v, ok := s.pollers.Load(componentID); ok {
+		return v.(*infra.SynologyPoller), nil
+	}
+	p, err := infra.NewSynologyPoller(componentID, credJSON)
+	if err != nil {
+		return nil, err
+	}
+	s.pollers.Store(componentID, p)
+	return p, nil
+}
+
+// compile-time interface check.
+var _ scanner.MetricsScanner = (*SynologyMetricsScanner)(nil)

--- a/internal/scanner/scheduler.go
+++ b/internal/scanner/scheduler.go
@@ -30,7 +30,8 @@ type ScanScheduler struct {
 	store                    *repo.Store
 	discovery                map[string]DiscoveryScanner // keyed by entity type
 	discoveryByMethod        map[string]DiscoveryScanner // keyed by collection_method
-	metrics                  map[string]MetricsScanner
+	metrics                  map[string]MetricsScanner   // keyed by entity type
+	metricsByMethod          map[string]MetricsScanner   // keyed by collection_method
 	snapshots                map[string]SnapshotScanner
 	mu                       sync.RWMutex
 }
@@ -43,6 +44,7 @@ func NewScanScheduler(store *repo.Store) *ScanScheduler {
 		discovery:         make(map[string]DiscoveryScanner),
 		discoveryByMethod: make(map[string]DiscoveryScanner),
 		metrics:           make(map[string]MetricsScanner),
+		metricsByMethod:   make(map[string]MetricsScanner),
 		snapshots:         make(map[string]SnapshotScanner),
 	}
 }
@@ -68,6 +70,15 @@ func (s *ScanScheduler) RegisterMetrics(entityType string, sc MetricsScanner) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.metrics[entityType] = sc
+}
+
+// RegisterMetricsByMethod registers a MetricsScanner keyed by collection_method
+// rather than entity type. This is used for SNMP hosts which may have any entity
+// type but share collection_method="snmp".
+func (s *ScanScheduler) RegisterMetricsByMethod(collectionMethod string, sc MetricsScanner) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.metricsByMethod[collectionMethod] = sc
 }
 
 // RegisterSnapshot registers a SnapshotScanner for the given entity type.
@@ -151,6 +162,8 @@ func (s *ScanScheduler) runDiscoveryPass(ctx context.Context) {
 
 // runMetricsPass iterates all enabled components and calls each registered
 // MetricsScanner concurrently with MetricsTimeout per entity.
+// Scanners are looked up by entity type first; if none is registered for the
+// type the scheduler falls back to a lookup by collection_method.
 func (s *ScanScheduler) runMetricsPass(ctx context.Context) {
 	components, err := s.listEnabled(ctx)
 	if err != nil {
@@ -160,12 +173,16 @@ func (s *ScanScheduler) runMetricsPass(ctx context.Context) {
 
 	s.mu.RLock()
 	scanners := copyMetrics(s.metrics)
+	methodScanners := copyMetrics(s.metricsByMethod)
 	s.mu.RUnlock()
 
 	var wg sync.WaitGroup
 	for i := range components {
 		c := &components[i]
 		sc, ok := scanners[c.Type]
+		if !ok {
+			sc, ok = methodScanners[c.CollectionMethod]
+		}
 		if !ok {
 			continue
 		}


### PR DESCRIPTION
## What
Implements the MetricsScanner interface (from REFACTOR-05) for every infrastructure integration type: Proxmox nodes, Synology DSM, SNMP hosts, Docker containers, and OPNsense firewalls. The scan scheduler drives metric collection every 2 minutes.

## Why
Closes REFACTOR-07. The MetricsScanner bucket provides high-frequency numeric readings that feed the existing hourly and daily rollup pipeline for trending, sparklines, and alerting.

## How

**New package: `internal/scanner/metrics/`**
- `events.go` — `ThresholdTracker` (one event per crossing, silent on repeat), threshold functions per spec (`cpuThreshold >90%→warn`, `memThreshold >90%→warn`, `tempThreshold >80°C→warn / >90°C→error`), `writeReading` helper
- `proxmox.go` — ProxmoxMetricsScanner: collects cpu%, mem%, disk% per node via `CollectNodeMetrics()`
- `synology.go` — SynologyMetricsScanner: collects cpu%, mem%, temperature, volume utilisation; reuses cached DSM session
- `snmp.go` — SNMPMetricsScanner: collects cpu%, mem%, per-disk %; registered by `collection_method="snmp"`
- `docker.go` — DockerMetricsScanner: delegates to `docker.ResourcePoller.PollAll()`; threshold events handled by the poller
- `opnsense.go` — OPNsenseMetricsScanner: calls `/api/diagnostics/system/systemResources` and `/api/diagnostics/interface/getInterfaceStatistics`

**Poller additions (metrics-only, no DB side-effects):**
- `infra.ProxmoxPoller.CollectNodeMetrics()` — returns `[]ProxmoxNodeMetrics` without writing to DB
- `infra.SynologyPoller.CollectMetrics()` — returns `*SynologyMetricsSnapshot` using cached session
- `infra.SNMPPoller.CollectMetrics()` — returns `*SNMPMetricsSnapshot`; `SanitizeDiskLabel` exported

**Scheduler:**
- Added `metricsByMethod` map + `RegisterMetricsByMethod()` for SNMP method-based dispatch (mirrors `RegisterDiscoveryByMethod`)
- `runMetricsPass` falls back to `metricsByMethod` when no type-keyed scanner is registered

**main.go:**
- All five MetricsScanner implementations registered
- Docker `ResourcePoller.Start()` ticker removed — the scan scheduler now calls `PollAll` every 2 minutes instead of every 60 seconds

**Rollup wiring:** readings land in `resource_readings`; `StartHourlyRollup` already aggregates from that table on its hourly schedule — no additional signalling needed.

## Test coverage
- `internal/scanner/metrics/events_test.go`: threshold functions (cpu, mem, temp), ThresholdTracker no-spam behaviour, independent keys, warn→error escalation
- `go test ./...` passes; `npm run build` passes with zero TypeScript errors

## Acceptance criteria
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] Metrics collected every 2 minutes for all registered infrastructure entities
- [x] Raw readings written to resource_readings
- [x] No successful metric reading writes to the events table
- [x] Threshold crossings write a warn/error event with entity source attribution
- [x] Threshold events do not spam — one event per crossing, not one per reading
- [x] Rollup jobs trigger correctly after metric writes

## Closes
Closes REFACTOR-07