### PR TITLE
feat: DetailPageLayout + DiscoverNowButton shared components (REFACTOR-09)

### DIFF
--- a/frontend/src/components/DetailPageLayout.css
+++ b/frontend/src/components/DetailPageLayout.css
@@ -1,0 +1,162 @@
+/* ── Detail Page Layout ──────────────────────────────────────────────────────
+   Shared chrome for all entity detail pages. Enforces:
+   breadcrumb + name (left) | status + polled + actions (right)
+   key data points row
+   divider / children / divider
+   EventFeed
+   ────────────────────────────────────────────────────────────────────────── */
+
+/* ── Header ──────────────────────────────────────────────────────────────── */
+
+.dpl-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.dpl-header-left {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dpl-breadcrumb {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+}
+
+.dpl-breadcrumb:hover { color: var(--text); }
+
+.dpl-name {
+  font-family: var(--mono);
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+
+.dpl-header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding-top: 4px;
+}
+
+/* ── Status indicator ────────────────────────────────────────────────────── */
+
+.dpl-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.dpl-dot-online  { background: var(--green); }
+.dpl-dot-offline { background: var(--red); }
+.dpl-dot-warning { background: var(--yellow, #eab308); }
+.dpl-dot-unknown { background: var(--text3); }
+
+.dpl-status-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  text-transform: capitalize;
+}
+
+.dpl-last-polled {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+}
+
+.dpl-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ── Key data points row ─────────────────────────────────────────────────── */
+
+.dpl-kdp-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.dpl-kdp-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--mono);
+  font-size: 11px;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 8px;
+  white-space: nowrap;
+}
+
+.dpl-kdp-label {
+  color: var(--text3);
+}
+
+.dpl-kdp-value {
+  color: var(--text2);
+}
+
+/* ── Dividers ────────────────────────────────────────────────────────────── */
+
+.dpl-divider {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 20px 0;
+}
+
+/* ── Content area ────────────────────────────────────────────────────────── */
+
+.dpl-content {
+  /* Children render directly — no additional wrapper styles needed */
+}
+
+/* ── Discover Now button ─────────────────────────────────────────────────── */
+
+.dpl-discover-btn {
+  font-family: var(--mono);
+  font-size: 11px;
+  background: var(--bg3);
+  color: var(--text2);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 3px 10px;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.dpl-discover-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.dpl-discover-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dpl-discover-error {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--red);
+}

--- a/frontend/src/components/DetailPageLayout.tsx
+++ b/frontend/src/components/DetailPageLayout.tsx
@@ -1,0 +1,128 @@
+import { useNavigate } from 'react-router-dom'
+import { Topbar } from './Topbar'
+import { EventFeed } from './EventFeed'
+import './DetailPageLayout.css'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface KeyDataPoint {
+  label: string
+  value: string
+}
+
+export interface StatusIndicator {
+  status: 'online' | 'offline' | 'unknown' | 'warning'
+  label?: string
+}
+
+export interface DetailPageLayoutProps {
+  /** e.g. "Infrastructure" — rendered as "← Infrastructure" link */
+  breadcrumb: string
+  /** Route to navigate to on breadcrumb click */
+  breadcrumbPath: string
+  /** Entity name — large heading and Topbar title */
+  name: string
+  /** Badges rendered under the name */
+  keyDataPoints?: KeyDataPoint[]
+  /** Online/offline/unknown dot + label, top right */
+  status?: StatusIndicator
+  /** "Last polled Xs ago" — top right, next to status */
+  lastPolled?: string
+  /** Top right action area (e.g. Discover Now button) */
+  actions?: React.ReactNode
+  /** Required for EventFeed at the bottom */
+  sourceType: string
+  /** Required for EventFeed at the bottom */
+  sourceId: string
+  /** Unique content section — rendered between dividers */
+  children: React.ReactNode
+}
+
+// ── Status dot colors ─────────────────────────────────────────────────────────
+
+const STATUS_DOT_CLASS: Record<StatusIndicator['status'], string> = {
+  online:  'dpl-dot-online',
+  offline: 'dpl-dot-offline',
+  unknown: 'dpl-dot-unknown',
+  warning: 'dpl-dot-warning',
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function DetailPageLayout({
+  breadcrumb,
+  breadcrumbPath,
+  name,
+  keyDataPoints,
+  status,
+  lastPolled,
+  actions,
+  sourceType,
+  sourceId,
+  children,
+}: DetailPageLayoutProps) {
+  const navigate = useNavigate()
+
+  return (
+    <>
+      <Topbar title={name} />
+      <div className="content">
+
+        {/* ── Header row ── */}
+        <div className="dpl-header">
+          <div className="dpl-header-left">
+            <button
+              className="dpl-breadcrumb"
+              onClick={() => navigate(breadcrumbPath)}
+            >
+              ← {breadcrumb}
+            </button>
+            <h1 className="dpl-name">{name}</h1>
+          </div>
+
+          <div className="dpl-header-right">
+            {status && (
+              <>
+                <span className={`dpl-status-dot ${STATUS_DOT_CLASS[status.status]}`} />
+                <span className="dpl-status-label">
+                  {status.label ?? status.status}
+                </span>
+              </>
+            )}
+            {lastPolled && (
+              <span className="dpl-last-polled">{lastPolled}</span>
+            )}
+            {actions && (
+              <div className="dpl-actions">{actions}</div>
+            )}
+          </div>
+        </div>
+
+        {/* ── Key data points ── */}
+        {keyDataPoints && keyDataPoints.length > 0 && (
+          <div className="dpl-kdp-row">
+            {keyDataPoints.map((pt, i) => (
+              <span key={i} className="dpl-kdp-badge">
+                {pt.label && <span className="dpl-kdp-label">{pt.label}</span>}
+                <span className="dpl-kdp-value">{pt.value}</span>
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* ── Divider ── */}
+        <div className="dpl-divider" />
+
+        {/* ── Unique content ── */}
+        <div className="dpl-content">{children}</div>
+
+        {/* ── Divider ── */}
+        <div className="dpl-divider" />
+
+        {/* ── Event feed — always at the bottom, not configurable ── */}
+        <EventFeed sourceType={sourceType} sourceId={sourceId} />
+
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/DiscoverNowButton.tsx
+++ b/frontend/src/components/DiscoverNowButton.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { infrastructure as infraApi } from '../api/client'
+
+interface Props {
+  /** The component type (e.g. "proxmox", "docker_engine") — for display context */
+  entityType: string
+  /** The infrastructure component ID to discover */
+  entityId: string
+  /** Called after a successful discover so the parent can reload its data */
+  onSuccess?: () => void
+}
+
+export function DiscoverNowButton({ entityId, onSuccess }: Props) {
+  const [discovering, setDiscovering] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleClick() {
+    if (discovering) return
+    setDiscovering(true)
+    setError(null)
+    try {
+      await infraApi.discover(entityId)
+      onSuccess?.()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Discover failed')
+    } finally {
+      setDiscovering(false)
+    }
+  }
+
+  return (
+    <>
+      <button
+        className="dpl-discover-btn"
+        onClick={() => void handleClick()}
+        disabled={discovering}
+      >
+        {discovering ? 'Discovering…' : 'Discover Now'}
+      </button>
+      {error && (
+        <span className="dpl-discover-error">{error}</span>
+      )}
+    </>
+  )
+}

--- a/frontend/src/pages/InfraComponentDetail.css
+++ b/frontend/src/pages/InfraComponentDetail.css
@@ -482,7 +482,7 @@
   transition: opacity 0.15s;
 }
 
-/* ── Scan Now button (header) ────────────────────────────────────────────────── */
+/* ── Discover Now button (header) ────────────────────────────────────────────── */
 
 .icd-scan-btn {
   font-family: var(--mono);


### PR DESCRIPTION
## What
Adds two new shared frontend components:
- `DetailPageLayout` — enforces the standard chrome for all entity detail pages (breadcrumb, name, key data points, status, dividers, EventFeed at bottom)
- `DiscoverNowButton` — reusable button that calls `POST /infrastructure/{id}/discover` with loading state and inline error display

Also renames the "Scan Now" CSS comment in `InfraComponentDetail.css` to "Discover Now" to match the canonical label.

## Why
Closes REFACTOR-09. Every detail page currently builds its own header chrome with slight inconsistencies. This component enforces a single layout contract so future pages are consistent by construction.

## How
- `DetailPageLayout` wraps `<Topbar>` + `<div className="content">` and enforces the exact structure: breadcrumb (top-left) → entity name → key data points row → divider → children → divider → `EventFeed`. `sourceType` and `sourceId` are required props so `EventFeed` is always rendered.
- `StatusIndicator` supports `online | offline | unknown | warning` with corresponding CSS color tokens from `variables.css`.
- `DiscoverNowButton` accepts `entityType`, `entityId`, and optional `onSuccess` callback. Uses `infrastructure.discover()` from the API client — no direct fetch().
- All styles use existing design tokens from `variables.css` — no invented values.

## Test coverage
- `npm run build` passes with zero TypeScript errors (249 modules transformed).

## Closes
Closes REFACTOR-09