### PR TITLE
feat: image update detection via registry polling (DD-9)

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -249,6 +249,16 @@ func main() {
 		go watcher.Start(dockerCtx)
 	}
 
+	// Image update poller — checks container registries daily at 02:00 UTC for
+	// newer image versions.  Skipped if the Docker socket is not available.
+	imagePollerCtx, imagePollerCancel := context.WithCancel(context.Background())
+	defer imagePollerCancel()
+	if imagePoller, err := docker.NewImageUpdatePoller(store); err != nil {
+		log.Printf("image update poller: socket not available, skipping (%v)", err)
+	} else {
+		go imagePoller.Start(imagePollerCtx)
+	}
+
 	// Docker ResourcePoller — metrics collection is driven by the scan scheduler
 	// (every 2 minutes via DockerMetricsScanner) rather than a standalone ticker.
 	// The poller is registered with the scheduler so PollAll is called on the

--- a/internal/api/docker_discovery.go
+++ b/internal/api/docker_discovery.go
@@ -39,16 +39,19 @@ func (h *DockerDiscoveryHandler) Routes(r chi.Router) {
 
 // discoveredContainerResponse is the per-container shape returned by the API.
 type discoveredContainerResponse struct {
-	ID                   string    `json:"id"`
-	ContainerName        string    `json:"container_name"`
-	Image                string    `json:"image"`
-	Status               string    `json:"status"`
-	AppID                *string   `json:"app_id"`
-	ProfileSuggestion    *string   `json:"profile_suggestion"`
-	SuggestionConfidence *int      `json:"suggestion_confidence"`
-	CPUPercent           *float64  `json:"cpu_percent"`
-	MemPercent           *float64  `json:"mem_percent"`
-	LastSeenAt           time.Time `json:"last_seen_at"`
+	ID                   string     `json:"id"`
+	ContainerName        string     `json:"container_name"`
+	Image                string     `json:"image"`
+	Status               string     `json:"status"`
+	AppID                *string    `json:"app_id"`
+	ProfileSuggestion    *string    `json:"profile_suggestion"`
+	SuggestionConfidence *int       `json:"suggestion_confidence"`
+	CPUPercent           *float64   `json:"cpu_percent"`
+	MemPercent           *float64   `json:"mem_percent"`
+	LastSeenAt           time.Time  `json:"last_seen_at"`
+	// Image update fields (DD-9): populated by the ImageUpdatePoller.
+	ImageUpdateAvailable bool       `json:"image_update_available"`
+	ImageLastCheckedAt   *time.Time `json:"image_last_checked_at,omitempty"`
 }
 
 type listDiscoveredContainersResponse struct {
@@ -107,6 +110,8 @@ func (h *DockerDiscoveryHandler) ListContainers(w http.ResponseWriter, r *http.R
 			ProfileSuggestion:    c.ProfileSuggestion,
 			SuggestionConfidence: c.SuggestionConfidence,
 			LastSeenAt:           c.LastSeenAt,
+			ImageUpdateAvailable: c.ImageUpdateAvailable != 0,
+			ImageLastCheckedAt:   c.ImageLastCheckedAt,
 		}
 
 		// Walk lookup priority until we find a source ID that has metrics.
@@ -256,6 +261,8 @@ func (h *DockerDiscoveryHandler) ListAll(w http.ResponseWriter, r *http.Request)
 			ProfileSuggestion:    c.ProfileSuggestion,
 			SuggestionConfidence: c.SuggestionConfidence,
 			LastSeenAt:           c.LastSeenAt,
+			ImageUpdateAvailable: c.ImageUpdateAvailable != 0,
+			ImageLastCheckedAt:   c.ImageLastCheckedAt,
 		}
 		if m, ok := metrics[c.ContainerID]; ok {
 			if v, ok := m["cpu_percent"]; ok {

--- a/internal/docker/enrichment_test.go
+++ b/internal/docker/enrichment_test.go
@@ -103,6 +103,9 @@ func (m *enrichMockContainerRepo) FindByName(_ context.Context, _ string, _ stri
 func (m *enrichMockContainerRepo) DeleteDiscoveredContainer(_ context.Context, _ string) error {
 	return nil
 }
+func (m *enrichMockContainerRepo) UpdateContainerImageCheck(_ context.Context, _, _, _ string, _ bool) error {
+	return nil
+}
 
 type enrichMockRouteRepo struct {
 	routes map[string]*models.DiscoveredRoute

--- a/internal/docker/image_poller.go
+++ b/internal/docker/image_poller.go
@@ -1,0 +1,262 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	dockerimage "github.com/docker/docker/api/types/image"
+	dockerclient "github.com/docker/docker/client"
+
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// imageUpdateAPI is the minimal Docker client subset used by ImageUpdatePoller,
+// enabling mock injection in tests.
+type imageUpdateAPI interface {
+	ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error)
+	ImageInspect(ctx context.Context, imageID string, opts ...dockerclient.ImageInspectOption) (dockerimage.InspectResponse, error)
+}
+
+// latestDigester is the registry lookup surface used by ImageUpdatePoller.
+// *RegistryClient satisfies this interface; tests inject a mock.
+type latestDigester interface {
+	GetLatestDigest(ctx context.Context, image string) (string, error)
+}
+
+// ImageUpdatePoller polls container registries daily to detect whether a newer
+// image is available for each running discovered container.  It is purely
+// informational — it never pulls or updates images.
+//
+// Startup gate: if no infrastructure_components with type="docker_engine" exist,
+// each Run call returns early without contacting any registry.
+//
+// Poll schedule: once on startup (after a 60-second delay to avoid hammering
+// registries at boot), then daily at 02:00 UTC.
+type ImageUpdatePoller struct {
+	store    *repo.Store
+	registry latestDigester
+	client   imageUpdateAPI
+}
+
+// NewImageUpdatePoller returns an ImageUpdatePoller connected to the local
+// Docker daemon.  It returns an error only if the Docker client cannot be
+// constructed (socket absent, etc.).
+func NewImageUpdatePoller(store *repo.Store) (*ImageUpdatePoller, error) {
+	cli, err := dockerclient.NewClientWithOpts(
+		dockerclient.FromEnv,
+		dockerclient.WithAPIVersionNegotiation(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("docker client: %w", err)
+	}
+	return &ImageUpdatePoller{
+		store:    store,
+		registry: NewRegistryClient(),
+		client:   cli,
+	}, nil
+}
+
+// newImageUpdatePollerWithClient creates an ImageUpdatePoller with an injected
+// client and registry (for tests).
+func newImageUpdatePollerWithClient(store *repo.Store, client imageUpdateAPI, registry latestDigester) *ImageUpdatePoller {
+	return &ImageUpdatePoller{store: store, registry: registry, client: client}
+}
+
+// Start runs the image update poller until ctx is cancelled.  It waits 60 s
+// before the first run to avoid registry traffic at boot, then waits until the
+// next 02:00 UTC before running again, and repeats every 24 hours.
+func (p *ImageUpdatePoller) Start(ctx context.Context) {
+	log.Printf("image update poller: starting (60s startup delay)")
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(60 * time.Second):
+	}
+
+	if err := p.Run(ctx); err != nil && ctx.Err() == nil {
+		log.Printf("image update poller: startup run error: %v", err)
+	}
+
+	// Wait until the next 02:00 UTC.
+	delay := imagePollerDurationUntilNext2AM()
+	log.Printf("image update poller: next scheduled run in %s (02:00 UTC)", delay.Round(time.Minute))
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(delay):
+	}
+
+	run := func() {
+		if err := p.Run(ctx); err != nil && ctx.Err() == nil {
+			log.Printf("image update poller: run error: %v", err)
+		}
+	}
+	run()
+
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			run()
+		}
+	}
+}
+
+// Run performs one full image update check cycle across all running discovered
+// containers.  It returns early if no Docker Engine infrastructure components
+// are configured.
+func (p *ImageUpdatePoller) Run(ctx context.Context) error {
+	// Gate check — skip silently if no Docker Engine components are configured.
+	components, err := p.store.InfraComponents.List(ctx)
+	if err != nil {
+		return fmt.Errorf("list infra components: %w", err)
+	}
+	hasDockerEngine := false
+	for _, c := range components {
+		if c.Type == "docker_engine" {
+			hasDockerEngine = true
+			break
+		}
+	}
+	if !hasDockerEngine {
+		log.Printf("image update poller: no Docker Engine components configured, skipping")
+		return nil
+	}
+
+	containers, err := p.store.DiscoveredContainers.ListAllDiscoveredContainers(ctx)
+	if err != nil {
+		return fmt.Errorf("list discovered containers: %w", err)
+	}
+
+	checked := 0
+	updatesAvailable := 0
+
+	for _, c := range containers {
+		// Only poll running containers.
+		if c.Status != "running" {
+			continue
+		}
+
+		// Step 1: Get image info from Docker socket.
+		inspect, err := p.client.ContainerInspect(ctx, c.ContainerID)
+		if err != nil {
+			log.Printf("image update poller: inspect container %s (%s): %v", c.ContainerName, c.ContainerID, err)
+			continue
+		}
+
+		// image_digest: prefer the OCI manifest descriptor digest (available on
+		// Docker Engine 25+), fall back to the image config hash (image ID).
+		imageDigest := inspect.Image // sha256 config hash — always present
+		if inspect.ImageManifestDescriptor != nil {
+			imageDigest = inspect.ImageManifestDescriptor.Digest.String()
+		} else {
+			// Try ImageInspect to find the manifest digest from RepoDigests.
+			if imgInfo, err := p.client.ImageInspect(ctx, inspect.Image); err == nil { //nolint:staticcheck
+				imageName := c.Image
+				if inspect.Config != nil && inspect.Config.Image != "" {
+					imageName = inspect.Config.Image
+				}
+				if d := extractRepoDigest(imgInfo.RepoDigests, imageName); d != "" {
+					imageDigest = d
+				}
+			}
+		}
+
+		// Step 2: Determine image name/tag to look up in the registry.
+		imageName := c.Image // from DB (set during discovery)
+		if inspect.Config != nil && inspect.Config.Image != "" {
+			imageName = inspect.Config.Image
+		}
+
+		// Step 3: Fetch the latest manifest digest from the registry.
+		registryDigest, err := p.registry.GetLatestDigest(ctx, imageName)
+		if err != nil {
+			log.Printf("image update poller: get digest for %s (%s): %v", c.ContainerName, imageName, err)
+			// Skip — do not mutate image_update_available on transient errors.
+			continue
+		}
+
+		// Step 4: Compare and persist.
+		// Only set update_available=1 when both digests are non-empty and differ.
+		// This avoids false positives when we could only get a config hash locally
+		// (config hash ≠ manifest hash by definition).
+		updateAvailable := imageDigest != "" && registryDigest != "" && imageDigest != registryDigest
+
+		if err := p.store.DiscoveredContainers.UpdateContainerImageCheck(
+			ctx, c.ID, imageDigest, registryDigest, updateAvailable,
+		); err != nil {
+			log.Printf("image update poller: persist check for %s: %v", c.ContainerName, err)
+			continue
+		}
+
+		checked++
+		if updateAvailable {
+			updatesAvailable++
+		}
+	}
+
+	log.Printf("image update poller: check complete: %d containers checked, %d updates available", checked, updatesAvailable)
+	return nil
+}
+
+// extractRepoDigest returns the manifest digest (sha256:...) from a
+// RepoDigests slice for the given image name.  Docker stores repo digests as
+// "image@sha256:digest" strings.  We return the first entry whose image part
+// matches the repo portion of imageName, or the first entry overall as a
+// fallback.
+func extractRepoDigest(repoDigests []string, imageName string) string {
+	// Strip tag from imageName to get the repo reference.
+	repo := imageName
+	if i := strings.LastIndex(repo, ":"); i >= 0 {
+		// Only strip if what follows has no slash (i.e. it's a tag, not a port).
+		if !strings.Contains(repo[i+1:], "/") {
+			repo = repo[:i]
+		}
+	}
+
+	for _, d := range repoDigests {
+		at := strings.LastIndex(d, "@")
+		if at < 0 {
+			continue
+		}
+		imgPart := d[:at]
+		digestPart := d[at+1:]
+
+		// Normalize docker.io prefix for comparison.
+		imgPartNorm := strings.TrimPrefix(imgPart, "docker.io/")
+		repoNorm := strings.TrimPrefix(repo, "docker.io/")
+
+		if imgPartNorm == repoNorm || strings.HasSuffix(imgPartNorm, "/"+repoNorm) {
+			return digestPart
+		}
+	}
+
+	// Fallback: return the first entry's digest regardless of image match.
+	if len(repoDigests) > 0 {
+		if at := strings.LastIndex(repoDigests[0], "@"); at >= 0 {
+			return repoDigests[0][at+1:]
+		}
+	}
+	return ""
+}
+
+// imagePollerDurationUntilNext2AM returns the duration from now until the next
+// 02:00 UTC.  Mirrors jobs.durationUntilNext2AM without importing the jobs package.
+func imagePollerDurationUntilNext2AM() time.Duration {
+	now := time.Now().UTC()
+	next := time.Date(now.Year(), now.Month(), now.Day(), 2, 0, 0, 0, time.UTC)
+	if !next.After(now) {
+		next = next.Add(24 * time.Hour)
+	}
+	return next.Sub(now)
+}

--- a/internal/docker/image_poller_test.go
+++ b/internal/docker/image_poller_test.go
@@ -1,0 +1,365 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	dockerimage "github.com/docker/docker/api/types/image"
+	dockerclient "github.com/docker/docker/client"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// ── mock imageUpdateAPI ────────────────────────────────────────────────────────
+
+type mockImageUpdateClient struct {
+	inspects      map[string]container.InspectResponse
+	inspectErr    error
+	imgInspects   map[string]dockerimage.InspectResponse
+	imgInspectErr error
+}
+
+func (m *mockImageUpdateClient) ContainerInspect(_ context.Context, id string) (container.InspectResponse, error) {
+	if m.inspectErr != nil {
+		return container.InspectResponse{}, m.inspectErr
+	}
+	if info, ok := m.inspects[id]; ok {
+		return info, nil
+	}
+	return container.InspectResponse{}, errors.New("container not found: " + id)
+}
+
+func (m *mockImageUpdateClient) ImageInspect(_ context.Context, id string, _ ...dockerclient.ImageInspectOption) (dockerimage.InspectResponse, error) {
+	if m.imgInspectErr != nil {
+		return dockerimage.InspectResponse{}, m.imgInspectErr
+	}
+	if info, ok := m.imgInspects[id]; ok {
+		return info, nil
+	}
+	return dockerimage.InspectResponse{}, errors.New("image not found: " + id)
+}
+
+// ── mock latestDigester ────────────────────────────────────────────────────────
+
+type mockLatestDigester struct {
+	digests map[string]string
+	err     error
+}
+
+func (m *mockLatestDigester) GetLatestDigest(_ context.Context, image string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	if d, ok := m.digests[image]; ok {
+		return d, nil
+	}
+	return "", errors.New("no digest for " + image)
+}
+
+// ── mock repos ─────────────────────────────────────────────────────────────────
+
+type mockInfraComponentRepo struct {
+	components []models.InfrastructureComponent
+}
+
+func (r *mockInfraComponentRepo) List(_ context.Context) ([]models.InfrastructureComponent, error) {
+	return r.components, nil
+}
+func (r *mockInfraComponentRepo) ListByParent(_ context.Context, _ string) ([]models.InfrastructureComponent, error) {
+	return nil, nil
+}
+func (r *mockInfraComponentRepo) Get(_ context.Context, _ string) (*models.InfrastructureComponent, error) {
+	return nil, repo.ErrNotFound
+}
+func (r *mockInfraComponentRepo) Create(_ context.Context, _ *models.InfrastructureComponent) error {
+	return nil
+}
+func (r *mockInfraComponentRepo) Update(_ context.Context, _ *models.InfrastructureComponent) error {
+	return nil
+}
+func (r *mockInfraComponentRepo) Delete(_ context.Context, _ string) error { return nil }
+func (r *mockInfraComponentRepo) UpdateStatus(_ context.Context, _, _, _ string) error {
+	return nil
+}
+func (r *mockInfraComponentRepo) UpdateSNMPMeta(_ context.Context, _, _ string) error { return nil }
+func (r *mockInfraComponentRepo) UpdateSynologyMeta(_ context.Context, _, _ string) error {
+	return nil
+}
+
+type imageCheckCall struct {
+	id              string
+	imageDigest     string
+	registryDigest  string
+	updateAvailable bool
+}
+
+type mockDiscoveredContainerRepo struct {
+	containers  []*models.DiscoveredContainer
+	imageChecks []imageCheckCall
+}
+
+func (r *mockDiscoveredContainerRepo) UpsertDiscoveredContainer(_ context.Context, _ *models.DiscoveredContainer) error {
+	return nil
+}
+func (r *mockDiscoveredContainerRepo) ListDiscoveredContainers(_ context.Context, _ string) ([]*models.DiscoveredContainer, error) {
+	return r.containers, nil
+}
+func (r *mockDiscoveredContainerRepo) ListAllDiscoveredContainers(_ context.Context) ([]*models.DiscoveredContainer, error) {
+	return r.containers, nil
+}
+func (r *mockDiscoveredContainerRepo) GetDiscoveredContainer(_ context.Context, _ string) (*models.DiscoveredContainer, error) {
+	return nil, repo.ErrNotFound
+}
+func (r *mockDiscoveredContainerRepo) FindByName(_ context.Context, _, _ string) (*models.DiscoveredContainer, error) {
+	return nil, repo.ErrNotFound
+}
+func (r *mockDiscoveredContainerRepo) SetDiscoveredContainerApp(_ context.Context, _, _ string) error {
+	return nil
+}
+func (r *mockDiscoveredContainerRepo) ClearDiscoveredContainerApp(_ context.Context, _ string) error {
+	return nil
+}
+func (r *mockDiscoveredContainerRepo) UpdateDiscoveredContainerStatus(_ context.Context, _ string, _ string, _ time.Time) error {
+	return nil
+}
+func (r *mockDiscoveredContainerRepo) MarkStoppedIfNotRunning(_ context.Context, _ string, _ []string) error {
+	return nil
+}
+func (r *mockDiscoveredContainerRepo) DeleteDiscoveredContainer(_ context.Context, _ string) error {
+	return nil
+}
+func (r *mockDiscoveredContainerRepo) UpdateContainerImageCheck(_ context.Context, id, imageDigest, registryDigest string, updateAvailable bool) error {
+	r.imageChecks = append(r.imageChecks, imageCheckCall{
+		id:              id,
+		imageDigest:     imageDigest,
+		registryDigest:  registryDigest,
+		updateAvailable: updateAvailable,
+	})
+	return nil
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+func makePollerStore(infraComponents []models.InfrastructureComponent, containers []*models.DiscoveredContainer) (*repo.Store, *mockDiscoveredContainerRepo) {
+	dc := &mockDiscoveredContainerRepo{containers: containers}
+	store := repo.NewStore(
+		nil, nil, nil, nil, nil, nil,
+		&mockInfraComponentRepo{components: infraComponents},
+		nil, nil, nil, nil, nil, nil, nil, nil,
+		dc, nil, nil, nil,
+	)
+	return store, dc
+}
+
+func dockerEngineComponent() models.InfrastructureComponent {
+	return models.InfrastructureComponent{ID: "engine-1", Type: "docker_engine"}
+}
+
+func makeInspect(containerID, imageID, imageName string, repoDigests []string) (map[string]container.InspectResponse, map[string]dockerimage.InspectResponse) {
+	inspects := map[string]container.InspectResponse{
+		containerID: {
+			ContainerJSONBase: &container.ContainerJSONBase{Image: imageID},
+			Config:            &container.Config{Image: imageName},
+		},
+	}
+	imgInspects := map[string]dockerimage.InspectResponse{
+		imageID: {RepoDigests: repoDigests},
+	}
+	return inspects, imgInspects
+}
+
+// ── gate check: no Docker Engine components ────────────────────────────────────
+
+func TestImageUpdatePoller_GateCheck_NoEngines(t *testing.T) {
+	store, dc := makePollerStore(nil, []*models.DiscoveredContainer{
+		{ID: "c1", ContainerID: "abc", ContainerName: "sonarr", Image: "linuxserver/sonarr:latest", Status: "running"},
+	})
+
+	reg := &mockLatestDigester{digests: map[string]string{"linuxserver/sonarr:latest": "sha256:new"}}
+	p := newImageUpdatePollerWithClient(store, &mockImageUpdateClient{}, reg)
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dc.imageChecks) != 0 {
+		t.Errorf("expected 0 image checks when no Docker Engine configured, got %d", len(dc.imageChecks))
+	}
+}
+
+// ── digest mismatch → update_available=true ────────────────────────────────────
+
+func TestImageUpdatePoller_DigestMismatch(t *testing.T) {
+	const (
+		localManifest    = "sha256:aaaaaaaaaaaa"
+		registryManifest = "sha256:bbbbbbbbbbbb"
+		containerID      = "ctr-abc"
+		imageName        = "linuxserver/sonarr:latest"
+	)
+
+	store, dc := makePollerStore(
+		[]models.InfrastructureComponent{dockerEngineComponent()},
+		[]*models.DiscoveredContainer{
+			{ID: "c1", ContainerID: containerID, ContainerName: "sonarr", Image: imageName, Status: "running"},
+		},
+	)
+
+	inspects, imgInspects := makeInspect(containerID, "sha256:cfg1", imageName,
+		[]string{"linuxserver/sonarr@" + localManifest})
+
+	client := &mockImageUpdateClient{inspects: inspects, imgInspects: imgInspects}
+	reg := &mockLatestDigester{digests: map[string]string{imageName: registryManifest}}
+	p := newImageUpdatePollerWithClient(store, client, reg)
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if len(dc.imageChecks) != 1 {
+		t.Fatalf("expected 1 image check, got %d", len(dc.imageChecks))
+	}
+	check := dc.imageChecks[0]
+	if !check.updateAvailable {
+		t.Error("expected update_available=true when digests differ")
+	}
+	if check.registryDigest != registryManifest {
+		t.Errorf("registry_digest: got %q, want %q", check.registryDigest, registryManifest)
+	}
+}
+
+// ── digest match → update_available=false ─────────────────────────────────────
+
+func TestImageUpdatePoller_DigestMatch(t *testing.T) {
+	const (
+		sameDigest  = "sha256:cccccccccccc"
+		containerID = "ctr-xyz"
+		imageName   = "ghcr.io/meeb/tubesync:latest"
+	)
+
+	store, dc := makePollerStore(
+		[]models.InfrastructureComponent{dockerEngineComponent()},
+		[]*models.DiscoveredContainer{
+			{ID: "c2", ContainerID: containerID, ContainerName: "tubesync", Image: imageName, Status: "running"},
+		},
+	)
+
+	inspects, imgInspects := makeInspect(containerID, "sha256:cfg2", imageName,
+		[]string{"ghcr.io/meeb/tubesync@" + sameDigest})
+
+	client := &mockImageUpdateClient{inspects: inspects, imgInspects: imgInspects}
+	reg := &mockLatestDigester{digests: map[string]string{imageName: sameDigest}}
+	p := newImageUpdatePollerWithClient(store, client, reg)
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if len(dc.imageChecks) != 1 {
+		t.Fatalf("expected 1 image check, got %d", len(dc.imageChecks))
+	}
+	if dc.imageChecks[0].updateAvailable {
+		t.Error("expected update_available=false when digests match")
+	}
+}
+
+// ── registry error → UpdateContainerImageCheck not called ─────────────────────
+
+func TestImageUpdatePoller_RegistryError_NoUpdateSet(t *testing.T) {
+	const containerID = "ctr-err"
+
+	store, dc := makePollerStore(
+		[]models.InfrastructureComponent{dockerEngineComponent()},
+		[]*models.DiscoveredContainer{
+			{ID: "c3", ContainerID: containerID, ContainerName: "myapp", Image: "myapp:latest", Status: "running"},
+		},
+	)
+
+	inspects, imgInspects := makeInspect(containerID, "sha256:cfg3", "myapp:latest",
+		[]string{"myapp@sha256:local"})
+
+	client := &mockImageUpdateClient{inspects: inspects, imgInspects: imgInspects}
+	reg := &mockLatestDigester{err: errors.New("rate limited (429)")}
+	p := newImageUpdatePollerWithClient(store, client, reg)
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	// UpdateContainerImageCheck must NOT be called on registry error.
+	if len(dc.imageChecks) != 0 {
+		t.Errorf("expected 0 image check calls on registry error, got %d", len(dc.imageChecks))
+	}
+}
+
+// ── stopped/exited containers skipped ────────────────────────────────────────
+
+func TestImageUpdatePoller_NonRunningContainersSkipped(t *testing.T) {
+	store, dc := makePollerStore(
+		[]models.InfrastructureComponent{dockerEngineComponent()},
+		[]*models.DiscoveredContainer{
+			{ID: "c4", ContainerID: "s1", ContainerName: "stopped-app", Image: "myapp:latest", Status: "stopped"},
+			{ID: "c5", ContainerID: "s2", ContainerName: "exited-app", Image: "myapp:latest", Status: "exited"},
+		},
+	)
+
+	reg := &mockLatestDigester{digests: map[string]string{"myapp:latest": "sha256:digest"}}
+	p := newImageUpdatePollerWithClient(store, &mockImageUpdateClient{}, reg)
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if len(dc.imageChecks) != 0 {
+		t.Errorf("expected 0 image checks for non-running containers, got %d", len(dc.imageChecks))
+	}
+}
+
+// ── extractRepoDigest ─────────────────────────────────────────────────────────
+
+func TestExtractRepoDigest(t *testing.T) {
+	cases := []struct {
+		name        string
+		repoDigests []string
+		imageName   string
+		want        string
+	}{
+		{
+			name:        "exact match",
+			repoDigests: []string{"linuxserver/sonarr@sha256:abc123"},
+			imageName:   "linuxserver/sonarr:latest",
+			want:        "sha256:abc123",
+		},
+		{
+			name:        "ghcr with tag",
+			repoDigests: []string{"ghcr.io/meeb/tubesync@sha256:def456"},
+			imageName:   "ghcr.io/meeb/tubesync:latest",
+			want:        "sha256:def456",
+		},
+		{
+			name:        "docker.io prefix stripped",
+			repoDigests: []string{"docker.io/library/ubuntu@sha256:fff000"},
+			imageName:   "library/ubuntu:22.04",
+			want:        "sha256:fff000",
+		},
+		{
+			name:        "fallback to first entry",
+			repoDigests: []string{"other/image@sha256:fallback"},
+			imageName:   "completely-different:latest",
+			want:        "sha256:fallback",
+		},
+		{
+			name:        "empty repo digests returns empty",
+			repoDigests: []string{},
+			imageName:   "anything:latest",
+			want:        "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractRepoDigest(tc.repoDigests, tc.imageName)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/docker/registry.go
+++ b/internal/docker/registry.go
@@ -1,0 +1,320 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// manifestAcceptHeader is the Accept header value sent to registries.  It covers
+// OCI image index, Docker manifest list, and single-arch Docker manifests in
+// priority order so we get the most specific manifest available.
+const manifestAcceptHeader = "application/vnd.oci.image.index.v1+json," +
+	"application/vnd.docker.distribution.manifest.list.v2+json," +
+	"application/vnd.docker.distribution.manifest.v2+json," +
+	"application/vnd.oci.image.manifest.v1+json"
+
+// httpDoer is the subset of *http.Client used by RegistryClient, enabling
+// mock injection in tests.
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// RegistryClient fetches manifest digests from container registries without
+// pulling image data.  It supports Docker Hub, GHCR, lscr.io, and any other
+// OCI-compliant registry via an unauthenticated anonymous token flow.
+type RegistryClient struct {
+	httpClient       httpDoer
+	warnedRegistries sync.Map // registry host → struct{}{} — logged once per host
+}
+
+// NewRegistryClient creates a RegistryClient with a default HTTP client.
+func NewRegistryClient() *RegistryClient {
+	return &RegistryClient{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// GetLatestDigest returns the Docker-Content-Digest of the latest manifest for
+// image (a full image:tag string such as "ghcr.io/meeb/tubesync:latest" or
+// "linuxserver/sonarr:latest").
+//
+// Error handling:
+//   - Rate limit (429): returns an error so the caller can skip this cycle.
+//   - Auth failure / network error: returns an error so the caller can skip.
+//   - Unknown registry: attempts unauthenticated OCI flow; logs a one-time
+//     warning and returns an error if that fails.
+func (r *RegistryClient) GetLatestDigest(ctx context.Context, image string) (string, error) {
+	registry, repo, tag := parseImageRef(image)
+
+	switch registry {
+	case "docker.io":
+		return r.getDockerHubDigest(ctx, repo, tag)
+	case "ghcr.io", "lscr.io":
+		return r.getOCIDigest(ctx, registry, repo, tag)
+	default:
+		digest, err := r.getOCIDigest(ctx, registry, repo, tag)
+		if err != nil {
+			if _, alreadyLogged := r.warnedRegistries.LoadOrStore(registry, struct{}{}); !alreadyLogged {
+				log.Printf("image update poller: unknown registry %q, unauthenticated attempt failed: %v", registry, err)
+			}
+			return "", err
+		}
+		return digest, nil
+	}
+}
+
+// parseImageRef splits a Docker image reference into (registry, repository, tag).
+//
+// Examples:
+//
+//	"lscr.io/linuxserver/sonarr:latest" → ("lscr.io",   "linuxserver/sonarr", "latest")
+//	"ghcr.io/meeb/tubesync:latest"      → ("ghcr.io",   "meeb/tubesync",      "latest")
+//	"linuxserver/sonarr:latest"         → ("docker.io", "linuxserver/sonarr",  "latest")
+//	"sonarr:4.0.0"                      → ("docker.io", "library/sonarr",      "4.0.0")
+//	"ubuntu"                            → ("docker.io", "library/ubuntu",      "latest")
+func parseImageRef(image string) (registry, repo, tag string) {
+	tag = "latest"
+	// Separate tag: last ":" that is not part of a port spec.
+	if i := strings.LastIndex(image, ":"); i >= 0 {
+		possibleTag := image[i+1:]
+		// A colon inside the hostname part (e.g. "localhost:5000/myimage") has a slash
+		// after it.  A tag never contains a slash.
+		if !strings.Contains(possibleTag, "/") {
+			tag = possibleTag
+			image = image[:i]
+		}
+	}
+
+	parts := strings.SplitN(image, "/", 2)
+	firstPart := parts[0]
+
+	// A registry hostname contains a dot, a colon (port), or is "localhost".
+	isRegistryHost := strings.ContainsAny(firstPart, ".:") || firstPart == "localhost"
+
+	if len(parts) == 2 && isRegistryHost {
+		registry = firstPart
+		repo = parts[1]
+	} else {
+		registry = "docker.io"
+		if len(parts) == 1 {
+			// Official library image, e.g. "ubuntu".
+			repo = "library/" + parts[0]
+		} else {
+			// User-scoped image, e.g. "linuxserver/sonarr".
+			repo = image
+		}
+	}
+	return
+}
+
+// getDockerHubDigest fetches a manifest digest from Docker Hub using the
+// standard token-auth flow.
+func (r *RegistryClient) getDockerHubDigest(ctx context.Context, repo, tag string) (string, error) {
+	token, err := r.fetchDockerHubToken(ctx, repo)
+	if err != nil {
+		return "", fmt.Errorf("docker hub token for %s: %w", repo, err)
+	}
+
+	url := fmt.Sprintf("https://registry-1.docker.io/v2/%s/manifests/%s", repo, tag)
+	return r.fetchManifestDigest(ctx, url, token)
+}
+
+// fetchDockerHubToken fetches an anonymous pull token from auth.docker.io.
+func (r *RegistryClient) fetchDockerHubToken(ctx context.Context, repo string) (string, error) {
+	url := fmt.Sprintf(
+		"https://auth.docker.io/token?service=registry.docker.io&scope=repository:%s:pull",
+		repo,
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch token: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token endpoint returned %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"` // Docker Hub uses both field names
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", fmt.Errorf("decode token response: %w", err)
+	}
+	if payload.Token != "" {
+		return payload.Token, nil
+	}
+	if payload.AccessToken != "" {
+		return payload.AccessToken, nil
+	}
+	return "", fmt.Errorf("no token in response")
+}
+
+// getOCIDigest fetches a manifest digest from an OCI-compliant registry,
+// handling the anonymous token flow described in the OCI Distribution Spec.
+func (r *RegistryClient) getOCIDigest(ctx context.Context, registry, repo, tag string) (string, error) {
+	url := fmt.Sprintf("https://%s/v2/%s/manifests/%s", registry, repo, tag)
+
+	// Attempt unauthenticated first.
+	digest, err := r.fetchManifestDigest(ctx, url, "")
+	if err == nil {
+		return digest, nil
+	}
+
+	// On 401, parse WWW-Authenticate to get the token endpoint.
+	token, tokenErr := r.fetchOCIAnonymousToken(ctx, registry, repo)
+	if tokenErr != nil {
+		return "", fmt.Errorf("oci token for %s/%s: %w", registry, repo, tokenErr)
+	}
+
+	return r.fetchManifestDigest(ctx, url, token)
+}
+
+// fetchOCIAnonymousToken obtains an anonymous pull token by probing the
+// registry's /v2/ endpoint and following the WWW-Authenticate challenge.
+func (r *RegistryClient) fetchOCIAnonymousToken(ctx context.Context, registry, repo string) (string, error) {
+	// Hit /v2/ to provoke a 401 with a WWW-Authenticate header.
+	probeURL := fmt.Sprintf("https://%s/v2/", registry)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("probe %s: %w", probeURL, err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body) //nolint:errcheck
+
+	wwwAuth := resp.Header.Get("Www-Authenticate")
+	if wwwAuth == "" {
+		// Registry may not require auth; return empty token so the caller retries.
+		return "", fmt.Errorf("no WWW-Authenticate header from %s", registry)
+	}
+
+	tokenURL, err := buildTokenURL(wwwAuth, repo)
+	if err != nil {
+		return "", fmt.Errorf("parse WWW-Authenticate: %w", err)
+	}
+
+	tokenReq, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL, nil)
+	if err != nil {
+		return "", err
+	}
+	tokenResp, err := r.httpClient.Do(tokenReq)
+	if err != nil {
+		return "", fmt.Errorf("fetch oci token: %w", err)
+	}
+	defer tokenResp.Body.Close()
+	body, _ := io.ReadAll(tokenResp.Body)
+
+	if tokenResp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token endpoint returned %d", tokenResp.StatusCode)
+	}
+
+	var payload struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", fmt.Errorf("decode oci token: %w", err)
+	}
+	if payload.Token != "" {
+		return payload.Token, nil
+	}
+	if payload.AccessToken != "" {
+		return payload.AccessToken, nil
+	}
+	return "", fmt.Errorf("no token in oci response")
+}
+
+// buildTokenURL parses a Bearer WWW-Authenticate challenge and appends the
+// pull scope for the given repository.
+//
+// Example input:
+//
+//	Bearer realm="https://ghcr.io/token",service="ghcr.io"
+func buildTokenURL(wwwAuth, repo string) (string, error) {
+	// Strip the "Bearer " prefix.
+	header := strings.TrimPrefix(wwwAuth, "Bearer ")
+	if header == wwwAuth {
+		return "", fmt.Errorf("unsupported auth scheme: %q", wwwAuth)
+	}
+
+	// Parse key=value pairs.
+	params := map[string]string{}
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(kv[0])
+		val := strings.Trim(strings.TrimSpace(kv[1]), `"`)
+		params[key] = val
+	}
+
+	realm, ok := params["realm"]
+	if !ok {
+		return "", fmt.Errorf("no realm in WWW-Authenticate")
+	}
+
+	url := realm
+	sep := "?"
+	if service, ok := params["service"]; ok {
+		url += sep + "service=" + service
+		sep = "&"
+	}
+	url += sep + "scope=repository:" + repo + ":pull"
+	return url, nil
+}
+
+// fetchManifestDigest performs a GET against url with optional Bearer token and
+// returns the Docker-Content-Digest response header value.
+func (r *RegistryClient) fetchManifestDigest(ctx context.Context, url, token string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", manifestAcceptHeader)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("manifest request: %w", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body) //nolint:errcheck
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		digest := resp.Header.Get("Docker-Content-Digest")
+		if digest == "" {
+			return "", fmt.Errorf("no Docker-Content-Digest header in response from %s", url)
+		}
+		return digest, nil
+	case http.StatusUnauthorized:
+		return "", fmt.Errorf("unauthorized (401)")
+	case http.StatusNotFound:
+		return "", fmt.Errorf("image/tag not found (404) at %s", url)
+	case http.StatusTooManyRequests:
+		return "", fmt.Errorf("rate limited (429) by %s", url)
+	default:
+		return "", fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
+	}
+}

--- a/internal/docker/registry_test.go
+++ b/internal/docker/registry_test.go
@@ -1,0 +1,219 @@
+package docker
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// ── parseImageRef ──────────────────────────────────────────────────────────────
+
+func TestParseImageRef(t *testing.T) {
+	cases := []struct {
+		input    string
+		registry string
+		repo     string
+		tag      string
+	}{
+		{
+			input:    "lscr.io/linuxserver/sonarr:latest",
+			registry: "lscr.io",
+			repo:     "linuxserver/sonarr",
+			tag:      "latest",
+		},
+		{
+			input:    "ghcr.io/meeb/tubesync:latest",
+			registry: "ghcr.io",
+			repo:     "meeb/tubesync",
+			tag:      "latest",
+		},
+		{
+			input:    "sonarr:4.0.0",
+			registry: "docker.io",
+			repo:     "library/sonarr",
+			tag:      "4.0.0",
+		},
+		{
+			input:    "linuxserver/sonarr:latest",
+			registry: "docker.io",
+			repo:     "linuxserver/sonarr",
+			tag:      "latest",
+		},
+		{
+			input:    "ubuntu",
+			registry: "docker.io",
+			repo:     "library/ubuntu",
+			tag:      "latest",
+		},
+		{
+			// Port in hostname must not be treated as tag separator.
+			input:    "localhost:5000/myimage:v1",
+			registry: "localhost:5000",
+			repo:     "myimage",
+			tag:      "v1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			reg, repo, tag := parseImageRef(tc.input)
+			if reg != tc.registry {
+				t.Errorf("registry: got %q, want %q", reg, tc.registry)
+			}
+			if repo != tc.repo {
+				t.Errorf("repo: got %q, want %q", repo, tc.repo)
+			}
+			if tag != tc.tag {
+				t.Errorf("tag: got %q, want %q", tag, tc.tag)
+			}
+		})
+	}
+}
+
+// ── GetLatestDigest — Docker Hub ───────────────────────────────────────────────
+
+func TestGetLatestDigest_DockerHub(t *testing.T) {
+	const wantDigest = "sha256:aabbccddeeff"
+
+	// Fake auth.docker.io token endpoint.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"token":"test-token"}`)) //nolint:errcheck
+	}))
+	defer tokenServer.Close()
+
+	// Fake registry-1.docker.io manifest endpoint.
+	manifestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Docker-Content-Digest", wantDigest)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer manifestServer.Close()
+
+	// Build a transport that rewrites requests to our fake servers.
+	transport := &rewriteTransport{
+		rules: map[string]string{
+			"auth.docker.io":        tokenServer.URL,
+			"registry-1.docker.io": manifestServer.URL,
+		},
+	}
+
+	rc := &RegistryClient{httpClient: &http.Client{Transport: transport}}
+
+	digest, err := rc.GetLatestDigest(context.Background(), "linuxserver/sonarr:latest")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if digest != wantDigest {
+		t.Errorf("digest: got %q, want %q", digest, wantDigest)
+	}
+}
+
+// ── GetLatestDigest — GHCR ────────────────────────────────────────────────────
+
+func TestGetLatestDigest_GHCR(t *testing.T) {
+	const wantDigest = "sha256:112233445566"
+
+	// Fake GHCR server: first request returns 401, second (with token) returns digest.
+	calls := 0
+	ghcrServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		switch r.URL.Path {
+		case "/v2/":
+			// Probe request — return 401 with WWW-Authenticate.
+			w.Header().Set("Www-Authenticate", `Bearer realm="https://ghcr.io/token",service="ghcr.io"`)
+			w.WriteHeader(http.StatusUnauthorized)
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"token":"ghcr-token"}`)) //nolint:errcheck
+		default:
+			// Manifest request.
+			if r.Header.Get("Authorization") == "Bearer ghcr-token" {
+				w.Header().Set("Docker-Content-Digest", wantDigest)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	}))
+	defer ghcrServer.Close()
+
+	transport := &rewriteTransport{
+		rules: map[string]string{
+			"ghcr.io": ghcrServer.URL,
+		},
+	}
+
+	rc := &RegistryClient{httpClient: &http.Client{Transport: transport}}
+
+	digest, err := rc.GetLatestDigest(context.Background(), "ghcr.io/meeb/tubesync:latest")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if digest != wantDigest {
+		t.Errorf("digest: got %q, want %q", digest, wantDigest)
+	}
+}
+
+// ── Rate-limit handling ────────────────────────────────────────────────────────
+
+func TestGetLatestDigest_RateLimit(t *testing.T) {
+	// Fake auth server.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"token":"tok"}`)) //nolint:errcheck
+	}))
+	defer tokenServer.Close()
+
+	// Manifest server returns 429.
+	manifestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer manifestServer.Close()
+
+	transport := &rewriteTransport{
+		rules: map[string]string{
+			"auth.docker.io":        tokenServer.URL,
+			"registry-1.docker.io": manifestServer.URL,
+		},
+	}
+
+	rc := &RegistryClient{httpClient: &http.Client{Transport: transport}}
+
+	_, err := rc.GetLatestDigest(context.Background(), "library/nginx:latest")
+	if err == nil {
+		t.Fatal("expected error for 429, got nil")
+	}
+}
+
+// ── rewriteTransport ──────────────────────────────────────────────────────────
+
+// rewriteTransport rewrites outbound request hosts to test server URLs so we
+// don't need real network access in tests.
+type rewriteTransport struct {
+	rules map[string]string // hostname → base URL of test server
+}
+
+func (rt *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	host := req.URL.Host
+	if host == "" {
+		host = req.URL.Hostname()
+	}
+	if base, ok := rt.rules[host]; ok {
+		// Parse the test server URL to get scheme+host.
+		cloned := req.Clone(req.Context())
+		parsed, err := http.NewRequest(req.Method, base+req.URL.RequestURI(), req.Body)
+		if err != nil {
+			return nil, err
+		}
+		cloned.URL = parsed.URL
+		return http.DefaultTransport.RoundTrip(cloned)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/internal/models/discovery.go
+++ b/internal/models/discovery.go
@@ -6,17 +6,22 @@ import "time"
 // app_id is set when the user links the container to an NORA app.
 // profile_suggestion is the profile_id NORA matched via image/name heuristics.
 type DiscoveredContainer struct {
-	ID                   string    `db:"id"                    json:"id"`
-	InfraComponentID     string    `db:"infra_component_id"    json:"infra_component_id"`
-	ContainerID          string    `db:"container_id"          json:"container_id"`
-	ContainerName        string    `db:"container_name"        json:"container_name"`
-	Image                string    `db:"image"                 json:"image"`
-	Status               string    `db:"status"                json:"status"`
-	AppID                *string   `db:"app_id"                json:"app_id,omitempty"`
-	ProfileSuggestion    *string   `db:"profile_suggestion"    json:"profile_suggestion,omitempty"`
-	SuggestionConfidence *int      `db:"suggestion_confidence" json:"suggestion_confidence,omitempty"`
-	LastSeenAt           time.Time `db:"last_seen_at"          json:"last_seen_at"`
-	CreatedAt            time.Time `db:"created_at"            json:"created_at"`
+	ID                   string     `db:"id"                    json:"id"`
+	InfraComponentID     string     `db:"infra_component_id"    json:"infra_component_id"`
+	ContainerID          string     `db:"container_id"          json:"container_id"`
+	ContainerName        string     `db:"container_name"        json:"container_name"`
+	Image                string     `db:"image"                 json:"image"`
+	Status               string     `db:"status"                json:"status"`
+	AppID                *string    `db:"app_id"                json:"app_id,omitempty"`
+	ProfileSuggestion    *string    `db:"profile_suggestion"    json:"profile_suggestion,omitempty"`
+	SuggestionConfidence *int       `db:"suggestion_confidence" json:"suggestion_confidence,omitempty"`
+	LastSeenAt           time.Time  `db:"last_seen_at"          json:"last_seen_at"`
+	CreatedAt            time.Time  `db:"created_at"            json:"created_at"`
+	// Fields added in migration 022 (DD-9).
+	ImageDigest          *string    `db:"image_digest"           json:"image_digest,omitempty"`
+	RegistryDigest       *string    `db:"registry_digest"        json:"registry_digest,omitempty"`
+	ImageUpdateAvailable int        `db:"image_update_available" json:"image_update_available"`
+	ImageLastCheckedAt   *time.Time `db:"image_last_checked_at"  json:"image_last_checked_at,omitempty"`
 }
 
 // DiscoveredRoute is an HTTP router entry found via a Traefik infrastructure component.

--- a/internal/repo/discovery.go
+++ b/internal/repo/discovery.go
@@ -31,6 +31,9 @@ type DiscoveredContainerRepo interface {
 	MarkStoppedIfNotRunning(ctx context.Context, infraComponentID string, runningIDs []string) error
 	// DeleteDiscoveredContainer hard-deletes a discovered container record by UUID.
 	DeleteDiscoveredContainer(ctx context.Context, id string) error
+	// UpdateContainerImageCheck writes the latest image and registry digests and
+	// sets image_update_available.  Called by the ImageUpdatePoller after each poll.
+	UpdateContainerImageCheck(ctx context.Context, id string, imageDigest string, registryDigest string, updateAvailable bool) error
 }
 
 // DiscoveredRouteRepo manages the discovered_routes table.
@@ -83,7 +86,8 @@ func (r *sqliteDiscoveredContainerRepo) ListDiscoveredContainers(ctx context.Con
 	var rows []*models.DiscoveredContainer
 	err := r.db.SelectContext(ctx, &rows, `
 		SELECT id, infra_component_id, container_id, container_name, image, status,
-		       app_id, profile_suggestion, suggestion_confidence, last_seen_at, created_at
+		       app_id, profile_suggestion, suggestion_confidence, last_seen_at, created_at,
+		       image_digest, registry_digest, COALESCE(image_update_available,0) AS image_update_available, image_last_checked_at
 		FROM discovered_containers
 		WHERE infra_component_id = ?
 		ORDER BY container_name ASC`, infraComponentID)
@@ -100,7 +104,8 @@ func (r *sqliteDiscoveredContainerRepo) ListAllDiscoveredContainers(ctx context.
 	var rows []*models.DiscoveredContainer
 	err := r.db.SelectContext(ctx, &rows, `
 		SELECT id, infra_component_id, container_id, container_name, image, status,
-		       app_id, profile_suggestion, suggestion_confidence, last_seen_at, created_at
+		       app_id, profile_suggestion, suggestion_confidence, last_seen_at, created_at,
+		       image_digest, registry_digest, COALESCE(image_update_available,0) AS image_update_available, image_last_checked_at
 		FROM discovered_containers
 		ORDER BY infra_component_id ASC, container_name ASC`)
 	if err != nil {
@@ -116,7 +121,8 @@ func (r *sqliteDiscoveredContainerRepo) GetDiscoveredContainer(ctx context.Conte
 	var c models.DiscoveredContainer
 	err := r.db.GetContext(ctx, &c, `
 		SELECT id, infra_component_id, container_id, container_name, image, status,
-		       app_id, profile_suggestion, suggestion_confidence, last_seen_at, created_at
+		       app_id, profile_suggestion, suggestion_confidence, last_seen_at, created_at,
+		       image_digest, registry_digest, COALESCE(image_update_available,0) AS image_update_available, image_last_checked_at
 		FROM discovered_containers
 		WHERE id = ?`, id)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -205,7 +211,8 @@ func (r *sqliteDiscoveredContainerRepo) FindByName(ctx context.Context, infraCom
 	var c models.DiscoveredContainer
 	err := r.db.GetContext(ctx, &c, `
 		SELECT id, infra_component_id, container_id, container_name, image, status,
-		       app_id, profile_suggestion, suggestion_confidence, last_seen_at, created_at
+		       app_id, profile_suggestion, suggestion_confidence, last_seen_at, created_at,
+		       image_digest, registry_digest, COALESCE(image_update_available,0) AS image_update_available, image_last_checked_at
 		FROM discovered_containers
 		WHERE infra_component_id = ? AND container_name = ?
 		LIMIT 1`, infraComponentID, name)
@@ -216,6 +223,27 @@ func (r *sqliteDiscoveredContainerRepo) FindByName(ctx context.Context, infraCom
 		return nil, fmt.Errorf("find discovered container by name %s: %w", name, err)
 	}
 	return &c, nil
+}
+
+func (r *sqliteDiscoveredContainerRepo) UpdateContainerImageCheck(ctx context.Context, id string, imageDigest string, registryDigest string, updateAvailable bool) error {
+	updateAvailableInt := 0
+	if updateAvailable {
+		updateAvailableInt = 1
+	}
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE discovered_containers
+		SET image_digest = ?, registry_digest = ?,
+		    image_update_available = ?, image_last_checked_at = ?
+		WHERE id = ?`,
+		imageDigest, registryDigest, updateAvailableInt, time.Now().UTC(), id)
+	if err != nil {
+		return fmt.Errorf("update image check on container %s: %w", id, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("discovered container %s: %w", id, ErrNotFound)
+	}
+	return nil
 }
 
 func (r *sqliteDiscoveredContainerRepo) DeleteDiscoveredContainer(ctx context.Context, id string) error {

--- a/migrations/022_image_update_columns.sql
+++ b/migrations/022_image_update_columns.sql
@@ -1,0 +1,11 @@
+-- 022_image_update_columns.sql
+-- Adds image update detection columns to discovered_containers for DD-9.
+-- image_digest:          manifest digest of the locally running image (from Docker socket)
+-- registry_digest:       latest manifest digest from the container registry for the same tag
+-- image_update_available: 1 if registry_digest differs from image_digest, 0 if same or unknown
+-- image_last_checked_at: when the registry was last polled for this container
+
+ALTER TABLE discovered_containers ADD COLUMN image_digest TEXT;
+ALTER TABLE discovered_containers ADD COLUMN registry_digest TEXT;
+ALTER TABLE discovered_containers ADD COLUMN image_update_available INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE discovered_containers ADD COLUMN image_last_checked_at DATETIME;


### PR DESCRIPTION
## What
Adds daily registry polling to detect whether a newer image is available for each running discovered container. Purely informational — NORA never pulls or updates images.

## Why
Closes DD-9. Gives users visibility into outdated containers directly in the discovery UI without leaving NORA.

## How

**Migration 022** — four new columns on `discovered_containers`:
- `image_digest`: manifest digest of the locally running image (from Docker socket)
- `registry_digest`: latest manifest digest from the registry for the same tag
- `image_update_available`: 1 if digests differ, 0 otherwise
- `image_last_checked_at`: when the registry was last polled

**RegistryClient** (`/internal/docker/registry.go`):
- Docker Hub: anonymous token flow via `auth.docker.io`
- GHCR / lscr.io: OCI anonymous token flow (WWW-Authenticate challenge)
- Unknown registries: unauthenticated OCI attempt, one-time warning per host
- Rate limit (429), auth failure, network errors → log warning, skip container, never set `update_available=1`

**ImageUpdatePoller** (`/internal/docker/image_poller.go`):
- Gate check on each run: returns early if no `docker_engine` infra components
- Startup delay: 60s after boot, then daily at 02:00 UTC
- Local digest: from `ContainerInspect.ImageManifestDescriptor` (Docker 25+) or `ImageInspect.RepoDigests` fallback
- Only running containers polled; stopped/exited retain their last values
- Wired in `main.go` alongside existing Docker workers

**API**: `image_update_available` (bool) and `image_last_checked_at` added to both `GET /api/v1/infrastructure/{id}/containers` and `GET /api/v1/discovery/all` responses.

## Test coverage
- `registry_test.go`: Docker Hub digest fetch (mock HTTP), GHCR digest fetch (mock HTTP with anonymous token flow), rate-limit error handling, `parseImageRef` for all image reference formats
- `image_poller_test.go`: gate check (no engines), digest mismatch → update_available=true, digest match → update_available=false, registry error → no mutation, stopped/exited containers skipped, `extractRepoDigest` edge cases

## Closes
Closes #DD-9