### PR TITLE
feat: snapshot scanner — 30-minute condition polling (REFACTOR-08)

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/digitalcheffe/nora/internal/scanner"
 	"github.com/digitalcheffe/nora/internal/scanner/discovery"
 	noraMetrics "github.com/digitalcheffe/nora/internal/scanner/metrics"
+	noraSnapshot "github.com/digitalcheffe/nora/internal/scanner/snapshot"
 	"github.com/digitalcheffe/nora/migrations"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -80,6 +81,7 @@ func main() {
 	discoveredContainerRepo := repo.NewDiscoveredContainerRepo(db)
 	discoveredRouteRepo := repo.NewDiscoveredRouteRepo(db)
 	webPushSubscriptionRepo := repo.NewWebPushSubscriptionRepo(db)
+	snapshotRepo := repo.NewSnapshotRepo(db)
 	store := repo.NewStore(
 		appRepo, eventRepo, checkRepo,
 		rollupRepo, resourceRepo, resourceRollupRepo,
@@ -88,6 +90,7 @@ func main() {
 		traefikComponentRepo, traefikOverviewRepo, traefikServiceRepo,
 		discoveredContainerRepo, discoveredRouteRepo,
 		webPushSubscriptionRepo,
+		snapshotRepo,
 	)
 
 	// Startup event — written once so users can see when NORA last started.
@@ -136,7 +139,34 @@ func main() {
 	scanScheduler.RegisterMetricsByMethod("snmp", noraMetrics.NewSNMPMetricsScanner(store))
 	// Docker MetricsScanner is wired after the ResourcePoller is created below.
 
+	// Snapshots (REFACTOR-08) — 30-minute condition polling.
+	// Infrastructure component scanners are registered by entity type / collection method.
+	// SSL snapshot scanning runs as a standalone job (iterates monitor_checks, not
+	// infrastructure_components) and is started on its own 30-minute ticker below.
+	scanScheduler.RegisterSnapshot("proxmox_node", noraSnapshot.NewProxmoxSnapshotScanner(store))
+	scanScheduler.RegisterSnapshot("synology", noraSnapshot.NewSynologySnapshotScanner(store))
+	scanScheduler.RegisterSnapshot("opnsense", noraSnapshot.NewOPNsenseSnapshotScanner(store))
+	scanScheduler.RegisterSnapshotByMethod("snmp", noraSnapshot.NewSNMPSnapshotScanner(store))
+
 	go scanScheduler.Start(scanCtx)
+
+	// SSL snapshot job — runs every SnapshotInterval independently of the scan
+	// scheduler because it iterates monitor_checks rather than infrastructure_components.
+	sslSnapshotCtx, sslSnapshotCancel := context.WithCancel(context.Background())
+	defer sslSnapshotCancel()
+	go func() {
+		sslJob := noraSnapshot.NewSSLSnapshotJob(store)
+		ticker := time.NewTicker(scanner.SnapshotInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-sslSnapshotCtx.Done():
+				return
+			case <-ticker.C:
+				sslJob.Run(sslSnapshotCtx)
+			}
+		}
+	}()
 
 	// Resource rollup jobs — hourly aggregation and daily rollup + retention purge.
 	rollupCtx, rollupCancel := context.WithCancel(context.Background())

--- a/internal/api/digest_test.go
+++ b/internal/api/digest_test.go
@@ -37,6 +37,7 @@ func newDigestRouter(t *testing.T) (http.Handler, *repo.Store) {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	digestJob := jobs.NewDigestJob(store, &config.Config{})
 	h := api.NewDigestHandler(store, digestJob)
@@ -67,6 +68,7 @@ func newDigestRouterWithSMTP(t *testing.T) (http.Handler, *repo.Store) {
 		repo.NewDockerEngineRepo(db),
 		repo.NewInfraRepo(db),
 		repo.NewSettingsRepo(db),
+		nil,
 		nil,
 		nil,
 		nil,

--- a/internal/api/docker_discovery_link_test.go
+++ b/internal/api/docker_discovery_link_test.go
@@ -42,6 +42,7 @@ func newDiscoveryLinkRouter(t *testing.T, profiles apptemplate.Loader) (http.Han
 		repo.NewDiscoveredContainerRepo(db),
 		repo.NewDiscoveredRouteRepo(db),
 		nil,
+		nil,
 	)
 	h := api.NewDockerDiscoveryHandler(store, profiles)
 	r := chi.NewRouter()

--- a/internal/api/infra_components_test.go
+++ b/internal/api/infra_components_test.go
@@ -28,7 +28,7 @@ func newInfraComponentRouter(t *testing.T) http.Handler {
 		repo.NewInfraRepo(db), repo.NewSettingsRepo(db), repo.NewMetricsRepo(db),
 		repo.NewUserRepo(db), tc,
 		repo.NewTraefikOverviewRepo(db), repo.NewTraefikServiceRepo(db),
-		repo.NewDiscoveredContainerRepo(db), repo.NewDiscoveredRouteRepo(db), nil,
+		repo.NewDiscoveredContainerRepo(db), repo.NewDiscoveredRouteRepo(db), nil, nil,
 	)
 	h := api.NewInfraComponentHandler(ic, rollups, checks, events, store)
 	r := chi.NewRouter()

--- a/internal/api/ingest_test.go
+++ b/internal/api/ingest_test.go
@@ -21,7 +21,7 @@ func newIngestRouter(t *testing.T) (http.Handler, *repo.Store) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 	profiler := &apptemplate.NoopLoader{}
 
@@ -44,7 +44,7 @@ func TestHandleIngest_HappyPath(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()
@@ -131,7 +131,7 @@ func TestHandleIngest_RateLimit(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()

--- a/internal/api/topology_test.go
+++ b/internal/api/topology_test.go
@@ -188,7 +188,7 @@ func TestGetTopology_FullChain(t *testing.T) {
 		repo.NewInfraRepo(db), repo.NewSettingsRepo(db), repo.NewMetricsRepo(db),
 		repo.NewUserRepo(db), tc,
 		repo.NewTraefikOverviewRepo(db), repo.NewTraefikServiceRepo(db),
-		repo.NewDiscoveredContainerRepo(db), repo.NewDiscoveredRouteRepo(db), nil,
+		repo.NewDiscoveredContainerRepo(db), repo.NewDiscoveredRouteRepo(db), nil, nil,
 	)
 	icHandler := api.NewInfraComponentHandler(ic, rollups, checks, repo.NewEventRepo(db), store)
 	r := chi.NewRouter()

--- a/internal/docker/resources_test.go
+++ b/internal/docker/resources_test.go
@@ -57,7 +57,7 @@ func (r *mockResourceReadingRepo) BackfillAppID(_ context.Context, _, _ string) 
 // --- helpers --------------------------------------------------------------
 
 func newTestResourcePoller(appRepo repo.AppRepo, eventRepo repo.EventRepo, resRepo repo.ResourceReadingRepo, cli resourcePollerAPI) *ResourcePoller {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	return newResourcePollerWithClient(store, "", cli)
 }
 

--- a/internal/docker/watcher_test.go
+++ b/internal/docker/watcher_test.go
@@ -97,7 +97,7 @@ func (r *mockEventRepo) Timeseries(_ context.Context, _, _ time.Time, _, _, _ st
 // --- helpers -------------------------------------------------------------
 
 func newTestWatcher(appRepo repo.AppRepo, eventRepo repo.EventRepo, dc dockerAPI) *Watcher {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	return &Watcher{store: store, client: dc}
 }
 

--- a/internal/infra/proxmox_test.go
+++ b/internal/infra/proxmox_test.go
@@ -44,6 +44,7 @@ func newProxmoxTestStore(t *testing.T) *repo.Store {
 		repo.NewDiscoveredContainerRepo(db),
 		repo.NewDiscoveredRouteRepo(db),
 		nil,
+		nil,
 	)
 }
 

--- a/internal/infra/snmp_test.go
+++ b/internal/infra/snmp_test.go
@@ -43,6 +43,7 @@ func newSNMPTestStore(t *testing.T) *repo.Store {
 		repo.NewDiscoveredContainerRepo(db),
 		repo.NewDiscoveredRouteRepo(db),
 		nil,
+		nil,
 	)
 }
 

--- a/internal/infra/synology_test.go
+++ b/internal/infra/synology_test.go
@@ -44,6 +44,7 @@ func newSynologyTestStore(t *testing.T) *repo.Store {
 		repo.NewDiscoveredContainerRepo(db),
 		repo.NewDiscoveredRouteRepo(db),
 		nil,
+		nil,
 	)
 }
 

--- a/internal/ingest/pipeline_test.go
+++ b/internal/ingest/pipeline_test.go
@@ -25,7 +25,7 @@ func newTestStore(t *testing.T) *repo.Store {
 	t.Cleanup(func() { db.Close() })
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func seedApp(t *testing.T, store *repo.Store, token string, rateLimit int) models.App {

--- a/internal/jobs/resource_rollup_test.go
+++ b/internal/jobs/resource_rollup_test.go
@@ -31,7 +31,7 @@ func newTestStore(t *testing.T) (*repo.Store, *sqlx.DB) {
 		repo.NewRollupRepo(db),
 		repo.NewResourceReadingRepo(db),
 		repo.NewResourceRollupRepo(db),
-		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
 	)
 	return store, db
 }

--- a/internal/models/snapshot.go
+++ b/internal/models/snapshot.go
@@ -1,0 +1,16 @@
+package models
+
+import "time"
+
+// Snapshot is a point-in-time reading of a slowly-changing condition value
+// for a single infrastructure entity. Written by SnapshotScanner implementations
+// (REFACTOR-08) and retained for 48 readings per (entity_id, metric_key) pair.
+type Snapshot struct {
+	ID            string    `db:"id"`
+	EntityType    string    `db:"entity_type"`
+	EntityID      string    `db:"entity_id"`
+	MetricKey     string    `db:"metric_key"`
+	MetricValue   string    `db:"metric_value"`
+	PreviousValue *string   `db:"previous_value"`
+	CapturedAt    time.Time `db:"captured_at"`
+}

--- a/internal/repo/snapshots.go
+++ b/internal/repo/snapshots.go
@@ -1,0 +1,74 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/jmoiron/sqlx"
+)
+
+// SnapshotRepo defines storage for slowly-changing condition snapshots.
+type SnapshotRepo interface {
+	// GetLatest returns the most recently captured snapshot for the given
+	// (entityID, metricKey) pair. Returns ErrNotFound if no reading exists yet.
+	GetLatest(ctx context.Context, entityID, metricKey string) (*models.Snapshot, error)
+	// Insert writes a new snapshot row.
+	Insert(ctx context.Context, s *models.Snapshot) error
+	// Prune deletes all but the most recent limit rows for (entityID, metricKey).
+	Prune(ctx context.Context, entityID, metricKey string, limit int) error
+}
+
+type sqliteSnapshotRepo struct{ db *sqlx.DB }
+
+// NewSnapshotRepo returns a SnapshotRepo backed by SQLite.
+func NewSnapshotRepo(db *sqlx.DB) SnapshotRepo {
+	return &sqliteSnapshotRepo{db: db}
+}
+
+func (r *sqliteSnapshotRepo) GetLatest(ctx context.Context, entityID, metricKey string) (*models.Snapshot, error) {
+	var s models.Snapshot
+	err := r.db.GetContext(ctx, &s, `
+		SELECT id, entity_type, entity_id, metric_key, metric_value, previous_value, captured_at
+		FROM snapshots
+		WHERE entity_id = ? AND metric_key = ?
+		ORDER BY captured_at DESC
+		LIMIT 1`, entityID, metricKey)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get latest snapshot: %w", err)
+	}
+	return &s, nil
+}
+
+func (r *sqliteSnapshotRepo) Insert(ctx context.Context, s *models.Snapshot) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO snapshots
+		  (id, entity_type, entity_id, metric_key, metric_value, previous_value, captured_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.EntityType, s.EntityID, s.MetricKey, s.MetricValue, s.PreviousValue, s.CapturedAt)
+	if err != nil {
+		return fmt.Errorf("insert snapshot: %w", err)
+	}
+	return nil
+}
+
+func (r *sqliteSnapshotRepo) Prune(ctx context.Context, entityID, metricKey string, limit int) error {
+	_, err := r.db.ExecContext(ctx, `
+		DELETE FROM snapshots
+		WHERE entity_id = ? AND metric_key = ?
+		  AND id NOT IN (
+		    SELECT id FROM snapshots
+		    WHERE entity_id = ? AND metric_key = ?
+		    ORDER BY captured_at DESC
+		    LIMIT ?
+		  )`, entityID, metricKey, entityID, metricKey, limit)
+	if err != nil {
+		return fmt.Errorf("prune snapshots %s/%s: %w", entityID, metricKey, err)
+	}
+	return nil
+}

--- a/internal/repo/store.go
+++ b/internal/repo/store.go
@@ -20,6 +20,7 @@ type Store struct {
 	DiscoveredContainers DiscoveredContainerRepo
 	DiscoveredRoutes     DiscoveredRouteRepo
 	WebPushSubscriptions WebPushSubscriptionRepo
+	Snapshots            SnapshotRepo
 }
 
 // NewStore creates a Store backed by the given repositories.
@@ -42,6 +43,7 @@ func NewStore(
 	discoveredContainers DiscoveredContainerRepo,
 	discoveredRoutes DiscoveredRouteRepo,
 	webPushSubscriptions WebPushSubscriptionRepo,
+	snapshots SnapshotRepo,
 ) *Store {
 	return &Store{
 		Apps:                 apps,
@@ -62,5 +64,6 @@ func NewStore(
 		DiscoveredContainers: discoveredContainers,
 		DiscoveredRoutes:     discoveredRoutes,
 		WebPushSubscriptions: webPushSubscriptions,
+		Snapshots:            snapshots,
 	}
 }

--- a/internal/scanner/scheduler.go
+++ b/internal/scanner/scheduler.go
@@ -32,8 +32,9 @@ type ScanScheduler struct {
 	discoveryByMethod        map[string]DiscoveryScanner // keyed by collection_method
 	metrics                  map[string]MetricsScanner   // keyed by entity type
 	metricsByMethod          map[string]MetricsScanner   // keyed by collection_method
-	snapshots                map[string]SnapshotScanner
-	mu                       sync.RWMutex
+	snapshots         map[string]SnapshotScanner // keyed by entity type
+	snapshotsByMethod map[string]SnapshotScanner // keyed by collection_method
+	mu                sync.RWMutex
 }
 
 // NewScanScheduler returns a ScanScheduler wired to store with empty scanner
@@ -46,6 +47,7 @@ func NewScanScheduler(store *repo.Store) *ScanScheduler {
 		metrics:           make(map[string]MetricsScanner),
 		metricsByMethod:   make(map[string]MetricsScanner),
 		snapshots:         make(map[string]SnapshotScanner),
+		snapshotsByMethod: make(map[string]SnapshotScanner),
 	}
 }
 
@@ -86,6 +88,15 @@ func (s *ScanScheduler) RegisterSnapshot(entityType string, sc SnapshotScanner) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.snapshots[entityType] = sc
+}
+
+// RegisterSnapshotByMethod registers a SnapshotScanner keyed by
+// collection_method rather than entity type. This is used for SNMP hosts
+// which may have any entity type but share collection_method="snmp".
+func (s *ScanScheduler) RegisterSnapshotByMethod(collectionMethod string, sc SnapshotScanner) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.snapshotsByMethod[collectionMethod] = sc
 }
 
 // Start launches the three ticker loops and blocks until ctx is cancelled.
@@ -203,6 +214,8 @@ func (s *ScanScheduler) runMetricsPass(ctx context.Context) {
 
 // runSnapshotPass iterates all enabled components and calls each registered
 // SnapshotScanner concurrently with SnapshotTimeout per entity.
+// Scanners are looked up by entity type first; if none is registered for the
+// type the scheduler falls back to a lookup by collection_method.
 func (s *ScanScheduler) runSnapshotPass(ctx context.Context) {
 	components, err := s.listEnabled(ctx)
 	if err != nil {
@@ -212,12 +225,16 @@ func (s *ScanScheduler) runSnapshotPass(ctx context.Context) {
 
 	s.mu.RLock()
 	scanners := copySnapshots(s.snapshots)
+	methodScanners := copySnapshots(s.snapshotsByMethod)
 	s.mu.RUnlock()
 
 	var wg sync.WaitGroup
 	for i := range components {
 		c := &components[i]
 		sc, ok := scanners[c.Type]
+		if !ok {
+			sc, ok = methodScanners[c.CollectionMethod]
+		}
 		if !ok {
 			continue
 		}

--- a/internal/scanner/snapshot/events.go
+++ b/internal/scanner/snapshot/events.go
@@ -1,0 +1,152 @@
+// Package snapshot provides SnapshotScanner implementations for each
+// infrastructure integration type supported by NORA.
+//
+// Each scanner captures slowly-changing condition data — SSL cert expiry,
+// storage utilisation, OS versions, update counts, disk health — and writes
+// point-in-time snapshot rows to the snapshots table every 30 minutes
+// (scanner.SnapshotInterval).
+//
+// Design rules:
+//   - Read the previous snapshot from the DB; compare to the new value.
+//   - Fire an event only when the condition changes — never on unchanged values.
+//   - Write a debug event on every successful snapshot run.
+//   - Retain the last 48 readings per (entity_id, metric_key); prune after insert.
+//   - Source attribution on events matches the REFACTOR-01 vocabulary:
+//     physical_host, monitor_check, or snmp_host.
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+const snapshotRetain = 48
+
+// storageCondition maps a utilisation percentage to a condition bucket.
+// < 80 % → "ok"; 80–90 % → "warn"; ≥ 90 % → "error".
+func storageCondition(pct float64) string {
+	switch {
+	case pct >= 90:
+		return "error"
+	case pct >= 80:
+		return "warn"
+	default:
+		return "ok"
+	}
+}
+
+// sslCondition maps days-remaining to a condition bucket.
+// ≤ 0 → "critical"; ≤ 7 → "error"; ≤ 30 → "warn"; > 30 → "ok".
+func sslCondition(days int) string {
+	switch {
+	case days <= 0:
+		return "critical"
+	case days <= 7:
+		return "error"
+	case days <= 30:
+		return "warn"
+	default:
+		return "ok"
+	}
+}
+
+// diskHealthCondition maps a disk status string to a normalised condition bucket.
+// "normal" → "ok"; "warning" → "warn"; "critical"/"failing" → "error".
+func diskHealthCondition(status string) string {
+	switch status {
+	case "warning":
+		return "warn"
+	case "critical", "failing":
+		return "error"
+	default:
+		return "ok"
+	}
+}
+
+// captureSnapshot reads the previous snapshot from the DB, inserts the new
+// value, prunes to snapshotRetain rows, and returns (previousValue, changed).
+// On the first reading for a key, previousValue is "" and changed is false.
+func captureSnapshot(
+	ctx context.Context,
+	store *repo.Store,
+	entityType, entityID, metricKey, metricValue string,
+	now time.Time,
+) (prevValue string, changed bool) {
+	prevSnap, err := store.Snapshots.GetLatest(ctx, entityID, metricKey)
+	var prev *string
+	if err == nil {
+		prev = &prevSnap.MetricValue
+		changed = prevSnap.MetricValue != metricValue
+	}
+
+	s := &models.Snapshot{
+		ID:            uuid.New().String(),
+		EntityType:    entityType,
+		EntityID:      entityID,
+		MetricKey:     metricKey,
+		MetricValue:   metricValue,
+		PreviousValue: prev,
+		CapturedAt:    now,
+	}
+	if insertErr := store.Snapshots.Insert(ctx, s); insertErr != nil {
+		log.Printf("snapshot: insert %s/%s: %v", entityID, metricKey, insertErr)
+	}
+	if pruneErr := store.Snapshots.Prune(ctx, entityID, metricKey, snapshotRetain); pruneErr != nil {
+		log.Printf("snapshot: prune %s/%s: %v", entityID, metricKey, pruneErr)
+	}
+
+	if prev != nil {
+		return *prev, changed
+	}
+	return "", false
+}
+
+// writeSnapshotEvent persists a single event for a snapshot condition change.
+func writeSnapshotEvent(
+	ctx context.Context,
+	store *repo.Store,
+	sourceID, sourceName, sourceType, level, title string,
+) {
+	payload := fmt.Sprintf(
+		`{"bucket":"snapshot","source_id":%q,"source_name":%q}`,
+		sourceID, sourceName,
+	)
+	ev := &models.Event{
+		ID:         uuid.New().String(),
+		Level:      level,
+		SourceName: sourceName,
+		SourceType: sourceType,
+		SourceID:   sourceID,
+		Title:      title,
+		Payload:    payload,
+		CreatedAt:  time.Now().UTC(),
+	}
+	if err := store.Events.Create(ctx, ev); err != nil {
+		log.Printf("snapshot: write event for %s (%s): %v", sourceName, sourceID, err)
+	}
+}
+
+// writeDebugEvent writes a debug-level completion event for a snapshot pass.
+func writeDebugEvent(ctx context.Context, store *repo.Store, sourceID, sourceName, sourceType string) {
+	writeSnapshotEvent(ctx, store, sourceID, sourceName, sourceType, "debug",
+		fmt.Sprintf("[snapshot] %s snapshot completed", sourceName))
+}
+
+// storageEventTitle returns a human-readable event title for a storage
+// utilisation condition change on a named pool.
+func storageEventTitle(componentName, poolKey, newCondition string, pct float64) (level, title string) {
+	switch newCondition {
+	case "error":
+		return "error", fmt.Sprintf("[snapshot] Storage critical — %s %s: %.1f%%", componentName, poolKey, pct)
+	case "warn":
+		return "warn", fmt.Sprintf("[snapshot] Storage high — %s %s: %.1f%%", componentName, poolKey, pct)
+	default:
+		return "info", fmt.Sprintf("[snapshot] Storage recovered — %s %s: %.1f%%", componentName, poolKey, pct)
+	}
+}

--- a/internal/scanner/snapshot/events_test.go
+++ b/internal/scanner/snapshot/events_test.go
@@ -1,0 +1,262 @@
+package snapshot
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// ── In-memory SnapshotRepo for tests ─────────────────────────────────────────
+
+type memSnapshotRepo struct {
+	mu   sync.Mutex
+	rows []models.Snapshot
+}
+
+func (r *memSnapshotRepo) GetLatest(_ context.Context, entityID, metricKey string) (*models.Snapshot, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var latest *models.Snapshot
+	for i := range r.rows {
+		row := &r.rows[i]
+		if row.EntityID == entityID && row.MetricKey == metricKey {
+			if latest == nil || row.CapturedAt.After(latest.CapturedAt) {
+				latest = row
+			}
+		}
+	}
+	if latest == nil {
+		return nil, repo.ErrNotFound
+	}
+	cp := *latest
+	return &cp, nil
+}
+
+func (r *memSnapshotRepo) Insert(_ context.Context, s *models.Snapshot) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.rows = append(r.rows, *s)
+	return nil
+}
+
+func (r *memSnapshotRepo) Prune(_ context.Context, entityID, metricKey string, limit int) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Collect matching rows sorted by time (already insertion-ordered here).
+	var matching []models.Snapshot
+	var other []models.Snapshot
+	for _, row := range r.rows {
+		if row.EntityID == entityID && row.MetricKey == metricKey {
+			matching = append(matching, row)
+		} else {
+			other = append(other, row)
+		}
+	}
+	if len(matching) > limit {
+		matching = matching[len(matching)-limit:]
+	}
+	r.rows = append(other, matching...)
+	return nil
+}
+
+// ── In-memory EventRepo stub ──────────────────────────────────────────────────
+
+type memEventRepo struct {
+	mu     sync.Mutex
+	events []models.Event
+}
+
+func (r *memEventRepo) Create(_ context.Context, ev *models.Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, *ev)
+	return nil
+}
+
+func (r *memEventRepo) List(_ context.Context, _ repo.ListFilter) ([]models.Event, int, error) {
+	return nil, 0, nil
+}
+func (r *memEventRepo) Get(_ context.Context, _ string) (*models.Event, error) {
+	return nil, errors.New("not implemented")
+}
+func (r *memEventRepo) Timeseries(_ context.Context, _, _ time.Time, _, _, _ string) ([]repo.TimeseriesBucket, error) {
+	return nil, nil
+}
+func (r *memEventRepo) CountForCategory(_ context.Context, _ repo.CategoryFilter) (int, error) {
+	return 0, nil
+}
+func (r *memEventRepo) SparklineBuckets(_ context.Context, _ repo.CategoryFilter, _ time.Time, _ time.Duration) ([7]int, error) {
+	return [7]int{}, nil
+}
+func (r *memEventRepo) LatestPerApp(_ context.Context, _ []string) (map[string]*models.Event, error) {
+	return nil, nil
+}
+func (r *memEventRepo) DeleteByLevelBefore(_ context.Context, _ string, _ time.Time) (int64, error) {
+	return 0, nil
+}
+func (r *memEventRepo) GroupByTypeAndLevel(_ context.Context, _ string, _, _ time.Time) ([]repo.EventTypeCount, error) {
+	return nil, nil
+}
+func (r *memEventRepo) MetricsForApp(_ context.Context, _ string, _, _ time.Time) (repo.EventMetrics, error) {
+	return repo.EventMetrics{}, nil
+}
+func (r *memEventRepo) CountPerApp(_ context.Context, _ time.Time) ([]repo.AppEventCount, error) {
+	return nil, nil
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+func buildTestStore(snapRepo *memSnapshotRepo, evRepo *memEventRepo) *repo.Store {
+	return &repo.Store{
+		Snapshots: snapRepo,
+		Events:    evRepo,
+	}
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+func TestCaptureSnapshot_FirstRead_NoChange(t *testing.T) {
+	snapRepo := &memSnapshotRepo{}
+	evRepo := &memEventRepo{}
+	store := buildTestStore(snapRepo, evRepo)
+
+	prev, changed := captureSnapshot(context.Background(), store,
+		"physical_host", "entity-1", "ssl_days_remaining", "45", time.Now())
+
+	if changed {
+		t.Error("want changed=false on first read, got true")
+	}
+	if prev != "" {
+		t.Errorf("want prev='', got %q", prev)
+	}
+	if len(snapRepo.rows) != 1 {
+		t.Errorf("want 1 snapshot row, got %d", len(snapRepo.rows))
+	}
+}
+
+func TestCaptureSnapshot_SameValue_NoChange(t *testing.T) {
+	snapRepo := &memSnapshotRepo{}
+	evRepo := &memEventRepo{}
+	store := buildTestStore(snapRepo, evRepo)
+
+	now := time.Now()
+	captureSnapshot(context.Background(), store, "physical_host", "e1", "metric", "42", now)
+	_, changed := captureSnapshot(context.Background(), store, "physical_host", "e1", "metric", "42", now.Add(time.Minute))
+
+	if changed {
+		t.Error("want changed=false when value unchanged")
+	}
+}
+
+func TestCaptureSnapshot_DifferentValue_Changed(t *testing.T) {
+	snapRepo := &memSnapshotRepo{}
+	evRepo := &memEventRepo{}
+	store := buildTestStore(snapRepo, evRepo)
+
+	now := time.Now()
+	captureSnapshot(context.Background(), store, "physical_host", "e1", "metric", "42", now)
+	prev, changed := captureSnapshot(context.Background(), store, "physical_host", "e1", "metric", "99", now.Add(time.Minute))
+
+	if !changed {
+		t.Error("want changed=true when value differs")
+	}
+	if prev != "42" {
+		t.Errorf("want prev=42, got %q", prev)
+	}
+}
+
+func TestCaptureSnapshot_Prunes_To48(t *testing.T) {
+	snapRepo := &memSnapshotRepo{}
+	evRepo := &memEventRepo{}
+	store := buildTestStore(snapRepo, evRepo)
+
+	now := time.Now()
+	for i := 0; i < 60; i++ {
+		captureSnapshot(context.Background(), store, "physical_host", "e1", "metric",
+			"val", now.Add(time.Duration(i)*time.Minute))
+	}
+
+	count := 0
+	for _, row := range snapRepo.rows {
+		if row.EntityID == "e1" && row.MetricKey == "metric" {
+			count++
+		}
+	}
+	if count > snapshotRetain {
+		t.Errorf("want at most %d rows after prune, got %d", snapshotRetain, count)
+	}
+}
+
+func TestStorageCondition(t *testing.T) {
+	tests := []struct{ pct float64; want string }{
+		{50, "ok"},
+		{79.9, "ok"},
+		{80, "warn"},
+		{89.9, "warn"},
+		{90, "error"},
+		{99, "error"},
+	}
+	for _, tt := range tests {
+		got := storageCondition(tt.pct)
+		if got != tt.want {
+			t.Errorf("storageCondition(%.1f) = %q, want %q", tt.pct, got, tt.want)
+		}
+	}
+}
+
+func TestSSLCondition(t *testing.T) {
+	tests := []struct{ days int; want string }{
+		{-1, "critical"},
+		{0, "critical"},
+		{1, "error"},
+		{7, "error"},
+		{8, "warn"},
+		{30, "warn"},
+		{31, "ok"},
+		{365, "ok"},
+	}
+	for _, tt := range tests {
+		got := sslCondition(tt.days)
+		if got != tt.want {
+			t.Errorf("sslCondition(%d) = %q, want %q", tt.days, got, tt.want)
+		}
+	}
+}
+
+func TestDiskHealthCondition(t *testing.T) {
+	tests := []struct{ status, want string }{
+		{"normal", "ok"},
+		{"warning", "warn"},
+		{"critical", "error"},
+		{"failing", "error"},
+		{"", "ok"},
+	}
+	for _, tt := range tests {
+		got := diskHealthCondition(tt.status)
+		if got != tt.want {
+			t.Errorf("diskHealthCondition(%q) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestSSLEventTitle_Improvement(t *testing.T) {
+	level, title := sslEventTitle("check", "ok", "warn", 45)
+	if level != "info" {
+		t.Errorf("want level=info on improvement, got %q", level)
+	}
+	if title == "" {
+		t.Error("want non-empty title")
+	}
+}
+
+func TestSSLEventTitle_Expiry(t *testing.T) {
+	level, _ := sslEventTitle("check", "critical", "ok", 0)
+	if level != "critical" {
+		t.Errorf("want level=critical for expired cert, got %q", level)
+	}
+}

--- a/internal/scanner/snapshot/opnsense.go
+++ b/internal/scanner/snapshot/opnsense.go
@@ -1,0 +1,141 @@
+package snapshot
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+)
+
+// OPNsenseSnapshotScanner captures the installed firmware version and available
+// update state for an OPNsense firewall every SnapshotInterval.
+type OPNsenseSnapshotScanner struct {
+	store *repo.Store
+}
+
+// NewOPNsenseSnapshotScanner returns an OPNsenseSnapshotScanner backed by store.
+func NewOPNsenseSnapshotScanner(store *repo.Store) *OPNsenseSnapshotScanner {
+	return &OPNsenseSnapshotScanner{store: store}
+}
+
+// opnsenseCreds mirrors the credentials JSON shape used by the metrics scanner.
+type opnsenseCreds struct {
+	BaseURL   string `json:"base_url"`
+	APIKey    string `json:"api_key"`
+	APISecret string `json:"api_secret"`
+	VerifyTLS bool   `json:"verify_tls"`
+}
+
+// opnsenseFirmwareInfo is the JSON shape returned by GET /api/core/firmware/info.
+type opnsenseFirmwareInfo struct {
+	Product struct {
+		ProductVersion string `json:"product_version"`
+		ProductLatest  string `json:"product_latest"`
+	} `json:"product"`
+}
+
+// TakeSnapshot fetches OPNsense firmware version and update state, then writes
+// snapshot rows. Events fire on condition changes only.
+func (s *OPNsenseSnapshotScanner) TakeSnapshot(ctx context.Context, entityID string, entityType string) (*scanner.SnapshotResult, error) {
+	c, err := s.store.InfraComponents.Get(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("get component %s: %w", entityID, err)
+	}
+	if c.Credentials == nil || *c.Credentials == "" {
+		return nil, fmt.Errorf("no credentials configured for %s", c.Name)
+	}
+
+	var creds opnsenseCreds
+	if err := json.Unmarshal([]byte(*c.Credentials), &creds); err != nil {
+		return nil, fmt.Errorf("parse opnsense credentials: %w", err)
+	}
+
+	transport := &http.Transport{}
+	if !creds.VerifyTLS {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	}
+	client := &http.Client{Transport: transport, Timeout: 15 * time.Second}
+
+	info, err := s.fetchFirmwareInfo(ctx, client, creds)
+	if err != nil {
+		return nil, fmt.Errorf("fetch firmware info: %w", err)
+	}
+
+	now := time.Now().UTC()
+	changed := false
+
+	// ── Installed version ──────────────────────────────────────────────────────
+	if info.Product.ProductVersion != "" {
+		_, ch := captureSnapshot(ctx, s.store, "physical_host", entityID,
+			"opnsense_version", info.Product.ProductVersion, now)
+		if ch {
+			changed = true
+			writeSnapshotEvent(ctx, s.store, entityID, c.Name, "physical_host", "info",
+				fmt.Sprintf("[snapshot] OPNsense updated — %s: %s",
+					c.Name, info.Product.ProductVersion))
+		}
+	}
+
+	// ── Update availability (product_latest != product_version) ───────────────
+	updateAvail := "false"
+	if info.Product.ProductLatest != "" &&
+		info.Product.ProductLatest != info.Product.ProductVersion {
+		updateAvail = info.Product.ProductLatest
+	}
+	prevUpd, ch := captureSnapshot(ctx, s.store, "physical_host", entityID,
+		"update_available", updateAvail, now)
+	if ch {
+		changed = true
+		if updateAvail != "false" && prevUpd == "false" {
+			writeSnapshotEvent(ctx, s.store, entityID, c.Name, "physical_host", "info",
+				fmt.Sprintf("[snapshot] OPNsense update available — %s: %s",
+					c.Name, updateAvail))
+		} else if updateAvail == "false" && prevUpd != "false" {
+			writeSnapshotEvent(ctx, s.store, entityID, c.Name, "physical_host", "info",
+				fmt.Sprintf("[snapshot] OPNsense update applied — %s", c.Name))
+		}
+	}
+
+	writeDebugEvent(ctx, s.store, entityID, c.Name, "physical_host")
+	log.Printf("opnsense snapshot: %s: done (changed=%v)", c.Name, changed)
+
+	return &scanner.SnapshotResult{
+		EntityID:   entityID,
+		EntityType: entityType,
+		Changed:    changed,
+	}, nil
+}
+
+func (s *OPNsenseSnapshotScanner) fetchFirmwareInfo(
+	ctx context.Context,
+	client *http.Client,
+	creds opnsenseCreds,
+) (*opnsenseFirmwareInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		creds.BaseURL+"/api/core/firmware/info", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(creds.APIKey, creds.APISecret)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET /api/core/firmware/info: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	var info opnsenseFirmwareInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("decode firmware info: %w", err)
+	}
+	return &info, nil
+}
+
+// compile-time interface check.
+var _ scanner.SnapshotScanner = (*OPNsenseSnapshotScanner)(nil)

--- a/internal/scanner/snapshot/proxmox.go
+++ b/internal/scanner/snapshot/proxmox.go
@@ -1,0 +1,138 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/infra"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+)
+
+// ProxmoxSnapshotScanner captures storage pool utilisation, PVE version, and
+// available update counts for all nodes in a Proxmox cluster every
+// SnapshotInterval.
+type ProxmoxSnapshotScanner struct {
+	store   *repo.Store
+	pollers sync.Map // componentID → *infra.ProxmoxPoller
+}
+
+// NewProxmoxSnapshotScanner returns a ProxmoxSnapshotScanner backed by store.
+func NewProxmoxSnapshotScanner(store *repo.Store) *ProxmoxSnapshotScanner {
+	return &ProxmoxSnapshotScanner{store: store}
+}
+
+// TakeSnapshot fetches storage pool utilisation, PVE version, and update counts
+// for every node in the Proxmox cluster and writes snapshot rows. Events are
+// fired on condition changes only.
+func (s *ProxmoxSnapshotScanner) TakeSnapshot(ctx context.Context, entityID string, entityType string) (*scanner.SnapshotResult, error) {
+	c, err := s.store.InfraComponents.Get(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("get component %s: %w", entityID, err)
+	}
+	if c.Credentials == nil || *c.Credentials == "" {
+		return nil, fmt.Errorf("no credentials configured for %s", c.Name)
+	}
+
+	poller, err := s.getOrCreatePoller(entityID, *c.Credentials)
+	if err != nil {
+		return nil, fmt.Errorf("create proxmox poller: %w", err)
+	}
+
+	now := time.Now().UTC()
+	changed := false
+
+	// ── Storage pools ─────────────────────────────────────────────────────────
+	pools, err := poller.FetchStoragePools(ctx)
+	if err != nil {
+		log.Printf("proxmox snapshot: %s: fetch storage pools: %v (non-fatal)", c.Name, err)
+	} else {
+		for _, pool := range pools {
+			if !pool.Active {
+				continue
+			}
+			nodePoolKey := fmt.Sprintf("%s/%s", pool.Node, pool.Name)
+			pctStr := fmt.Sprintf("%.2f", pool.UsedPercent)
+
+			_, ch := captureSnapshot(ctx, s.store, "physical_host", entityID,
+				"storage_pct_"+nodePoolKey, pctStr, now)
+			if ch {
+				changed = true
+				newCond := storageCondition(pool.UsedPercent)
+				if newCond != "ok" {
+					level, title := storageEventTitle(c.Name, nodePoolKey, newCond, pool.UsedPercent)
+					writeSnapshotEvent(ctx, s.store, entityID, c.Name, "physical_host", level, title)
+				}
+			}
+
+			captureSnapshot(ctx, s.store, "physical_host", entityID,
+				"storage_used_bytes_"+nodePoolKey, fmt.Sprintf("%d", pool.UsedBytes), now)
+			captureSnapshot(ctx, s.store, "physical_host", entityID,
+				"storage_total_bytes_"+nodePoolKey, fmt.Sprintf("%d", pool.TotalBytes), now)
+		}
+	}
+
+	// ── Node status: PVE version + available updates ───────────────────────────
+	nodeStatuses, err := poller.FetchNodeStatus(ctx)
+	if err != nil {
+		log.Printf("proxmox snapshot: %s: fetch node status: %v (non-fatal)", c.Name, err)
+	} else {
+		for _, ns := range nodeStatuses {
+			// PVE version
+			if ns.PVEVersion != "" {
+				_, ch := captureSnapshot(ctx, s.store, "physical_host", entityID,
+					"pve_version_"+ns.Node, ns.PVEVersion, now)
+				if ch {
+					changed = true
+					writeSnapshotEvent(ctx, s.store, entityID, c.Name, "physical_host", "info",
+						fmt.Sprintf("[snapshot] PVE updated — %s/%s: %s", c.Name, ns.Node, ns.PVEVersion))
+				}
+			}
+
+			// Available updates
+			updStr := fmt.Sprintf("%d", ns.UpdatesAvailable)
+			prevUpd, ch := captureSnapshot(ctx, s.store, "physical_host", entityID,
+				"updates_available_"+ns.Node, updStr, now)
+			if ch {
+				changed = true
+				prev := 0
+				fmt.Sscanf(prevUpd, "%d", &prev)
+				if ns.UpdatesAvailable > 0 && prev == 0 {
+					writeSnapshotEvent(ctx, s.store, entityID, c.Name, "physical_host", "info",
+						fmt.Sprintf("[snapshot] %d update(s) available — %s/%s",
+							ns.UpdatesAvailable, c.Name, ns.Node))
+				} else if ns.UpdatesAvailable == 0 && prev > 0 {
+					writeSnapshotEvent(ctx, s.store, entityID, c.Name, "physical_host", "info",
+						fmt.Sprintf("[snapshot] Updates applied — %s/%s", c.Name, ns.Node))
+				}
+			}
+		}
+	}
+
+	writeDebugEvent(ctx, s.store, entityID, c.Name, "physical_host")
+	log.Printf("proxmox snapshot: %s: done (changed=%v)", c.Name, changed)
+
+	return &scanner.SnapshotResult{
+		EntityID:   entityID,
+		EntityType: entityType,
+		Changed:    changed,
+	}, nil
+}
+
+func (s *ProxmoxSnapshotScanner) getOrCreatePoller(componentID, credJSON string) (*infra.ProxmoxPoller, error) {
+	if v, ok := s.pollers.Load(componentID); ok {
+		return v.(*infra.ProxmoxPoller), nil
+	}
+	p, err := infra.NewProxmoxPoller(componentID, credJSON)
+	if err != nil {
+		return nil, err
+	}
+	s.pollers.Store(componentID, p)
+	return p, nil
+}
+
+// compile-time interface check.
+var _ scanner.SnapshotScanner = (*ProxmoxSnapshotScanner)(nil)

--- a/internal/scanner/snapshot/snmp.go
+++ b/internal/scanner/snapshot/snmp.go
@@ -1,0 +1,98 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/infra"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+)
+
+// SNMPSnapshotScanner captures per-disk utilisation for hosts polled via SNMP
+// every SnapshotInterval. It fires warn events when a disk exceeds 80% and
+// error events when it exceeds 90%, and recovery events when it drops back below
+// the threshold.
+//
+// It is registered by collection_method="snmp" rather than by entity type,
+// matching the pattern established by the SNMP metrics scanner.
+type SNMPSnapshotScanner struct {
+	store   *repo.Store
+	pollers sync.Map // componentID → *infra.SNMPPoller
+}
+
+// NewSNMPSnapshotScanner returns an SNMPSnapshotScanner backed by store.
+func NewSNMPSnapshotScanner(store *repo.Store) *SNMPSnapshotScanner {
+	return &SNMPSnapshotScanner{store: store}
+}
+
+// TakeSnapshot reads disk utilisation from the SNMP host and writes snapshot
+// rows. Events fire on condition changes only.
+func (s *SNMPSnapshotScanner) TakeSnapshot(ctx context.Context, entityID string, entityType string) (*scanner.SnapshotResult, error) {
+	c, err := s.store.InfraComponents.Get(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("get component %s: %w", entityID, err)
+	}
+	if c.SNMPConfig == nil || *c.SNMPConfig == "" {
+		return nil, fmt.Errorf("no SNMP config for %s", c.Name)
+	}
+
+	poller, err := s.getOrCreatePoller(entityID, c.IP, *c.SNMPConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create SNMP poller: %w", err)
+	}
+
+	snap, err := poller.CollectMetrics(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("collect SNMP metrics: %w", err)
+	}
+
+	now := time.Now().UTC()
+	changed := false
+
+	for _, disk := range snap.Disks {
+		label := infra.SanitizeDiskLabel(disk.Label)
+		pctStr := fmt.Sprintf("%.2f", disk.Percent)
+		prevStr, ch := captureSnapshot(ctx, s.store, "snmp_host", entityID,
+			"disk_pct_"+label, pctStr, now)
+		if ch {
+			changed = true
+			newCond := storageCondition(disk.Percent)
+			var prevPct float64
+			fmt.Sscanf(prevStr, "%f", &prevPct)
+			prevCond := storageCondition(prevPct)
+
+			if newCond != prevCond {
+				level, title := storageEventTitle(c.Name, disk.Label, newCond, disk.Percent)
+				writeSnapshotEvent(ctx, s.store, entityID, c.Name, "physical_host", level, title)
+			}
+		}
+	}
+
+	writeDebugEvent(ctx, s.store, entityID, c.Name, "physical_host")
+	log.Printf("snmp snapshot: %s: done (changed=%v, disks=%d)", c.Name, changed, len(snap.Disks))
+
+	return &scanner.SnapshotResult{
+		EntityID:   entityID,
+		EntityType: entityType,
+		Changed:    changed,
+	}, nil
+}
+
+func (s *SNMPSnapshotScanner) getOrCreatePoller(componentID, ip, cfgJSON string) (*infra.SNMPPoller, error) {
+	if v, ok := s.pollers.Load(componentID); ok {
+		return v.(*infra.SNMPPoller), nil
+	}
+	p, err := infra.NewSNMPPoller(componentID, ip, cfgJSON)
+	if err != nil {
+		return nil, err
+	}
+	s.pollers.Store(componentID, p)
+	return p, nil
+}
+
+// compile-time interface check.
+var _ scanner.SnapshotScanner = (*SNMPSnapshotScanner)(nil)

--- a/internal/scanner/snapshot/ssl.go
+++ b/internal/scanner/snapshot/ssl.go
@@ -1,0 +1,180 @@
+package snapshot
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// SSLSnapshotJob captures SSL certificate expiry conditions for all enabled
+// SSL monitor checks every SnapshotInterval.
+//
+// For Traefik-sourced checks (ssl_source="traefik"), cert data is read from the
+// traefik_certs cache. For standalone checks a direct TLS dial is made.
+//
+// Unlike the metric-based monitor scheduler, this job fires events only on
+// condition changes (ok/warn/error/critical bucket transitions), not on every
+// status change.
+type SSLSnapshotJob struct {
+	store *repo.Store
+}
+
+// NewSSLSnapshotJob returns an SSLSnapshotJob backed by store.
+func NewSSLSnapshotJob(store *repo.Store) *SSLSnapshotJob {
+	return &SSLSnapshotJob{store: store}
+}
+
+// Run executes one SSL snapshot pass across all enabled SSL checks.
+func (j *SSLSnapshotJob) Run(ctx context.Context) {
+	checks, err := j.store.Checks.List(ctx)
+	if err != nil {
+		log.Printf("ssl snapshot: list checks: %v", err)
+		return
+	}
+
+	now := time.Now().UTC()
+	for i := range checks {
+		c := &checks[i]
+		if !c.Enabled || c.Type != "ssl" {
+			continue
+		}
+		j.snapshotCheck(ctx, c.ID, c.Name, c.Target, c.SSLSource, now)
+	}
+}
+
+// snapshotCheck snapshots a single SSL check.
+func (j *SSLSnapshotJob) snapshotCheck(
+	ctx context.Context,
+	checkID, checkName, target string,
+	sslSource *string,
+	now time.Time,
+) {
+	var daysRemaining int
+	var issuer, subject string
+
+	if sslSource != nil && *sslSource == "traefik" {
+		domain := target
+		cert, err := j.store.Infra.GetCertByDomain(ctx, domain)
+		if err != nil {
+			log.Printf("ssl snapshot: traefik cert for %s: %v", domain, err)
+			return
+		}
+		if cert.ExpiresAt == nil {
+			return
+		}
+		daysRemaining = int(time.Until(*cert.ExpiresAt).Hours() / 24)
+		if cert.Issuer != nil {
+			issuer = *cert.Issuer
+		}
+		subject = cert.Domain
+	} else {
+		d, iss, sub, err := dialSSL(ctx, target)
+		if err != nil {
+			log.Printf("ssl snapshot: dial %s: %v", target, err)
+			return
+		}
+		daysRemaining = d
+		issuer = iss
+		subject = sub
+	}
+
+	// Snapshot the raw days remaining value.
+	daysStr := fmt.Sprintf("%d", daysRemaining)
+	captureSnapshot(ctx, j.store, "monitor_check", checkID, "ssl_days_remaining", daysStr, now)
+
+	// Snapshot and event-check the condition bucket.
+	newCond := sslCondition(daysRemaining)
+	prevCond, changed := captureSnapshot(ctx, j.store, "monitor_check", checkID, "ssl_condition", newCond, now)
+
+	// Snapshot issuer and subject (no events — informational only).
+	captureSnapshot(ctx, j.store, "monitor_check", checkID, "ssl_issuer", issuer, now)
+	captureSnapshot(ctx, j.store, "monitor_check", checkID, "ssl_subject", subject, now)
+
+	if changed {
+		level, title := sslEventTitle(checkName, newCond, prevCond, daysRemaining)
+		writeSnapshotEvent(ctx, j.store, checkID, checkName, "monitor_check", level, title)
+	}
+
+	writeDebugEvent(ctx, j.store, checkID, checkName, "monitor_check")
+}
+
+// dialSSL opens a TLS connection to target and returns days remaining,
+// issuer, and subject common name.
+func dialSSL(ctx context.Context, target string) (daysRemaining int, issuer, subject string, err error) {
+	host := target
+	for _, prefix := range []string{"https://", "http://"} {
+		host = strings.TrimPrefix(host, prefix)
+	}
+	if i := strings.Index(host, "/"); i != -1 {
+		host = host[:i]
+	}
+	if !strings.Contains(host, ":") {
+		host = host + ":443"
+	}
+
+	dialer := &tls.Dialer{
+		NetDialer: &net.Dialer{Timeout: 10 * time.Second},
+		Config:    &tls.Config{InsecureSkipVerify: false}, //nolint:gosec
+	}
+	conn, dialErr := dialer.DialContext(ctx, "tcp", host)
+	if dialErr != nil {
+		return 0, "", "", fmt.Errorf("tls dial: %w", dialErr)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return 0, "", "", fmt.Errorf("not a TLS connection")
+	}
+	certs := tlsConn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		return 0, "", "", fmt.Errorf("no peer certificates")
+	}
+	cert := certs[0]
+	days := int(time.Until(cert.NotAfter.UTC()).Hours() / 24)
+	return days, cert.Issuer.CommonName, cert.Subject.CommonName, nil
+}
+
+// sslEventTitle returns the level and title for an SSL condition change event.
+func sslEventTitle(checkName, newCond, prevCond string, days int) (level, title string) {
+	// Renewal: condition improved (e.g. error → ok, or days jumped back up significantly).
+	if condLevel(newCond) < condLevel(prevCond) {
+		return "info", fmt.Sprintf("[snapshot] SSL renewed — %s: %d days remaining", checkName, days)
+	}
+	switch newCond {
+	case "critical":
+		return "critical", fmt.Sprintf("[snapshot] SSL expired — %s", checkName)
+	case "error":
+		return "error", fmt.Sprintf("[snapshot] SSL expiry critical — %s: %d days remaining", checkName, days)
+	case "warn":
+		return "warn", fmt.Sprintf("[snapshot] SSL expiring soon — %s: %d days remaining", checkName, days)
+	default:
+		return "info", fmt.Sprintf("[snapshot] SSL renewed — %s: %d days remaining", checkName, days)
+	}
+}
+
+// condLevel maps a condition string to an integer for comparison.
+func condLevel(cond string) int {
+	switch cond {
+	case "critical":
+		return 4
+	case "error":
+		return 3
+	case "warn":
+		return 2
+	case "ok":
+		return 1
+	default:
+		return 0
+	}
+}
+
+// SSLSnapshotJob does not implement scanner.SnapshotScanner intentionally —
+// it runs as a standalone job because it iterates monitor_checks rather than
+// infrastructure_components. It is started from main.go on a 30-minute ticker.

--- a/internal/scanner/snapshot/synology.go
+++ b/internal/scanner/snapshot/synology.go
@@ -1,0 +1,203 @@
+package snapshot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/infra"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner"
+)
+
+// SynologySnapshotScanner captures volume utilisation, disk health, DSM version,
+// and available update state for a Synology NAS every SnapshotInterval.
+type SynologySnapshotScanner struct {
+	store   *repo.Store
+	pollers sync.Map // componentID → *infra.SynologyPoller
+}
+
+// NewSynologySnapshotScanner returns a SynologySnapshotScanner backed by store.
+func NewSynologySnapshotScanner(store *repo.Store) *SynologySnapshotScanner {
+	return &SynologySnapshotScanner{store: store}
+}
+
+// TakeSnapshot fetches Synology condition data and writes snapshot rows. Events
+// are fired on condition changes only.
+func (s *SynologySnapshotScanner) TakeSnapshot(ctx context.Context, entityID string, entityType string) (*scanner.SnapshotResult, error) {
+	c, err := s.store.InfraComponents.Get(ctx, entityID)
+	if err != nil {
+		return nil, fmt.Errorf("get component %s: %w", entityID, err)
+	}
+	if c.Credentials == nil || *c.Credentials == "" {
+		return nil, fmt.Errorf("no credentials configured for %s", c.Name)
+	}
+
+	// Prefer the cached SynologyMeta (written by the legacy poller) to avoid
+	// an extra API call when the poller is already running.
+	if c.SynologyMeta != nil && *c.SynologyMeta != "" {
+		return s.snapshotFromMeta(ctx, entityID, entityType, c.Name, *c.SynologyMeta)
+	}
+
+	// No cached meta: fall back to a direct API call.
+	poller, err := s.getOrCreatePoller(entityID, *c.Credentials)
+	if err != nil {
+		return nil, fmt.Errorf("create synology poller: %w", err)
+	}
+	snap, err := poller.CollectMetrics(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("collect synology metrics: %w", err)
+	}
+
+	now := time.Now().UTC()
+	changed := false
+
+	// Volume utilisation
+	for _, vol := range snap.VolumeStats {
+		pctStr := fmt.Sprintf("%.2f", vol.DiskPercent)
+		_, ch := captureSnapshot(ctx, s.store, "physical_host", entityID,
+			"volume_pct_"+vol.Key, pctStr, now)
+		if ch {
+			changed = true
+			newCond := storageCondition(vol.DiskPercent)
+			if newCond != "ok" {
+				level, title := storageEventTitle(c.Name, vol.Key, newCond, vol.DiskPercent)
+				writeSnapshotEvent(ctx, s.store, entityID, c.Name, "physical_host", level, title)
+			}
+		}
+	}
+
+	writeDebugEvent(ctx, s.store, entityID, c.Name, "physical_host")
+	log.Printf("synology snapshot: %s: done via direct API (changed=%v)", c.Name, changed)
+
+	return &scanner.SnapshotResult{
+		EntityID:   entityID,
+		EntityType: entityType,
+		Changed:    changed,
+	}, nil
+}
+
+// snapshotFromMeta uses the cached SynologyMeta JSON (written every 5 minutes
+// by the legacy poller) so no extra API call is needed for the snapshot pass.
+func (s *SynologySnapshotScanner) snapshotFromMeta(
+	ctx context.Context,
+	entityID, entityType, componentName, metaJSON string,
+) (*scanner.SnapshotResult, error) {
+	var meta infra.SynologyMeta
+	if err := json.Unmarshal([]byte(metaJSON), &meta); err != nil {
+		return nil, fmt.Errorf("parse synology_meta: %w", err)
+	}
+
+	now := time.Now().UTC()
+	changed := false
+
+	// ── Volume utilisation ─────────────────────────────────────────────────────
+	for _, vol := range meta.Volumes {
+		pctStr := fmt.Sprintf("%.2f", vol.Percent)
+		_, ch := captureSnapshot(ctx, s.store, "physical_host", entityID,
+			"volume_pct_"+sanitiseVolPath(vol.Path), pctStr, now)
+		if ch {
+			changed = true
+			newCond := storageCondition(vol.Percent)
+			if newCond != "ok" {
+				level, title := storageEventTitle(componentName, vol.Path, newCond, vol.Percent)
+				writeSnapshotEvent(ctx, s.store, entityID, componentName, "physical_host", level, title)
+			}
+		}
+
+		captureSnapshot(ctx, s.store, "physical_host", entityID,
+			"volume_used_bytes_"+sanitiseVolPath(vol.Path),
+			fmt.Sprintf("%d", vol.UsedBytes), now)
+		captureSnapshot(ctx, s.store, "physical_host", entityID,
+			"volume_total_bytes_"+sanitiseVolPath(vol.Path),
+			fmt.Sprintf("%d", vol.TotalBytes), now)
+	}
+
+	// ── Disk health ────────────────────────────────────────────────────────────
+	for _, disk := range meta.Disks {
+		slotKey := fmt.Sprintf("disk%d", disk.Slot)
+		_, ch := captureSnapshot(ctx, s.store, "physical_host", entityID,
+			"disk_health_"+slotKey, disk.Status, now)
+		if ch {
+			changed = true
+			newCond := diskHealthCondition(disk.Status)
+			if newCond != "ok" {
+				level := "warn"
+				if newCond == "error" {
+					level = "error"
+				}
+				writeSnapshotEvent(ctx, s.store, entityID, componentName, "physical_host", level,
+					fmt.Sprintf("[snapshot] Disk health %s — %s slot %d (%s): %s",
+						disk.Status, componentName, disk.Slot, disk.Model, disk.Status))
+			}
+		}
+	}
+
+	// ── DSM version ────────────────────────────────────────────────────────────
+	if meta.DSMVersion != "" {
+		_, ch := captureSnapshot(ctx, s.store, "physical_host", entityID,
+			"dsm_version", meta.DSMVersion, now)
+		if ch {
+			changed = true
+			writeSnapshotEvent(ctx, s.store, entityID, componentName, "physical_host", "info",
+				fmt.Sprintf("[snapshot] DSM updated — %s: %s", componentName, meta.DSMVersion))
+		}
+	}
+
+	// ── Available updates ──────────────────────────────────────────────────────
+	updateVal := "false"
+	if meta.Update.Available && meta.Update.Version != "" {
+		updateVal = meta.Update.Version
+	}
+	prevUpd, ch := captureSnapshot(ctx, s.store, "physical_host", entityID,
+		"update_available", updateVal, now)
+	if ch {
+		changed = true
+		if meta.Update.Available && prevUpd == "false" {
+			writeSnapshotEvent(ctx, s.store, entityID, componentName, "physical_host", "info",
+				fmt.Sprintf("[snapshot] DSM update available — %s: %s", componentName, meta.Update.Version))
+		} else if !meta.Update.Available && prevUpd != "false" {
+			writeSnapshotEvent(ctx, s.store, entityID, componentName, "physical_host", "info",
+				fmt.Sprintf("[snapshot] DSM update applied — %s", componentName))
+		}
+	}
+
+	writeDebugEvent(ctx, s.store, entityID, componentName, "physical_host")
+	log.Printf("synology snapshot: %s: done from meta cache (changed=%v)", componentName, changed)
+
+	return &scanner.SnapshotResult{
+		EntityID:   entityID,
+		EntityType: entityType,
+		Changed:    changed,
+	}, nil
+}
+
+func (s *SynologySnapshotScanner) getOrCreatePoller(componentID, credJSON string) (*infra.SynologyPoller, error) {
+	if v, ok := s.pollers.Load(componentID); ok {
+		return v.(*infra.SynologyPoller), nil
+	}
+	p, err := infra.NewSynologyPoller(componentID, credJSON)
+	if err != nil {
+		return nil, err
+	}
+	s.pollers.Store(componentID, p)
+	return p, nil
+}
+
+// sanitiseVolPath strips the leading slash from a volume path for use as a
+// metric key suffix, e.g. "/volume1" → "volume1".
+func sanitiseVolPath(path string) string {
+	if len(path) > 0 && path[0] == '/' {
+		return path[1:]
+	}
+	if path == "" {
+		return "unknown"
+	}
+	return path
+}
+
+// compile-time interface check.
+var _ scanner.SnapshotScanner = (*SynologySnapshotScanner)(nil)

--- a/migrations/021_snapshots.sql
+++ b/migrations/021_snapshots.sql
@@ -1,0 +1,25 @@
+-- 021_snapshots.sql
+-- Snapshot table for slowly-changing condition data: SSL expiry, storage
+-- utilisation, OS versions, update counts, and disk health.
+--
+-- Snapshot scanners (REFACTOR-08) write one row per (entity_id, metric_key)
+-- pair per 30-minute pass. The most recent 48 readings per pair are retained;
+-- older rows are pruned by the scanner after each insert.
+--
+-- entity_type values match the source_type vocabulary used in the events table:
+--   physical_host   — infrastructure_components with type proxmox_node/synology/etc.
+--   monitor_check   — monitor_checks (SSL cert expiry)
+--   snmp_host       — infrastructure_components with collection_method=snmp
+
+CREATE TABLE snapshots (
+    id             TEXT      PRIMARY KEY,
+    entity_type    TEXT      NOT NULL,
+    entity_id      TEXT      NOT NULL,
+    metric_key     TEXT      NOT NULL,
+    metric_value   TEXT      NOT NULL,
+    previous_value TEXT,
+    captured_at    TIMESTAMP NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX idx_snapshots_entity_metric
+    ON snapshots (entity_id, metric_key, captured_at DESC);


### PR DESCRIPTION
## What
Implements REFACTOR-08: snapshot scanning with DB-backed state tracking for condition-change events fired every 30 minutes.

## Why
Closes REFACTOR-08. Completes the three-bucket scanner architecture (Discovery + Metrics + Snapshots) introduced in REFACTOR-05.

## How
- **`migrations/021_snapshots.sql`** — new `snapshots` table; 48-reading retention per entity+key via NOT IN subquery
- **`internal/repo/snapshots.go`** — `SnapshotRepo` with `GetLatest`, `Insert`, `Prune`; added `Snapshots` field to `Store`
- **`internal/scanner/snapshot/events.go`** — shared helpers: `captureSnapshot` (read→insert→prune, returns changed bool), `storageCondition` / `sslCondition` / `diskHealthCondition` threshold logic, event writers
- **`internal/scanner/snapshot/ssl.go`** — `SSLSnapshotJob` runs standalone (30m ticker in main.go) because it iterates `monitor_checks`, not `infrastructure_components`; handles both Traefik-sourced and standalone SSL checks
- **`internal/scanner/snapshot/proxmox.go`** — storage pool utilization, PVE version, available update count
- **`internal/scanner/snapshot/synology.go`** — volumes, disk health, DSM version; prefers cached `synology_meta` column to avoid extra API calls
- **`internal/scanner/snapshot/opnsense.go`** — firmware version and update availability via `/api/core/firmware/info`
- **`internal/scanner/snapshot/snmp.go`** — disk utilization registered via `RegisterSnapshotByMethod("snmp", ...)`
- Extended `ScanScheduler` with `snapshotsByMethod` map + `RegisterSnapshotByMethod` (matches MetricsScanner pattern)
- All test files updated for the new 19-arg `NewStore` signature

## Test coverage
- `internal/scanner/snapshot/events_test.go`: captureSnapshot (first read, same value, changed value, prune-to-48), all three condition helpers, SSL event title improvement/degradation
- `go test ./...` passes across all packages

## Closes
Closes REFACTOR-08