### PR TITLE
refactor: terminology audit — Infrastructure vs Topology, Discover Now (REFACTOR-11)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,11 +28,11 @@ export default function App() {
           <Route path="checks/:id" element={<CheckDetail />} />
           <Route path="apps" element={<Apps />} />
           <Route path="apps/:id" element={<AppDetail />} />
-          <Route path="topology" element={<Infrastructure />} />
-          <Route path="topology/proxmox/:componentId" element={<ProxmoxDetail />} />
-          <Route path="topology/synology/:componentId" element={<SynologyDetail />} />
-          <Route path="topology/traefik/:componentId" element={<TraefikDetail />} />
-          <Route path="topology/:id" element={<InfraComponentDetail />} />
+          <Route path="infrastructure" element={<Infrastructure />} />
+          <Route path="infrastructure/proxmox/:componentId" element={<ProxmoxDetail />} />
+          <Route path="infrastructure/synology/:componentId" element={<SynologyDetail />} />
+          <Route path="infrastructure/traefik/:componentId" element={<TraefikDetail />} />
+          <Route path="infrastructure/:id" element={<InfraComponentDetail />} />
           <Route path="settings" element={<Settings />} />
           <Route path="profile" element={<Profile />} />
           <Route path="app-templates/new" element={<AppTemplateEditor />} />

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -48,7 +48,7 @@ export function BottomNav() {
         </NavLink>
 
         {/* Hosts */}
-        <NavLink to="/topology" className={({ isActive }) => `bottom-tab${isActive ? ' active' : ''}`}>
+        <NavLink to="/infrastructure" className={({ isActive }) => `bottom-tab${isActive ? ' active' : ''}`}>
           <div className="bottom-tab-icon">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
               <rect x="2" y="2" width="20" height="8" rx="2" />

--- a/frontend/src/components/MobileTopBar.tsx
+++ b/frontend/src/components/MobileTopBar.tsx
@@ -12,7 +12,7 @@ const ROUTE_TITLES: Record<string, string> = {
   '/apps':      'Apps',
   '/checks':    'Monitor',
   '/events':    'Events',
-  '/topology':  'Hosts',
+  '/infrastructure':  'Hosts',
   '/settings':  'Settings',
   '/profile':   'Profile',
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -47,7 +47,7 @@ const NAV_ITEMS = [
     ),
   },
   {
-    to: '/topology',
+    to: '/infrastructure',
     title: 'Infrastructure',
     icon: (
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -258,7 +258,7 @@ export function Dashboard() {
               <div>
                 <div className="section-header">
                   <div className="section-title">Infrastructure</div>
-                  <button className="section-action" onClick={() => navigate('/topology')}>
+                  <button className="section-action" onClick={() => navigate('/infrastructure')}>
                     View all →
                   </button>
                 </div>
@@ -280,7 +280,7 @@ export function Dashboard() {
                       <HostWidget
                         key={host.id}
                         host={hostData}
-                        onClick={() => navigate('/topology')}
+                        onClick={() => navigate('/infrastructure')}
                       />
                     )
                   })}

--- a/frontend/src/pages/InfraComponentDetail.tsx
+++ b/frontend/src/pages/InfraComponentDetail.tsx
@@ -375,7 +375,7 @@ export function InfraComponentDetail() {
         <Topbar title="Component" />
         <div className="content">
           <div className="icd-error">{error ?? 'Component not found'}</div>
-          <button className="icd-back-btn" onClick={() => navigate('/topology')}>← Back</button>
+          <button className="icd-back-btn" onClick={() => navigate('/infrastructure')}>← Back</button>
         </div>
       </>
     )
@@ -383,13 +383,13 @@ export function InfraComponentDetail() {
 
   // Traefik components have their own detail page.
   if (component.type === 'traefik') {
-    navigate(`/topology/traefik/${component.id}`, { replace: true })
+    navigate(`/infrastructure/traefik/${component.id}`, { replace: true })
     return null
   }
 
   // Synology components have their own detail page.
   if (component.type === 'synology') {
-    navigate(`/topology/synology/${component.id}`, { replace: true })
+    navigate(`/infrastructure/synology/${component.id}`, { replace: true })
     return null
   }
 
@@ -450,7 +450,7 @@ export function InfraComponentDetail() {
   return (
     <DetailPageLayout
       breadcrumb="Infrastructure"
-      breadcrumbPath="/topology"
+      breadcrumbPath="/infrastructure"
       name={component.name}
       status={{ status: dplStatus(component.last_status) }}
       lastPolled={component.last_polled_at ? `Polled ${timeAgo(component.last_polled_at)}` : undefined}
@@ -551,7 +551,7 @@ function ProxmoxChildrenSection({ children, onNavigate }: ProxmoxChildrenSection
               <div
                 key={c.id}
                 className="icd-child-card"
-                onClick={() => onNavigate(`/topology/${c.id}`)}
+                onClick={() => onNavigate(`/infrastructure/${c.id}`)}
               >
                 <div className="icd-child-header">
                   <span className={`icd-status-dot ${statusDotClass(c.last_status)}`} />
@@ -576,7 +576,7 @@ function ProxmoxChildrenSection({ children, onNavigate }: ProxmoxChildrenSection
               <div
                 key={c.id}
                 className="icd-child-card"
-                onClick={() => onNavigate(`/topology/${c.id}`)}
+                onClick={() => onNavigate(`/infrastructure/${c.id}`)}
               >
                 <div className="icd-child-header">
                   <span className={`icd-status-dot ${statusDotClass(c.last_status)}`} />

--- a/frontend/src/pages/Infrastructure.tsx
+++ b/frontend/src/pages/Infrastructure.tsx
@@ -487,7 +487,7 @@ export function Infrastructure() {
 
     return (
       <div key={c.id} className="infra-card">
-        <div className="infra-card-header" style={{ cursor: 'pointer' }} onClick={() => navigate(`/topology/traefik/${c.id}`)}>
+        <div className="infra-card-header" style={{ cursor: 'pointer' }} onClick={() => navigate(`/infrastructure/traefik/${c.id}`)}>
           <div className="infra-card-title-group">
             <div className="infra-card-name">
               {c.name}
@@ -511,7 +511,7 @@ export function Infrastructure() {
           <div className="infra-card-actions">
             <button
               className="infra-card-btn accent"
-              onClick={() => navigate(`/topology/traefik/${c.id}`)}
+              onClick={() => navigate(`/infrastructure/traefik/${c.id}`)}
               disabled={isDeleting || isScanning}
             >
               View Detail
@@ -552,7 +552,7 @@ export function Infrastructure() {
         <div
           className="infra-card-header"
           style={{ cursor: 'pointer' }}
-          onClick={() => navigate(`/topology/${c.id}`)}
+          onClick={() => navigate(`/infrastructure/${c.id}`)}
         >
           <div className="infra-card-title-group">
             <div className="infra-card-name">{c.name}</div>
@@ -616,8 +616,8 @@ export function Infrastructure() {
     const canScan = c.collection_method !== 'none'
 
     const detailPath = c.type === 'proxmox_node'
-      ? `/topology/proxmox/${c.id}`
-      : `/topology/${c.id}`
+      ? `/infrastructure/proxmox/${c.id}`
+      : `/infrastructure/${c.id}`
 
     return (
       <div key={c.id} className="infra-card">

--- a/frontend/src/pages/ProxmoxDetail.tsx
+++ b/frontend/src/pages/ProxmoxDetail.tsx
@@ -622,7 +622,7 @@ export function ProxmoxDetail() {
           <div className="px-fullpage-error">
             {topError ?? 'Component not found'}
           </div>
-          <button className="px-back-btn" onClick={() => navigate('/topology')}>
+          <button className="px-back-btn" onClick={() => navigate('/infrastructure')}>
             ← Infrastructure
           </button>
         </div>
@@ -643,7 +643,7 @@ export function ProxmoxDetail() {
   return (
     <DetailPageLayout
       breadcrumb="Infrastructure"
-      breadcrumbPath="/topology"
+      breadcrumbPath="/infrastructure"
       name={topLoading ? '…' : (component?.name ?? 'Proxmox')}
       status={component ? { status: dplStatus(component.last_status) } : undefined}
       lastPolled={component?.last_polled_at ? `Polled ${timeAgo(component.last_polled_at)}` : undefined}

--- a/frontend/src/pages/SynologyDetail.tsx
+++ b/frontend/src/pages/SynologyDetail.tsx
@@ -174,7 +174,7 @@ export function SynologyDetail() {
         <Topbar title="Synology NAS" />
         <div className="content">
           <div className="icd-error">{error ?? 'Component not found'}</div>
-          <button className="icd-back-btn" onClick={() => navigate('/topology')}>← Back</button>
+          <button className="icd-back-btn" onClick={() => navigate('/infrastructure')}>← Back</button>
         </div>
       </>
     )
@@ -201,7 +201,7 @@ export function SynologyDetail() {
   return (
     <DetailPageLayout
       breadcrumb="Infrastructure"
-      breadcrumbPath="/topology"
+      breadcrumbPath="/infrastructure"
       name={component.name}
       status={{ status: dplStatus(component.last_status) }}
       lastPolled={d?.polled_at ? `Polled ${timeAgo(d.polled_at)}` : undefined}

--- a/frontend/src/pages/TraefikDetail.tsx
+++ b/frontend/src/pages/TraefikDetail.tsx
@@ -571,7 +571,7 @@ export function TraefikDetail() {
   return (
     <DetailPageLayout
       breadcrumb="Infrastructure"
-      breadcrumbPath="/topology"
+      breadcrumbPath="/infrastructure"
       name={topLoading ? '…' : (component?.name ?? 'Traefik')}
       status={component ? { status: dplStatus(component.last_status) } : undefined}
       lastPolled={overview?.updated_at ? `Polled ${timeAgo(overview.updated_at)}` : undefined}

--- a/internal/api/infra_components.go
+++ b/internal/api/infra_components.go
@@ -543,7 +543,7 @@ func (h *InfraComponentHandler) GetResources(w http.ResponseWriter, r *http.Requ
 
 	if len(rollups) == 0 {
 		// No rollup exists yet (hourly job hasn't run since first scan).
-		// Fall back to raw resource_readings from the last hour so Scan Now
+		// Fall back to raw resource_readings from the last hour so Discover Now
 		// shows data immediately without waiting for the rollup cycle.
 		now := time.Now().UTC()
 		aggs, aggErr := h.rollups.AggregateReadings(r.Context(), now.Add(-time.Hour), now)

--- a/internal/docker/resources.go
+++ b/internal/docker/resources.go
@@ -116,7 +116,7 @@ func (p *ResourcePoller) Start(ctx context.Context) {
 
 // PollAll is the exported, on-demand counterpart to the ticker-driven pollAll.
 // It performs a single full poll of all running containers and is called when
-// a user triggers a manual "Scan Now" on a docker_socket infrastructure component.
+// a user triggers a manual "Discover Now" on a docker_socket infrastructure component.
 func (p *ResourcePoller) PollAll(ctx context.Context) {
 	p.pollAll(ctx)
 }

--- a/internal/jobs/scan.go
+++ b/internal/jobs/scan.go
@@ -14,7 +14,7 @@ import (
 
 // ScanOneComponent immediately runs the appropriate poller for a single
 // infrastructure component. It returns the resulting status string and any
-// error encountered. This is the backend for the "Scan Now" API endpoint.
+// error encountered. This is the backend for the "Discover Now" API endpoint.
 func ScanOneComponent(ctx context.Context, store *repo.Store, c *models.InfrastructureComponent) (string, error) {
 	if !c.Enabled {
 		return c.LastStatus, fmt.Errorf("component is disabled")


### PR DESCRIPTION
## What
Full terminology audit correcting the misuse of "topology" to mean "infrastructure inventory", and replacing all instances of "Scan Now" with "Discover Now".

## Why
**Infrastructure** = inventory and management of components (hosts, VMs, Docker engines, integrations). **Topology** = the visual relationship map rendered from that inventory. These are distinct concepts and must not be used interchangeably. Additionally, the correct button label throughout the app is "Discover Now", never "Scan Now".

## How

**Route paths corrected:**
- All frontend routes `/topology/*` renamed to `/infrastructure/*` — these render the infrastructure inventory (`Infrastructure.tsx`) and its detail pages, not the visual map
- `Topology.tsx` (the actual visual relationship map component) and the backend `GET /api/v1/topology` endpoint (which returns the relationship chain) remain correctly named — they genuinely refer to topology

**Navigation updated:**
- `Sidebar.tsx`, `BottomNav.tsx`, `MobileTopBar.tsx` — updated link targets from `/topology` to `/infrastructure`
- `Dashboard.tsx`, `Infrastructure.tsx`, `InfraComponentDetail.tsx`, `ProxmoxDetail.tsx`, `SynologyDetail.tsx`, `TraefikDetail.tsx` — all `navigate()` calls and `breadcrumbPath` props corrected

**Scan Now → Discover Now:**
- Comments in `internal/jobs/scan.go`, `internal/docker/resources.go`, `internal/api/infra_components.go` updated

## Test coverage
- `go build ./...` passes
- `go test ./...` passes (all 7 test packages)
- `cd frontend && npm run build` passes with zero TypeScript errors
- `grep -ri "scan now"` returns zero results
- `grep -ri "path=\"topology\|navigate('/topology\|to=\"/topology\|to: '/topology"` returns zero results

## Closes
Closes REFACTOR-11