### PR TITLE
feat: retrofit all detail pages to use DetailPageLayout (REFACTOR-10)

### DIFF
--- a/frontend/src/components/DetailPageLayout.css
+++ b/frontend/src/components/DetailPageLayout.css
@@ -160,3 +160,80 @@
   font-size: 11px;
   color: var(--red);
 }
+
+/* ── Header extra (compact linked apps, etc.) ─────────────────────────────── */
+
+.dpl-header-extra {
+  margin-bottom: 10px;
+}
+
+.dpl-linked-apps-compact {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.dpl-linked-apps-label {
+  font-size: 10px;
+  font-family: var(--mono);
+  color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-right: 2px;
+}
+
+.dpl-linked-app-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  font-size: 12px;
+  color: var(--text1);
+}
+
+.dpl-linked-app-chip button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text3);
+  font-size: 13px;
+  padding: 0;
+  line-height: 1;
+}
+
+.dpl-linked-app-chip button:hover {
+  color: var(--red, #ef4444);
+}
+
+.dpl-linked-apps-select {
+  font-size: 11px;
+  padding: 2px 6px;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text1);
+}
+
+.dpl-linked-apps-link-btn {
+  font-size: 11px;
+  padding: 2px 8px;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--text1);
+}
+
+.dpl-linked-apps-link-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.dpl-linked-apps-link-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/DetailPageLayout.tsx
+++ b/frontend/src/components/DetailPageLayout.tsx
@@ -30,8 +30,10 @@ export interface DetailPageLayoutProps {
   lastPolled?: string
   /** Top right action area (e.g. Discover Now button) */
   actions?: React.ReactNode
-  /** Required for EventFeed at the bottom */
-  sourceType: string
+  /** Extra content rendered between the KDP row and the first divider (e.g. compact linked apps) */
+  headerExtra?: React.ReactNode
+  /** Optional source_type filter for EventFeed at the bottom */
+  sourceType?: string
   /** Required for EventFeed at the bottom */
   sourceId: string
   /** Unique content section — rendered between dividers */
@@ -57,6 +59,7 @@ export function DetailPageLayout({
   status,
   lastPolled,
   actions,
+  headerExtra,
   sourceType,
   sourceId,
   children,
@@ -108,6 +111,11 @@ export function DetailPageLayout({
               </span>
             ))}
           </div>
+        )}
+
+        {/* ── Header extra (e.g. compact linked apps) ── */}
+        {headerExtra && (
+          <div className="dpl-header-extra">{headerExtra}</div>
         )}
 
         {/* ── Divider ── */}

--- a/frontend/src/components/DockerEngineDetail.tsx
+++ b/frontend/src/components/DockerEngineDetail.tsx
@@ -8,7 +8,7 @@ import type { DiscoveredContainer, App, AppTemplate } from '../api/types'
 
 interface Props {
   engineId: string
-  onCountsLoaded: (total: number, unlinked: number) => void
+  onCountsLoaded: (total: number, running: number, unlinked: number) => void
 }
 
 // ── Link form state ───────────────────────────────────────────────────────────
@@ -91,8 +91,9 @@ export function DockerEngineDetail({ engineId, onCountsLoaded }: Props) {
         setContainers(ctrs.data)
         setApps(appList.data)
         setTemplates(tmplList.data)
+        const running = ctrs.data.filter(c => c.status === 'running').length
         const unlinked = ctrs.data.filter(c => !c.app_id).length
-        onCountsLoadedRef.current(ctrs.data.length, unlinked)
+        onCountsLoadedRef.current(ctrs.data.length, running, unlinked)
       })
       .catch(console.error)
       .finally(() => setLoading(false))

--- a/frontend/src/pages/AppDetail.tsx
+++ b/frontend/src/pages/AppDetail.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
-import { Topbar } from '../components/Topbar'
-import { EventFeed } from '../components/EventFeed'
+import { DetailPageLayout } from '../components/DetailPageLayout'
 import { apps as appsApi, dashboard as dashboardApi, appTemplates as templatesApi } from '../api/client'
 import type { App, AppSummary, AppTemplate } from '../api/types'
 import '../styles/Modal.css'
@@ -317,7 +316,7 @@ export function AppDetail() {
   const navigate = useNavigate()
   const { tick } = useAutoRefresh()
 
-  const [timeFilter, setTimeFilter] = useState<TimeFilter>('week')
+  const timeFilter: TimeFilter = 'week'
 
   const [app, setApp] = useState<App | null>(null)
   const [appSummary, setAppSummary] = useState<AppSummary | null>(null)
@@ -347,32 +346,32 @@ export function AppDetail() {
 
   const appName = app?.name ?? appId
   const baseUrl = app?.config?.base_url as string | undefined
-  const status = appSummary?.status ?? 'online'
-  const topbarStatus = status === 'online' ? 'ok' : (status as 'warn' | 'down')
+  const rawStatus = appSummary?.status ?? 'online'
+  const dplStatus: 'online' | 'offline' | 'unknown' | 'warning' =
+    rawStatus === 'online' ? 'online' : rawStatus === 'down' ? 'offline' : 'warning'
   const lastEvent = appSummary?.last_event_at
     ? new Date(appSummary.last_event_at).toLocaleString('en-US', {
         month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true,
       })
     : null
+
+  const keyDataPoints = [
+    { label: 'Profile', value: app?.profile_id || 'Generic' },
+    { label: 'Rate limit', value: app?.rate_limit ? `${app.rate_limit}/min` : 'Unlimited' },
+    ...(baseUrl ? [{ label: 'URL', value: baseUrl }] : []),
+  ]
+
   return (
     <>
-      <Topbar title={appName} status={topbarStatus} timeFilter={timeFilter} onTimeFilter={setTimeFilter} />
-      <div className="content">
-
-        {/* ── App header ── */}
-        <div className="detail-header">
-          <div className="detail-header-left">
-            <div className="detail-app-icon">{appName.slice(0, 2).toUpperCase()}</div>
-            <div className="detail-app-meta">
-              <div className="detail-app-name">{appName}</div>
-              {lastEvent && <div className="detail-app-last">Last event: {lastEvent}</div>}
-            </div>
-            <div className="detail-status-dot-wrap">
-              <div className={`status-dot${status !== 'online' ? ` ${status === 'down' ? 'down' : 'warn'}` : ''}`} />
-            </div>
-          </div>
-
-          <div className="detail-header-actions">
+      <DetailPageLayout
+        breadcrumb="Apps"
+        breadcrumbPath="/apps"
+        name={appName}
+        status={{ status: dplStatus }}
+        lastPolled={lastEvent ? `Last event: ${lastEvent}` : undefined}
+        keyDataPoints={keyDataPoints}
+        actions={
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
             {baseUrl && (
               <a className="detail-launch-btn" href={baseUrl} target="_blank" rel="noopener noreferrer">
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -391,8 +390,10 @@ export function AppDetail() {
               Settings
             </button>
           </div>
-        </div>
-
+        }
+        sourceType="app"
+        sourceId={appId}
+      >
         {/* ── Stats row ── */}
         {appSummary && (
           <div className="detail-stats-row">
@@ -412,11 +413,7 @@ export function AppDetail() {
             )}
           </div>
         )}
-
-        {/* ── Events section ── */}
-        <EventFeed sourceType="app" sourceId={appId} />
-
-      </div>
+      </DetailPageLayout>
 
       {showSettings && app && (
         <AppSettingsModal

--- a/frontend/src/pages/CheckDetail.tsx
+++ b/frontend/src/pages/CheckDetail.tsx
@@ -2,8 +2,8 @@ import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { Topbar } from '../components/Topbar'
+import { DetailPageLayout } from '../components/DetailPageLayout'
 import { checks as checksApi, integrations as integrationsApi } from '../api/client'
-import { EventFeed } from '../components/EventFeed'
 import type { MonitorCheck, InfraIntegration, TraefikCert } from '../api/types'
 import {
   CheckForm,
@@ -16,31 +16,6 @@ import {
 import { formatEventTime } from '../utils/formatTime'
 import '../styles/Modal.css'
 import './CheckDetail.css'
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function statusLabel(check: MonitorCheck): string {
-  if (check.type === 'ssl') {
-    if (check.last_result) {
-      try {
-        const r = JSON.parse(check.last_result) as { days_remaining?: number }
-        if (r.days_remaining != null) return `${r.days_remaining}d`
-      } catch { /* fallthrough */ }
-    }
-    return 'SSL'
-  }
-  if (check.last_status === 'up') return 'UP'
-  if (check.last_status === 'down') return 'DOWN'
-  if (check.last_status === 'warn') return 'WARN'
-  return '—'
-}
-
-function statusClass(status: string | null): string {
-  if (status === 'up') return 'monitor-status-block up'
-  if (status === 'warn') return 'monitor-status-block warn'
-  if (status === 'down' || status === 'critical') return 'monitor-status-block down'
-  return 'monitor-status-block unknown'
-}
 
 // ── Edit Modal ────────────────────────────────────────────────────────────────
 
@@ -239,32 +214,29 @@ export function CheckDetail() {
 
   if (!check) return null
 
+  const dplStatus: 'online' | 'offline' | 'unknown' | 'warning' =
+    check.last_status === 'up'   ? 'online'  :
+    check.last_status === 'down' ? 'offline' :
+    check.last_status === 'warn' ? 'warning' : 'unknown'
+
+  const keyDataPoints = [
+    { label: 'Type', value: check.type.toUpperCase() },
+    { label: 'Target', value: check.target },
+    { label: 'Interval', value: `every ${check.interval_secs}s` },
+    { label: 'Status', value: check.last_status ? check.last_status.toUpperCase() : 'UNKNOWN' },
+  ]
+
   return (
     <>
-      <Topbar title={check.name} />
-      <div className="content">
-
-        {/* Header */}
-        <div className="check-detail-header">
-          <div className="check-detail-header-left">
-            <button className="check-detail-back-btn" onClick={() => navigate('/checks')}>
-              ← Checks
-            </button>
-            <div className={statusClass(check.last_status)}>
-              {statusLabel(check)}
-            </div>
-            <div className="check-detail-meta">
-              <div className="check-detail-name">
-                {check.name}
-                <span className={`check-type-badge check-type-${check.type}`}>
-                  {check.type.toUpperCase()}
-                </span>
-                {!check.enabled && <span className="check-paused-badge">PAUSED</span>}
-              </div>
-              <div className="check-detail-target">{check.target}</div>
-            </div>
-          </div>
-          <div className="check-detail-header-actions">
+      <DetailPageLayout
+        breadcrumb="Checks"
+        breadcrumbPath="/checks"
+        name={check.name}
+        status={{ status: dplStatus }}
+        lastPolled={check.last_checked_at ? formatEventTime(check.last_checked_at) : undefined}
+        keyDataPoints={keyDataPoints}
+        actions={
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
             <button
               className="check-detail-action-btn"
               onClick={() => void handleRun()}
@@ -282,34 +254,10 @@ export function CheckDetail() {
               ⚙ Settings
             </button>
           </div>
-        </div>
-
-        {/* Stats */}
-        <div className="check-detail-stats">
-          <div className="check-detail-stat">
-            <div className="check-detail-stat-label">Status</div>
-            <div className={`check-detail-stat-value ${check.last_status ?? 'unknown'}`}>
-              {check.last_status ? check.last_status.toUpperCase() : 'UNKNOWN'}
-            </div>
-          </div>
-          <div className="check-detail-stat">
-            <div className="check-detail-stat-label">Last Checked</div>
-            <div className="check-detail-stat-value">
-              {check.last_checked_at
-                ? new Date(check.last_checked_at).toLocaleString()
-                : '—'}
-            </div>
-          </div>
-          <div className="check-detail-stat">
-            <div className="check-detail-stat-label">Interval</div>
-            <div className="check-detail-stat-value">every {check.interval_secs}s</div>
-          </div>
-          <div className="check-detail-stat">
-            <div className="check-detail-stat-label">Type</div>
-            <div className="check-detail-stat-value">{check.type.toUpperCase()}</div>
-          </div>
-        </div>
-
+        }
+        sourceType="monitor_check"
+        sourceId={id ?? ''}
+      >
         {/* Last Result */}
         <div className="check-detail-section">
           <div className="check-detail-section-header">
@@ -326,11 +274,7 @@ export function CheckDetail() {
             </div>
           </div>
         </div>
-
-        {/* History */}
-        <EventFeed sourceType="monitor_check" sourceId={id ?? ''} title="HISTORY" />
-
-      </div>
+      </DetailPageLayout>
 
       {showEdit && (
         <EditModal

--- a/frontend/src/pages/InfraComponentDetail.tsx
+++ b/frontend/src/pages/InfraComponentDetail.tsx
@@ -2,12 +2,12 @@ import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { Topbar } from '../components/Topbar'
+import { DetailPageLayout } from '../components/DetailPageLayout'
+import { DiscoverNowButton } from '../components/DiscoverNowButton'
 import { DockerEngineDetail } from '../components/DockerEngineDetail'
-import { EventFeed } from '../components/EventFeed'
 import { infrastructure as infraApi, apps as appsApi } from '../api/client'
 import type {
   App,
-  DiscoverResult,
   InfrastructureComponent,
   ResourceSummary,
   ResourceHistory,
@@ -18,6 +18,15 @@ import type {
 import './InfraComponentDetail.css'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+function timeAgo(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const secs = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  if (secs < 60) return `${secs}s ago`
+  if (secs < 3600) return `${Math.floor(secs / 60)}m ago`
+  if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`
+  return `${Math.floor(secs / 86400)}d ago`
+}
 
 const TYPE_LABEL: Record<string, string> = {
   proxmox_node:  'Proxmox Node',
@@ -279,8 +288,7 @@ export function InfraComponentDetail() {
   const [allApps,       setAllApps]       = useState<App[]>([])
   const [linkingAppId,  setLinkingAppId]  = useState('')
   const [linkBusy,      setLinkBusy]      = useState(false)
-  const [discovering,   setDiscovering]   = useState(false)
-  const [discoverError, setDiscoverError] = useState<string | null>(null)
+  const [dockerCounts,  setDockerCounts]  = useState({ total: 0, running: 0 })
   const [loading,       setLoading]       = useState(true)
   const [error,         setError]         = useState<string | null>(null)
 
@@ -312,31 +320,17 @@ export function InfraComponentDetail() {
       .finally(() => setLoading(false))
   }, [id, tick])
 
-  async function handleDiscover() {
+  async function handleDiscoverSuccess() {
     if (!id || !component) return
-    setDiscovering(true)
-    setDiscoverError(null)
-    try {
-      const result: DiscoverResult = await infraApi.discover(id)
-      if (result.error) {
-        setDiscoverError(result.error)
-        return
-      }
-      // Re-fetch component status + resources + SNMP detail after discovery.
-      const [comp, res] = await Promise.all([
-        infraApi.get(id),
-        infraApi.resources(id, 'hour'),
-      ])
-      setComponent(comp)
-      setResources(res)
-      if (component.collection_method === 'snmp') {
-        const det = await infraApi.snmpDetail(id)
-        setSnmpDetail(det)
-      }
-    } catch (err: unknown) {
-      setDiscoverError(err instanceof Error ? err.message : 'Discovery failed')
-    } finally {
-      setDiscovering(false)
+    const [comp, res] = await Promise.all([
+      infraApi.get(id),
+      infraApi.resources(id, 'hour'),
+    ])
+    setComponent(comp)
+    setResources(res)
+    if (component.collection_method === 'snmp') {
+      const det = await infraApi.snmpDetail(id)
+      setSnmpDetail(det)
     }
   }
 
@@ -359,9 +353,9 @@ export function InfraComponentDetail() {
     setLinkedApps(prev => prev.filter(a => a.id !== appId))
   }
 
-  const statusClass = (s: string) => {
+  function dplStatus(s: string): 'online' | 'offline' | 'unknown' | 'warning' {
     if (s === 'online')   return 'online'
-    if (s === 'degraded') return 'degraded'
+    if (s === 'degraded') return 'warning'
     if (s === 'offline')  return 'offline'
     return 'unknown'
   }
@@ -399,59 +393,108 @@ export function InfraComponentDetail() {
     return null
   }
 
+  const keyDataPoints = [
+    { label: 'Type', value: TYPE_LABEL[component.type] ?? component.type },
+    ...(component.ip ? [{ label: 'IP', value: component.ip }] : []),
+    ...(component.type === 'docker_engine' ? [
+      { label: 'Containers', value: `${dockerCounts.running} running / ${dockerCounts.total} total` },
+    ] : []),
+    ...(component.collection_method === 'snmp' && snmpDetail && !snmpDetail.no_data ? [
+      { label: 'Hostname', value: snmpDetail.hostname || '—' },
+      { label: 'Uptime', value: snmpDetail.uptime || '—' },
+      { label: 'OS', value: snmpDetail.os_description
+          ? (snmpDetail.os_description.length > 30 ? snmpDetail.os_description.slice(0, 30) + '…' : snmpDetail.os_description)
+          : '—' },
+    ] : []),
+  ]
+
+  const linkedIds = new Set(linkedApps.map(a => a.id))
+  const availableApps = allApps.filter(a => !linkedIds.has(a.id))
+
+  const dockerLinkedAppsHeader = component.type === 'docker_engine' ? (
+    <div className="dpl-linked-apps-compact">
+      <span className="dpl-linked-apps-label">Linked Apps</span>
+      {linkedApps.map(app => (
+        <span key={app.id} className="dpl-linked-app-chip">
+          {app.name}
+          <button onClick={() => void handleUnlinkApp(app.id)} title="Unlink">×</button>
+        </span>
+      ))}
+      {availableApps.length > 0 && (
+        <>
+          <select
+            className="dpl-linked-apps-select"
+            value={linkingAppId}
+            onChange={e => setLinkingAppId(e.target.value)}
+          >
+            <option value="">— link app —</option>
+            {availableApps.map(a => (
+              <option key={a.id} value={a.id}>{a.name}</option>
+            ))}
+          </select>
+          <button
+            className="dpl-linked-apps-link-btn"
+            disabled={!linkingAppId || linkBusy}
+            onClick={() => void handleLinkApp()}
+          >
+            {linkBusy ? 'Linking…' : 'Link'}
+          </button>
+        </>
+      )}
+      {linkedApps.length === 0 && availableApps.length === 0 && (
+        <span style={{ fontSize: 12, color: 'var(--text3)' }}>None</span>
+      )}
+    </div>
+  ) : undefined
+
   return (
-    <>
-      <Topbar title={component.name} />
-      <div className="content">
+    <DetailPageLayout
+      breadcrumb="Infrastructure"
+      breadcrumbPath="/topology"
+      name={component.name}
+      status={{ status: dplStatus(component.last_status) }}
+      lastPolled={component.last_polled_at ? `Polled ${timeAgo(component.last_polled_at)}` : undefined}
+      keyDataPoints={keyDataPoints}
+      headerExtra={dockerLinkedAppsHeader}
+      actions={
+        component.collection_method !== 'none' ? (
+          <DiscoverNowButton
+            entityType={component.type}
+            entityId={component.id}
+            onSuccess={() => void handleDiscoverSuccess()}
+          />
+        ) : undefined
+      }
+      sourceId={component.id}
+    >
+      {/* SNMP hosts: three-section detail view */}
+      {component.collection_method === 'snmp' && (
+        <SNMPSection detail={snmpDetail} />
+      )}
 
-        {/* Header */}
-        <div className="icd-header">
-          <div className="icd-header-left">
-            <button className="icd-back-btn" onClick={() => navigate('/topology')}>← Infrastructure</button>
-            <h1 className="icd-title">{component.name}</h1>
-          </div>
-          <div className="icd-header-meta">
-            <span className={`icd-status-dot ${statusClass(component.last_status)}`} />
-            <span className="icd-status-label">{component.last_status}</span>
-            <span className="icd-type-badge">{TYPE_LABEL[component.type] ?? component.type}</span>
-            {component.ip && <span className="icd-ip">{component.ip}</span>}
-            {component.collection_method !== 'none' && (
-              <button
-                className="icd-scan-btn"
-                onClick={() => void handleDiscover()}
-                disabled={discovering}
-              >
-                {discovering ? 'Discovering…' : 'Discover Now'}
-              </button>
-            )}
-          </div>
+      {/* Non-SNMP resource metrics */}
+      {component.type !== 'docker_engine' && component.collection_method !== 'snmp' && (
+        <ResourceSection resources={resources} history={history} />
+      )}
+
+      {/* Type-specific content */}
+      {component.type === 'docker_engine' && (
+        <div className="icd-section">
+          <div className="icd-section-title">Containers</div>
+          <DockerEngineDetail
+            engineId={component.id}
+            onCountsLoaded={(total, running) => setDockerCounts({ total, running })}
+          />
         </div>
-        {discoverError && <div className="icd-scan-error">{discoverError}</div>}
+      )}
 
-        {/* SNMP hosts: three-section detail view */}
-        {component.collection_method === 'snmp' && (
-          <SNMPSection detail={snmpDetail} />
-        )}
+      {/* Discovered VMs & LXC containers (Proxmox nodes) */}
+      {component.type === 'proxmox_node' && (
+        <ProxmoxChildrenSection children={children} onNavigate={navigate} />
+      )}
 
-        {/* Non-SNMP resource metrics (Proxmox, Synology, etc.) */}
-        {component.type !== 'docker_engine' && component.collection_method !== 'snmp' && (
-          <ResourceSection resources={resources} history={history} />
-        )}
-
-        {/* Type-specific content */}
-        {component.type === 'docker_engine' && (
-          <div className="icd-section">
-            <div className="icd-section-title">Containers</div>
-            <DockerEngineDetail engineId={component.id} onCountsLoaded={() => {}} />
-          </div>
-        )}
-
-        {/* Discovered VMs & LXC containers (Proxmox nodes) */}
-        {component.type === 'proxmox_node' && (
-          <ProxmoxChildrenSection children={children} onNavigate={navigate} />
-        )}
-
-        {/* Linked Applications */}
+      {/* Linked Applications — only for non-docker types (docker uses headerExtra) */}
+      {component.type !== 'docker_engine' && (
         <LinkedAppsSection
           linkedApps={linkedApps}
           allApps={allApps}
@@ -461,12 +504,8 @@ export function InfraComponentDetail() {
           onLink={() => void handleLinkApp()}
           onUnlink={(appId) => void handleUnlinkApp(appId)}
         />
-
-        {/* Recent Events */}
-        <EventFeed sourceId={component.id} />
-
-      </div>
-    </>
+      )}
+    </DetailPageLayout>
   )
 }
 

--- a/frontend/src/pages/ProxmoxDetail.tsx
+++ b/frontend/src/pages/ProxmoxDetail.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { Topbar } from '../components/Topbar'
+import { DetailPageLayout } from '../components/DetailPageLayout'
+import { DiscoverNowButton } from '../components/DiscoverNowButton'
 import { infrastructure as infraApi, proxmox as proxmoxApi } from '../api/client'
 import type {
   InfrastructureComponent,
@@ -523,8 +525,6 @@ export function ProxmoxDetail() {
   const [resources,    setResources]    = useState<ResourceSummary | null>(null)
   const [topLoading,   setTopLoading]   = useState(true)
   const [topError,     setTopError]     = useState<string | null>(null)
-  const [discovering,  setDiscovering]  = useState(false)
-  const [discoverError, setDiscoverError] = useState<string | null>(null)
 
   // Section data
   const [pools,        setPools]        = useState<ProxmoxStoragePool[]>([])
@@ -596,23 +596,6 @@ export function ProxmoxDetail() {
       .finally(() => setFailuresLoading(false))
   }, [componentId])
 
-  const handleDiscoverNow = useCallback(async () => {
-    if (!componentId || discovering) return
-    setDiscovering(true)
-    setDiscoverError(null)
-    try {
-      await infraApi.discover(componentId)
-      loadTop()
-      loadPools()
-      loadGuests()
-      loadStatus()
-      loadFailures()
-    } catch (err) {
-      setDiscoverError(err instanceof Error ? err.message : 'Discover failed')
-    } finally {
-      setDiscovering(false)
-    }
-  }, [componentId, discovering, loadTop, loadPools, loadGuests, loadStatus, loadFailures])
 
   // Initial load and auto-refresh
   useEffect(() => {
@@ -623,9 +606,9 @@ export function ProxmoxDetail() {
     loadFailures()
   }, [loadTop, loadPools, loadGuests, loadStatus, loadFailures, tick])
 
-  const statusClass = (s: string) => {
+  function dplStatus(s: string): 'online' | 'offline' | 'unknown' | 'warning' {
     if (s === 'online')   return 'online'
-    if (s === 'degraded') return 'degraded'
+    if (s === 'degraded') return 'warning'
     if (s === 'offline')  return 'offline'
     return 'unknown'
   }
@@ -648,87 +631,76 @@ export function ProxmoxDetail() {
   }
 
   const updatesAvailable = nodeStatuses.reduce((sum, ns) => sum + ns.updates_available, 0)
+  const ns = nodeStatuses[0]
+
+  const keyDataPoints = [
+    { label: 'Uptime',   value: ns?.uptime     ? formatUptime(ns.uptime)    : '—' },
+    { label: 'vCPUs',    value: ns?.cpu_count   ? String(ns.cpu_count)       : '—' },
+    { label: 'RAM',      value: ns?.total_mem_bytes ? formatBytes(ns.total_mem_bytes) : '—' },
+    { label: 'PVE',      value: ns?.pve_version ?? '—' },
+  ]
 
   return (
-    <>
-      <Topbar title={component?.name ?? 'Proxmox'} />
-      <div className="content">
-
-        {/* Header */}
-        <div className="px-header">
-          <div className="px-header-left">
-            <button className="px-back-btn" onClick={() => navigate(-1)}>
-              ← Infrastructure
-            </button>
-            <h1 className="px-title">
-              {topLoading ? <span className="px-skeleton-inline" /> : (component?.name ?? '…')}
-            </h1>
-          </div>
-          <div className="px-header-right">
-            {component && (
-              <>
-                <span className={`px-status-dot ${statusClass(component.last_status)}`} />
-                <span className="px-status-label">{component.last_status}</span>
-              </>
-            )}
-            {component?.last_polled_at && (
-              <span className="px-polled-at">
-                Last polled {timeAgo(component.last_polled_at)}
-              </span>
-            )}
-            <button
-              className="px-scan-btn"
-              onClick={() => void handleDiscoverNow()}
-              disabled={discovering || topLoading}
-            >
-              {discovering ? 'Discovering…' : 'Discover Now'}
-            </button>
-            {discoverError && (
-              <span className="px-scan-error">{discoverError}</span>
-            )}
-          </div>
-        </div>
-
-        {/* Updates banner */}
-        {!statusLoading && !statusError && updatesAvailable > 0 && component && (
-          <UpdatesBanner
-            componentId={componentId!}
-            count={updatesAvailable}
-            nodeName={component.name}
-          />
-        )}
-
-        {/* Node Overview */}
-        <NodeOverviewSection
-          resources={topLoading ? null : resources}
-          nodeStatuses={statusLoading ? [] : nodeStatuses}
+    <DetailPageLayout
+      breadcrumb="Infrastructure"
+      breadcrumbPath="/topology"
+      name={topLoading ? '…' : (component?.name ?? 'Proxmox')}
+      status={component ? { status: dplStatus(component.last_status) } : undefined}
+      lastPolled={component?.last_polled_at ? `Polled ${timeAgo(component.last_polled_at)}` : undefined}
+      keyDataPoints={statusLoading ? [] : keyDataPoints}
+      actions={
+        <DiscoverNowButton
+          entityType="proxmox_node"
+          entityId={componentId!}
+          onSuccess={() => {
+            loadTop()
+            loadPools()
+            loadGuests()
+            loadStatus()
+            loadFailures()
+          }}
         />
-
-        {/* Storage Pools */}
-        <StoragePoolsSection
-          pools={pools}
-          loading={poolsLoading}
-          error={poolsError ? `Failed to load storage pools. ${poolsError}` : null}
-          onRetry={loadPools}
+      }
+      sourceId={componentId!}
+    >
+      {/* Updates banner */}
+      {!statusLoading && !statusError && updatesAvailable > 0 && component && (
+        <UpdatesBanner
+          componentId={componentId!}
+          count={updatesAvailable}
+          nodeName={component.name}
         />
+      )}
 
-        {/* VMs & LXCs */}
-        <GuestsSection
-          guests={guests}
-          loading={guestsLoading}
-          error={guestsError ? `Failed to load guests. ${guestsError}` : null}
-          onRetry={loadGuests}
-        />
+      {/* Node Overview */}
+      <NodeOverviewSection
+        resources={topLoading ? null : resources}
+        nodeStatuses={statusLoading ? [] : nodeStatuses}
+      />
 
-        {/* Task Failures */}
-        <TaskFailuresSection
-          failures={failures}
-          loading={failuresLoading}
-          error={failuresError ? `Failed to load task failures. ${failuresError}` : null}
-          onRetry={loadFailures}
-        />
+      {/* Storage Pools */}
+      <StoragePoolsSection
+        pools={pools}
+        loading={poolsLoading}
+        error={poolsError ? `Failed to load storage pools. ${poolsError}` : null}
+        onRetry={loadPools}
+      />
 
-      </div>
-    </>
+      {/* VMs & LXCs */}
+      <GuestsSection
+        guests={guests}
+        loading={guestsLoading}
+        error={guestsError ? `Failed to load guests. ${guestsError}` : null}
+        onRetry={loadGuests}
+      />
+
+      {/* Task Failures */}
+      <TaskFailuresSection
+        failures={failures}
+        loading={failuresLoading}
+        error={failuresError ? `Failed to load task failures. ${failuresError}` : null}
+        onRetry={loadFailures}
+      />
+    </DetailPageLayout>
   )
 }

--- a/frontend/src/pages/SynologyDetail.tsx
+++ b/frontend/src/pages/SynologyDetail.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { Topbar } from '../components/Topbar'
+import { DetailPageLayout } from '../components/DetailPageLayout'
+import { DiscoverNowButton } from '../components/DiscoverNowButton'
 import { infrastructure as infraApi, synology as synologyApi } from '../api/client'
 import type {
   InfrastructureComponent,
@@ -59,13 +61,6 @@ function statusDotClass(status: string): string {
 function statusLabel(status: string): string {
   if (!status) return '—'
   return status.charAt(0).toUpperCase() + status.slice(1)
-}
-
-function hostStatusClass(s: string): string {
-  if (s === 'online') return 'online'
-  if (s === 'degraded') return 'degraded'
-  if (s === 'offline' || s === 'down') return 'offline'
-  return 'unknown'
 }
 
 // ── Sub-components ────────────────────────────────────────────────────────────
@@ -143,8 +138,6 @@ export function SynologyDetail() {
   const [noData, setNoData] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [discovering,   setDiscovering]   = useState(false)
-  const [discoverError, setDiscoverError] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     if (!componentId) return
@@ -163,20 +156,6 @@ export function SynologyDetail() {
       setLoading(false)
     }
   }, [componentId])
-
-  const handleDiscoverNow = useCallback(async () => {
-    if (!componentId || discovering) return
-    setDiscovering(true)
-    setDiscoverError(null)
-    try {
-      await infraApi.discover(componentId)
-      void load()
-    } catch (err) {
-      setDiscoverError(err instanceof Error ? err.message : 'Discover failed')
-    } finally {
-      setDiscovering(false)
-    }
-  }, [componentId, discovering, load])
 
   useEffect(() => { load() }, [load, tick])
 
@@ -202,142 +181,142 @@ export function SynologyDetail() {
   }
 
   const d = detail
-  const statusCls = hostStatusClass(component.last_status)
+
+  function dplStatus(s: string): 'online' | 'offline' | 'unknown' | 'warning' {
+    if (s === 'online')   return 'online'
+    if (s === 'degraded') return 'warning'
+    if (s === 'offline' || s === 'down') return 'offline'
+    return 'unknown'
+  }
+
+  const totalStorageBytes = d?.volumes.reduce((sum, v) => sum + v.total_bytes, 0) ?? 0
+
+  const keyDataPoints = [
+    { label: 'Model',   value: d?.model        || '—' },
+    { label: 'DSM',     value: d?.dsm_version  || '—' },
+    { label: 'Storage', value: totalStorageBytes > 0 ? formatBytes(totalStorageBytes) : '—' },
+    { label: 'Uptime',  value: d?.uptime       || '—' },
+  ]
 
   return (
-    <>
-      <Topbar title={component.name} />
-      <div className="content">
-
-        {/* Header */}
-        <div className="icd-header">
-          <div className="icd-header-left">
-            <button className="icd-back-btn" onClick={() => navigate('/topology')}>← Infrastructure</button>
-            <h1 className="icd-title">{component.name}</h1>
-          </div>
-          <div className="icd-header-meta">
-            <span className={`icd-status-dot ${statusCls}`} />
-            <span className="icd-status-label">{component.last_status}</span>
-            <span className="icd-type-badge">Synology NAS</span>
-            {component.ip && <span className="icd-ip">{component.ip}</span>}
-            {d?.polled_at && (
-              <span className="syn-polled-at">polled {timeAgo(d.polled_at)}</span>
-            )}
-            <button
-              className="icd-scan-btn"
-              onClick={() => void handleDiscoverNow()}
-              disabled={discovering}
+    <DetailPageLayout
+      breadcrumb="Infrastructure"
+      breadcrumbPath="/topology"
+      name={component.name}
+      status={{ status: dplStatus(component.last_status) }}
+      lastPolled={d?.polled_at ? `Polled ${timeAgo(d.polled_at)}` : undefined}
+      keyDataPoints={noData ? [] : keyDataPoints}
+      actions={
+        <DiscoverNowButton
+          entityType="synology"
+          entityId={componentId!}
+          onSuccess={() => void load()}
+        />
+      }
+      sourceId={componentId!}
+    >
+      {/* Section 1 — System Info */}
+      <div className="icd-section">
+        <div className="icd-section-title">System Info</div>
+        {noData ? (
+          <div className="snmp-pending">Awaiting first scan</div>
+        ) : (
+          <div className="syn-info-grid">
+            <span className="syn-info-key">Model</span>
+            <span className="syn-info-val">{d?.model || '—'}</span>
+            <span className="syn-info-key">DSM</span>
+            <span className="syn-info-val">{d?.dsm_version || '—'}</span>
+            <span className="syn-info-key">Hostname</span>
+            <span className="syn-info-val">{d?.hostname || '—'}</span>
+            <span className="syn-info-key">Uptime</span>
+            <span className="syn-info-val">{d?.uptime || '—'}</span>
+            <span className="syn-info-key">Temp</span>
+            <span
+              className="syn-info-val"
+              style={d?.temperature_c ? { color: tempColor(d.temperature_c) } : undefined}
             >
-              {discovering ? 'Discovering…' : 'Discover Now'}
-            </button>
-            {discoverError && <span className="icd-scan-error">{discoverError}</span>}
+              {d?.temperature_c ? `${d.temperature_c}°C` : '—'}
+            </span>
           </div>
-        </div>
-
-        {/* Section 1 — System Info */}
-        <div className="icd-section">
-          <div className="icd-section-title">System Info</div>
-          {noData ? (
-            <div className="snmp-pending">Awaiting first scan</div>
-          ) : (
-            <div className="syn-info-grid">
-              <span className="syn-info-key">Model</span>
-              <span className="syn-info-val">{d?.model || '—'}</span>
-              <span className="syn-info-key">DSM</span>
-              <span className="syn-info-val">{d?.dsm_version || '—'}</span>
-              <span className="syn-info-key">Hostname</span>
-              <span className="syn-info-val">{d?.hostname || '—'}</span>
-              <span className="syn-info-key">Uptime</span>
-              <span className="syn-info-val">{d?.uptime || '—'}</span>
-              <span className="syn-info-key">Temp</span>
-              <span
-                className="syn-info-val"
-                style={d?.temperature_c ? { color: tempColor(d.temperature_c) } : undefined}
-              >
-                {d?.temperature_c ? `${d.temperature_c}°C` : '—'}
-              </span>
-            </div>
-          )}
-        </div>
-
-        {/* Section 2 — CPU & Memory */}
-        <div className="icd-section">
-          <div className="icd-section-title">CPU &amp; Memory</div>
-          <div className="syn-res-list">
-            <ResourceBar
-              label="CPU"
-              value={d?.cpu_percent ?? 0}
-              color={barFillColor(d?.cpu_percent ?? 0)}
-            />
-            <ResourceBar
-              label="MEM"
-              value={d?.memory?.percent ?? 0}
-              color={barFillColor(d?.memory?.percent ?? 0)}
-              extra={
-                d?.memory?.total_bytes
-                  ? `${formatBytes(d.memory.used_bytes)} / ${formatBytes(d.memory.total_bytes)}`
-                  : undefined
-              }
-            />
-          </div>
-        </div>
-
-        {/* Section 3 — Volumes */}
-        <div className="icd-section">
-          <div className="icd-section-title">Volumes</div>
-          {!d || d.volumes.length === 0 ? (
-            <div className="snmp-pending">Pending first scan</div>
-          ) : (
-            <div className="syn-vol-list">
-              {d.volumes.map(vol => (
-                <VolumeRow key={vol.path} vol={vol} />
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Section 4 — Disks */}
-        <div className="icd-section">
-          <div className="icd-section-title">Disks</div>
-          {!d || d.disks.length === 0 ? (
-            <div className="snmp-pending">Pending first scan</div>
-          ) : (
-            <div className="syn-disk-list">
-              {d.disks.map(disk => (
-                <DiskRow key={disk.slot} disk={disk} />
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Section 5 — Updates */}
-        <div className="icd-section">
-          <div className="icd-section-title">Updates</div>
-          <div className="syn-update-row">
-            <span className="syn-update-label">DSM</span>
-            {!d ? (
-              <span className="syn-update-value muted">—</span>
-            ) : d.update?.available ? (
-              <>
-                <span className="syn-update-arrow">↑</span>
-                <span className="syn-update-value available">{d.update.version} available</span>
-                {d.dsm_version && (
-                  <span className="syn-update-current">(currently {d.dsm_version})</span>
-                )}
-              </>
-            ) : (
-              <>
-                <span className="syn-update-check">✓</span>
-                <span className="syn-update-value">Up to date</span>
-                {d.dsm_version && (
-                  <span className="syn-update-current muted">{d.dsm_version}</span>
-                )}
-              </>
-            )}
-          </div>
-        </div>
-
+        )}
       </div>
-    </>
+
+      {/* Section 2 — CPU & Memory */}
+      <div className="icd-section">
+        <div className="icd-section-title">CPU &amp; Memory</div>
+        <div className="syn-res-list">
+          <ResourceBar
+            label="CPU"
+            value={d?.cpu_percent ?? 0}
+            color={barFillColor(d?.cpu_percent ?? 0)}
+          />
+          <ResourceBar
+            label="MEM"
+            value={d?.memory?.percent ?? 0}
+            color={barFillColor(d?.memory?.percent ?? 0)}
+            extra={
+              d?.memory?.total_bytes
+                ? `${formatBytes(d.memory.used_bytes)} / ${formatBytes(d.memory.total_bytes)}`
+                : undefined
+            }
+          />
+        </div>
+      </div>
+
+      {/* Section 3 — Volumes */}
+      <div className="icd-section">
+        <div className="icd-section-title">Volumes</div>
+        {!d || d.volumes.length === 0 ? (
+          <div className="snmp-pending">Pending first scan</div>
+        ) : (
+          <div className="syn-vol-list">
+            {d.volumes.map(vol => (
+              <VolumeRow key={vol.path} vol={vol} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Section 4 — Disks */}
+      <div className="icd-section">
+        <div className="icd-section-title">Disks</div>
+        {!d || d.disks.length === 0 ? (
+          <div className="snmp-pending">Pending first scan</div>
+        ) : (
+          <div className="syn-disk-list">
+            {d.disks.map(disk => (
+              <DiskRow key={disk.slot} disk={disk} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Section 5 — Updates */}
+      <div className="icd-section">
+        <div className="icd-section-title">Updates</div>
+        <div className="syn-update-row">
+          <span className="syn-update-label">DSM</span>
+          {!d ? (
+            <span className="syn-update-value muted">—</span>
+          ) : d.update?.available ? (
+            <>
+              <span className="syn-update-arrow">↑</span>
+              <span className="syn-update-value available">{d.update.version} available</span>
+              {d.dsm_version && (
+                <span className="syn-update-current">(currently {d.dsm_version})</span>
+              )}
+            </>
+          ) : (
+            <>
+              <span className="syn-update-check">✓</span>
+              <span className="syn-update-value">Up to date</span>
+              {d.dsm_version && (
+                <span className="syn-update-current muted">{d.dsm_version}</span>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </DetailPageLayout>
   )
 }

--- a/frontend/src/pages/TraefikDetail.tsx
+++ b/frontend/src/pages/TraefikDetail.tsx
@@ -2,15 +2,14 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { Topbar } from '../components/Topbar'
-import { EventRow } from '../components/EventRow'
+import { DetailPageLayout } from '../components/DetailPageLayout'
+import { DiscoverNowButton } from '../components/DiscoverNowButton'
 import {
   infrastructure as infraApi,
   traefik as traefikApi,
 } from '../api/client'
 import type {
-  Event,
   InfrastructureComponent,
-  DiscoverResult,
   TraefikOverview,
   DiscoveredRoute,
   TraefikServiceDetail,
@@ -462,60 +461,6 @@ function ServicesSection({
   )
 }
 
-// ── Events section ────────────────────────────────────────────────────────────
-
-function ComponentEventsSection({ componentId }: { componentId: string }) {
-  const [events, setEvents] = useState<Event[]>([])
-  const [total, setTotal] = useState(0)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    setLoading(true)
-    infraApi.events(componentId, { limit: 25, sort: 'newest' })
-      .then(r => { setEvents(r.data); setTotal(r.total); setError(null) })
-      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load events'))
-      .finally(() => setLoading(false))
-  }, [componentId])
-
-  return (
-    <div className="tk-section">
-      <div className="tk-section-header-row">
-        <div className="tk-section-title" style={{ margin: 0 }}>Recent Events</div>
-        {!loading && !error && (
-          <span className="tk-count-label">{total} total</span>
-        )}
-      </div>
-      {error ? (
-        <SectionError msg={error} onRetry={() => {
-          setLoading(true)
-          infraApi.events(componentId, { limit: 25, sort: 'newest' })
-            .then(r => { setEvents(r.data); setTotal(r.total); setError(null) })
-            .catch(err => setError(err instanceof Error ? err.message : 'Failed to load events'))
-            .finally(() => setLoading(false))
-        }} />
-      ) : loading ? (
-        <table className="tk-table"><tbody><SkeletonRows count={4} /></tbody></table>
-      ) : events.length === 0 ? (
-        <div className="tk-empty">No events recorded for this component.</div>
-      ) : (
-        <>
-          <div className="event-row events-col-header">
-            <span>Time</span>
-            <span />
-            <span>Source</span>
-            <span>Event</span>
-            <span>Severity</span>
-          </div>
-          {events.map(ev => (
-            <EventRow key={ev.id} event={ev} />
-          ))}
-        </>
-      )}
-    </div>
-  )
-}
-
 // ── Main page ─────────────────────────────────────────────────────────────────
 
 export function TraefikDetail() {
@@ -529,10 +474,6 @@ export function TraefikDetail() {
   const [component,    setComponent]    = useState<InfrastructureComponent | null>(null)
   const [topLoading,   setTopLoading]   = useState(true)
   const [topError,     setTopError]     = useState<string | null>(null)
-
-  // Discover Now
-  const [discovering,     setDiscovering]     = useState(false)
-  const [discoverResult,  setDiscoverResult]  = useState<DiscoverResult | null>(null)
 
   // Overview
   const [overview,        setOverview]        = useState<TraefikOverview | null>(null)
@@ -585,31 +526,6 @@ export function TraefikDetail() {
       .finally(() => setServicesLoading(false))
   }, [componentId])
 
-  const handleDiscoverNow = useCallback(async () => {
-    if (!componentId || discovering) return
-    setDiscovering(true)
-    setDiscoverResult(null)
-    try {
-      const result = await infraApi.discover(componentId)
-      setDiscoverResult(result)
-      // Reload all sections with fresh data from the just-completed poll.
-      loadTop()
-      loadOverview()
-      loadRouters()
-      loadServices()
-    } catch (err) {
-      setDiscoverResult({
-        status: 'error',
-        discovered: 0,
-        updated: 0,
-        missing: 0,
-        error: err instanceof Error ? err.message : 'Discover failed',
-      })
-    } finally {
-      setDiscovering(false)
-    }
-  }, [componentId, discovering, loadTop, loadOverview, loadRouters, loadServices])
-
   useEffect(() => {
     loadTop()
     loadOverview()
@@ -623,9 +539,9 @@ export function TraefikDetail() {
     serviceHealthMap[s.service_name] = `${s.servers_up}/${s.server_count} UP`
   }
 
-  const statusClass = (s: string) => {
+  function dplStatus(s: string): 'online' | 'offline' | 'unknown' | 'warning' {
     if (s === 'online')   return 'online'
-    if (s === 'degraded') return 'degraded'
+    if (s === 'degraded') return 'warning'
     if (s === 'offline')  return 'offline'
     return 'unknown'
   }
@@ -646,82 +562,60 @@ export function TraefikDetail() {
     )
   }
 
+  const keyDataPoints = [
+    { label: 'Version',  value: overview?.version ?? '—' },
+    { label: 'Routers',  value: overview ? String(overview.routers_total) : '—' },
+    { label: 'Services', value: overview ? String(overview.services_total) : '—' },
+  ]
+
   return (
-    <>
-      <Topbar title={component?.name ?? 'Traefik'} />
-      <div className="content">
-
-        {/* Header */}
-        <div className="tk-header">
-          <div className="tk-header-left">
-            <button className="tk-back-btn" onClick={() => navigate(-1)}>
-              ← Infrastructure
-            </button>
-            <h1 className="tk-title">
-              {topLoading
-                ? <span className="tk-skeleton-inline" />
-                : (component?.name ?? '…')}
-            </h1>
-          </div>
-          <div className="tk-header-right">
-            {component && (
-              <>
-                <span className={`tk-status-dot ${statusClass(component.last_status)}`} />
-                <span className="tk-status-label">{component.last_status}</span>
-              </>
-            )}
-            {!overviewLoading && overview?.version && (
-              <span className="tk-version">{overview.version}</span>
-            )}
-            {overview?.updated_at && (
-              <span className="tk-polled-at">
-                Last polled {timeAgo(overview.updated_at)}
-              </span>
-            )}
-            <button
-              className="tk-scan-btn"
-              onClick={() => void handleDiscoverNow()}
-              disabled={discovering || topLoading}
-            >
-              {discovering ? 'Discovering…' : 'Discover Now'}
-            </button>
-            {discoverResult?.error && (
-              <span className="tk-scan-error">{discoverResult.error}</span>
-            )}
-          </div>
-        </div>
-
-        {/* Overview */}
-        <OverviewSection
-          overview={overviewLoading ? null : overview}
-          loading={overviewLoading}
-          error={overviewError}
-          onRetry={loadOverview}
-          routersRef={routersSectionRef}
+    <DetailPageLayout
+      breadcrumb="Infrastructure"
+      breadcrumbPath="/topology"
+      name={topLoading ? '…' : (component?.name ?? 'Traefik')}
+      status={component ? { status: dplStatus(component.last_status) } : undefined}
+      lastPolled={overview?.updated_at ? `Polled ${timeAgo(overview.updated_at)}` : undefined}
+      keyDataPoints={overviewLoading ? [] : keyDataPoints}
+      actions={
+        <DiscoverNowButton
+          entityType="traefik"
+          entityId={componentId!}
+          onSuccess={() => {
+            loadTop()
+            loadOverview()
+            loadRouters()
+            loadServices()
+          }}
         />
+      }
+      sourceId={componentId!}
+    >
+      {/* Overview */}
+      <OverviewSection
+        overview={overviewLoading ? null : overview}
+        loading={overviewLoading}
+        error={overviewError}
+        onRetry={loadOverview}
+        routersRef={routersSectionRef}
+      />
 
-        {/* Routers */}
-        <RoutersSection
-          routers={routers}
-          loading={routersLoading}
-          error={routersError}
-          onRetry={loadRouters}
-          sectionRef={routersSectionRef}
-          serviceHealthMap={serviceHealthMap}
-        />
+      {/* Routers */}
+      <RoutersSection
+        routers={routers}
+        loading={routersLoading}
+        error={routersError}
+        onRetry={loadRouters}
+        sectionRef={routersSectionRef}
+        serviceHealthMap={serviceHealthMap}
+      />
 
-        {/* Services */}
-        <ServicesSection
-          services={services}
-          loading={servicesLoading}
-          error={servicesError}
-          onRetry={loadServices}
-        />
-
-        {/* Events */}
-        {componentId && <ComponentEventsSection componentId={componentId} />}
-
-      </div>
-    </>
+      {/* Services */}
+      <ServicesSection
+        services={services}
+        loading={servicesLoading}
+        error={servicesError}
+        onRetry={loadServices}
+      />
+    </DetailPageLayout>
   )
 }


### PR DESCRIPTION
## What
Retrofits every entity detail page in the frontend to use the shared `DetailPageLayout` component established in REFACTOR-09. No new features — consistent structure across all pages.

## Why
Closes REFACTOR-10. Each page was previously managing its own breadcrumb, status indicator, and event feed independently. DetailPageLayout enforces a single consistent chrome for all detail views.

## How

**DetailPageLayout changes:**
- `sourceType` made optional (infrastructure components don't need a type filter)
- New `headerExtra` prop renders between the KDP row and the first content divider — used to surface the Docker engine's linked-apps list in the header area without polluting the body

**DockerEngineDetail:** `onCountsLoaded` now passes `(total, running, unlinked)` so InfraComponentDetail can show running/total in keyDataPoints

**Per-page retrofit:**
- **AppDetail** — keyDataPoints: profile, rate limit, URL; actions: Launch + Settings; EventFeed via layout
- **CheckDetail** — keyDataPoints: type, target, interval, status; EventFeed replaces manual HISTORY feed; unused `statusLabel`/`statusClass` helpers removed
- **InfraComponentDetail** — per-type keyDataPoints; docker_engine linked apps move to `headerExtra`; `DiscoverNowButton` replaces inline discover logic
- **ProxmoxDetail** — keyDataPoints: uptime, vCPUs, RAM, PVE version from `nodeStatuses`; **EventFeed added** (was missing); `DiscoverNowButton` adopted
- **SynologyDetail** — keyDataPoints: model, DSM, total storage, uptime; **EventFeed added** (was missing); `DiscoverNowButton` adopted
- **TraefikDetail** — keyDataPoints: version, routers, services; bespoke `ComponentEventsSection` replaced by DetailPageLayout's built-in EventFeed

## Test coverage
- `npm run build` passes with zero TypeScript errors
- All pages compile cleanly; no unused imports or variables

## Closes
Closes REFACTOR-10