### PR TITLE
feat: auth backend — JWT sessions, register/login/logout/me (T-30)

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -290,10 +290,12 @@ func main() {
 	r.Post("/api/v1/ingest/{token}", api.HandleIngest(store, registry, limiter))
 	pushHandler := api.NewPushHandler(cfg, store, pushSender)
 	pushHandler.RegisterPublicRoutes(r)
+	authHandler := api.NewAuthHandler(userRepo, cfg.Secret)
+	authHandler.RegisterPublicRoutes(r)
 
 	// API v1 — protected by auth middleware
 	r.Route("/api/v1", func(r chi.Router) {
-		r.Use(auth.RequireAuth(cfg.DevMode))
+		r.Use(auth.RequireAuth(cfg.Secret))
 		api.NewAppsHandler(appRepo).Routes(r)
 		api.NewEventsHandler(eventRepo).Routes(r)
 		api.NewChecksHandler(checkRepo, eventRepo).Routes(r)
@@ -311,6 +313,7 @@ func main() {
 		api.NewProxmoxDetailHandler(infraComponentRepo).Routes(r)
 		pushHandler.Routes(r)
 		api.NewRulesHandler(store, rulesEngine).Routes(r)
+		authHandler.Routes(r)
 	})
 
 	// Frontend — serve embedded React app, SPA fallback to index.html
@@ -328,7 +331,7 @@ func main() {
 	}
 
 	addr := fmt.Sprintf(":%s", cfg.Port)
-	log.Printf("NORA listening on %s (dev_mode=%v)", addr, cfg.DevMode)
+	log.Printf("NORA listening on %s", addr)
 	if err := http.ListenAndServe(addr, r); err != nil {
 		log.Fatalf("server error: %v", err)
 	}

--- a/internal/api/apps_test.go
+++ b/internal/api/apps_test.go
@@ -19,7 +19,7 @@ import (
 // newTestDB opens an in-memory SQLite database with all migrations applied.
 func newTestDB(t *testing.T) *sqlx.DB {
 	t.Helper()
-	cfg := &config.Config{DBPath: ":memory:", DevMode: true}
+	cfg := &config.Config{DBPath: ":memory:"}
 	db, err := repo.Open(cfg, migrations.Files)
 	if err != nil {
 		t.Fatalf("open test db: %v", err)

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1,0 +1,240 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/auth"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// AuthHandler serves authentication endpoints.
+type AuthHandler struct {
+	users  repo.UserRepo
+	secret string
+}
+
+// NewAuthHandler creates an AuthHandler.
+func NewAuthHandler(users repo.UserRepo, secret string) *AuthHandler {
+	return &AuthHandler{users: users, secret: secret}
+}
+
+// Routes registers auth endpoints on r.
+// Public routes (login, setup-required, first-run register) must be registered
+// outside the protected group; call RegisterPublicRoutes for those.
+func (h *AuthHandler) Routes(r chi.Router) {
+	r.Post("/auth/logout", h.Logout)
+	r.Get("/auth/me", h.Me)
+}
+
+// RegisterPublicRoutes registers auth endpoints that do not require a session.
+func (h *AuthHandler) RegisterPublicRoutes(r chi.Router) {
+	r.Get("/api/v1/auth/setup-required", h.SetupRequired)
+	r.Post("/api/v1/auth/login", h.Login)
+	// Register is conditionally public: open for first user, admin-only thereafter.
+	// We handle the guard inside the handler itself.
+	r.Post("/api/v1/auth/register", h.Register)
+}
+
+// --- request / response types ---
+
+type loginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type loginResponse struct {
+	Token string      `json:"token"`
+	User  models.User `json:"user"`
+}
+
+type registerRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+	Role     string `json:"role"`
+}
+
+// --- handlers ---
+
+// SetupRequired reports whether the first-run setup flow is needed.
+// GET /api/v1/auth/setup-required
+func (h *AuthHandler) SetupRequired(w http.ResponseWriter, r *http.Request) {
+	n, err := h.users.Count(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"required": n == 0})
+}
+
+// Register creates a new user.
+// POST /api/v1/auth/register
+// Open (no auth) when the users table is empty; requires admin JWT otherwise.
+func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
+	n, err := h.users.Count(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// After first user exists, require admin auth.
+	if n > 0 {
+		token := extractBearerOrCookie(r)
+		if token == "" {
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		claims, err := auth.ValidateToken(token, h.secret)
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		if claims.Role != "admin" {
+			writeError(w, http.StatusForbidden, "admin role required")
+			return
+		}
+	}
+
+	var req registerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Email == "" {
+		writeError(w, http.StatusBadRequest, "email is required")
+		return
+	}
+	if req.Password == "" {
+		writeError(w, http.StatusBadRequest, "password is required")
+		return
+	}
+
+	role := req.Role
+	if n == 0 {
+		// First user is always admin regardless of the role field.
+		role = "admin"
+	} else if role == "" {
+		role = "member"
+	}
+	if role != "admin" && role != "member" {
+		writeError(w, http.StatusBadRequest, "role must be admin or member")
+		return
+	}
+
+	hashed, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to hash password")
+		return
+	}
+
+	u := &models.User{
+		ID:    uuid.NewString(),
+		Email: req.Email,
+		Role:  role,
+	}
+	if err := h.users.Create(r.Context(), u, string(hashed)); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	created, err := h.users.GetByID(r.Context(), u.ID)
+	if err != nil {
+		writeJSON(w, http.StatusCreated, u)
+		return
+	}
+	writeJSON(w, http.StatusCreated, created)
+}
+
+// Login validates credentials and returns a JWT in the response body and as a cookie.
+// POST /api/v1/auth/login
+func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
+	var req loginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Email == "" || req.Password == "" {
+		writeError(w, http.StatusBadRequest, "email and password are required")
+		return
+	}
+
+	user, hash, err := h.users.GetByEmail(r.Context(), req.Email)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusUnauthorized, "invalid credentials")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(req.Password)); err != nil {
+		writeError(w, http.StatusUnauthorized, "invalid credentials")
+		return
+	}
+
+	token, err := auth.GenerateToken(user.ID, user.Role, h.secret)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate token")
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     "nora_session",
+		Value:    token,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Expires:  time.Now().Add(24 * time.Hour),
+	})
+
+	writeJSON(w, http.StatusOK, loginResponse{Token: token, User: *user})
+}
+
+// Logout clears the session cookie.
+// POST /api/v1/auth/logout
+func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "nora_session",
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Expires:  time.Unix(0, 0),
+		MaxAge:   -1,
+	})
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Me returns the currently authenticated user.
+// GET /api/v1/auth/me
+func (h *AuthHandler) Me(w http.ResponseWriter, r *http.Request) {
+	userID := auth.UserID(r.Context())
+	user, err := h.users.GetByID(r.Context(), userID)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "user not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, user)
+}
+
+// extractBearerOrCookie reads a token from Authorization header or cookie.
+func extractBearerOrCookie(r *http.Request) string {
+	if h := r.Header.Get("Authorization"); len(h) > 7 && h[:7] == "Bearer " {
+		return h[7:]
+	}
+	if c, err := r.Cookie("nora_session"); err == nil {
+		return c.Value
+	}
+	return ""
+}

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -1,16 +1,15 @@
 package api
 
 import (
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/digitalcheffe/nora/internal/models"
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // UsersHandler serves user management endpoints.
@@ -84,9 +83,12 @@ func (h *UsersHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Email: req.Email,
 		Role:  role,
 	}
-	// NOTE: SHA-256 is used as a placeholder until T-10 implements full auth with bcrypt.
-	hash := sha256.Sum256([]byte(req.Password))
-	passwordHash := fmt.Sprintf("%x", hash)
+	hashed, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to hash password")
+		return
+	}
+	passwordHash := string(hashed)
 
 	if err := h.users.Create(r.Context(), u, passwordHash); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,49 @@
+package auth
+
+import (
+	"errors"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const tokenExpiry = 24 * time.Hour
+
+// Claims holds the authenticated user identity embedded in a JWT.
+type Claims struct {
+	UserID string `json:"user_id"`
+	Role   string `json:"role"`
+	jwt.RegisteredClaims
+}
+
+// GenerateToken creates a signed JWT for the given user. The token expires in 24 hours.
+func GenerateToken(userID string, role string, secret string) (string, error) {
+	claims := Claims{
+		UserID: userID,
+		Role:   role,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(tokenExpiry)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(secret))
+}
+
+// ValidateToken parses and validates a JWT, returning the embedded Claims on success.
+func ValidateToken(tokenStr string, secret string) (*Claims, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &Claims{}, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return []byte(secret), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	claims, ok := token.Claims.(*Claims)
+	if !ok || !token.Valid {
+		return nil, errors.New("invalid token")
+	}
+	return claims, nil
+}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,182 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/auth"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const testSecret = "test-secret-key"
+
+func TestGenerateAndValidateToken(t *testing.T) {
+	token, err := auth.GenerateToken("user-1", "admin", testSecret)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+
+	claims, err := auth.ValidateToken(token, testSecret)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if claims.UserID != "user-1" {
+		t.Errorf("UserID: got %q, want %q", claims.UserID, "user-1")
+	}
+	if claims.Role != "admin" {
+		t.Errorf("Role: got %q, want %q", claims.Role, "admin")
+	}
+}
+
+func TestValidateToken_WrongSecret(t *testing.T) {
+	token, err := auth.GenerateToken("user-1", "admin", testSecret)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	_, err = auth.ValidateToken(token, "wrong-secret")
+	if err == nil {
+		t.Fatal("expected error with wrong secret, got nil")
+	}
+}
+
+func TestValidateToken_Expired(t *testing.T) {
+	// Build an already-expired token manually.
+	claims := auth.Claims{
+		UserID: "user-1",
+		Role:   "admin",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString([]byte(testSecret))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	_, err = auth.ValidateToken(signed, testSecret)
+	if err == nil {
+		t.Fatal("expected error for expired token, got nil")
+	}
+}
+
+func TestValidateToken_Malformed(t *testing.T) {
+	_, err := auth.ValidateToken("not.a.token", testSecret)
+	if err == nil {
+		t.Fatal("expected error for malformed token, got nil")
+	}
+}
+
+// --- middleware tests ---
+
+func okHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func TestRequireAuth_ValidBearerToken(t *testing.T) {
+	token, _ := auth.GenerateToken("user-1", "member", testSecret)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	auth.RequireAuth(testSecret)(http.HandlerFunc(okHandler)).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestRequireAuth_ValidCookie(t *testing.T) {
+	token, _ := auth.GenerateToken("user-1", "member", testSecret)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: "nora_session", Value: token})
+	rr := httptest.NewRecorder()
+
+	auth.RequireAuth(testSecret)(http.HandlerFunc(okHandler)).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestRequireAuth_MissingToken(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	auth.RequireAuth(testSecret)(http.HandlerFunc(okHandler)).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRequireAuth_InvalidToken(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer bad.token.here")
+	rr := httptest.NewRecorder()
+
+	auth.RequireAuth(testSecret)(http.HandlerFunc(okHandler)).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRequireAdmin_AdminToken(t *testing.T) {
+	token, _ := auth.GenerateToken("user-1", "admin", testSecret)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	auth.RequireAdmin(testSecret)(http.HandlerFunc(okHandler)).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestRequireAdmin_MemberToken(t *testing.T) {
+	token, _ := auth.GenerateToken("user-1", "member", testSecret)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	auth.RequireAdmin(testSecret)(http.HandlerFunc(okHandler)).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusForbidden)
+	}
+}
+
+func TestContextHelpers(t *testing.T) {
+	token, _ := auth.GenerateToken("user-42", "admin", testSecret)
+
+	var capturedUserID, capturedRole string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUserID = auth.UserID(r.Context())
+		capturedRole = auth.Role(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	auth.RequireAuth(testSecret)(handler).ServeHTTP(rr, req)
+
+	if capturedUserID != "user-42" {
+		t.Errorf("UserID: got %q, want %q", capturedUserID, "user-42")
+	}
+	if capturedRole != "admin" {
+		t.Errorf("Role: got %q, want %q", capturedRole, "admin")
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -3,28 +3,61 @@ package auth
 import (
 	"context"
 	"net/http"
+	"strings"
 )
 
 type contextKey string
 
-const userIDKey contextKey = "userID"
+const (
+	userIDKey contextKey = "userID"
+	roleKey   contextKey = "role"
+)
 
-// RequireAuth is an HTTP middleware that enforces authentication.
-// When NORA_DEV_MODE=true a hardcoded admin session is injected — no login required.
-// TODO(T-30): remove the dev-mode bypass before production release.
-func RequireAuth(devMode bool) func(http.Handler) http.Handler {
+// RequireAuth validates the JWT from the Authorization header or nora_session cookie.
+// On success it injects userID and role into the request context.
+// Returns 401 if the token is missing or invalid.
+func RequireAuth(secret string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if devMode {
-				// Dev bypass: inject a hardcoded admin identity so every request
-				// is treated as authenticated. Never ship this in a production image.
-				ctx := context.WithValue(r.Context(), userIDKey, "dev-admin")
-				next.ServeHTTP(w, r.WithContext(ctx))
+			token := extractToken(r)
+			if token == "" {
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 				return
 			}
+			claims, err := ValidateToken(token, secret)
+			if err != nil {
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
+			ctx := context.WithValue(r.Context(), userIDKey, claims.UserID)
+			ctx = context.WithValue(ctx, roleKey, claims.Role)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
 
-			// TODO(T-10): validate JWT/session cookie and populate context.
-			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+// RequireAdmin is like RequireAuth but additionally enforces that the caller has role "admin".
+// Returns 403 for authenticated non-admin callers.
+func RequireAdmin(secret string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token := extractToken(r)
+			if token == "" {
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
+			claims, err := ValidateToken(token, secret)
+			if err != nil {
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
+			if claims.Role != "admin" {
+				http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
+				return
+			}
+			ctx := context.WithValue(r.Context(), userIDKey, claims.UserID)
+			ctx = context.WithValue(ctx, roleKey, claims.Role)
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }
@@ -33,4 +66,21 @@ func RequireAuth(devMode bool) func(http.Handler) http.Handler {
 func UserID(ctx context.Context) string {
 	v, _ := ctx.Value(userIDKey).(string)
 	return v
+}
+
+// Role returns the authenticated user role stored in the request context.
+func Role(ctx context.Context) string {
+	v, _ := ctx.Value(roleKey).(string)
+	return v
+}
+
+// extractToken reads a JWT from the Authorization Bearer header, falling back to the nora_session cookie.
+func extractToken(r *http.Request) string {
+	if h := r.Header.Get("Authorization"); strings.HasPrefix(h, "Bearer ") {
+		return strings.TrimPrefix(h, "Bearer ")
+	}
+	if cookie, err := r.Cookie("nora_session"); err == nil {
+		return cookie.Value
+	}
+	return ""
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,6 @@ import (
 )
 
 type Config struct {
-	DevMode        bool
 	Secret         string
 	DBPath         string
 	Port           string
@@ -22,8 +21,11 @@ type Config struct {
 }
 
 func Load() *Config {
+	if os.Getenv("NORA_DEV_MODE") != "" {
+		log.Println("warning: NORA_DEV_MODE is no longer supported — auth is always required")
+	}
+
 	cfg := &Config{
-		DevMode:        getEnvBool("NORA_DEV_MODE", false),
 		Secret:         os.Getenv("NORA_SECRET"),
 		DBPath:         getEnvStr("NORA_DB_PATH", "/data/nora.db"),
 		Port:           getEnvStr("NORA_PORT", "8081"),
@@ -37,8 +39,8 @@ func Load() *Config {
 		VAPIDPrivate:   os.Getenv("NORA_VAPID_PRIVATE"),
 	}
 
-	if !cfg.DevMode && cfg.Secret == "" {
-		log.Fatal("NORA_SECRET is required when NORA_DEV_MODE is false")
+	if cfg.Secret == "" {
+		log.Fatal("NORA_SECRET is required")
 	}
 
 	return cfg
@@ -49,18 +51,6 @@ func getEnvStr(key, def string) string {
 		return v
 	}
 	return def
-}
-
-func getEnvBool(key string, def bool) bool {
-	v := os.Getenv(key)
-	if v == "" {
-		return def
-	}
-	b, err := strconv.ParseBool(v)
-	if err != nil {
-		return def
-	}
-	return b
 }
 
 func getEnvInt(key string, def int) int {

--- a/internal/infra/proxmox_test.go
+++ b/internal/infra/proxmox_test.go
@@ -18,7 +18,7 @@ import (
 
 func newProxmoxTestStore(t *testing.T) *repo.Store {
 	t.Helper()
-	cfg := &config.Config{DBPath: ":memory:", DevMode: true}
+	cfg := &config.Config{DBPath: ":memory:"}
 	db, err := repo.Open(cfg, migrations.Files)
 	if err != nil {
 		t.Fatalf("open test db: %v", err)

--- a/internal/infra/snmp_test.go
+++ b/internal/infra/snmp_test.go
@@ -18,7 +18,7 @@ import (
 
 func newSNMPTestStore(t *testing.T) *repo.Store {
 	t.Helper()
-	cfg := &config.Config{DBPath: ":memory:", DevMode: true}
+	cfg := &config.Config{DBPath: ":memory:"}
 	db, err := repo.Open(cfg, migrations.Files)
 	if err != nil {
 		t.Fatalf("open test db: %v", err)

--- a/internal/infra/synology_test.go
+++ b/internal/infra/synology_test.go
@@ -18,7 +18,7 @@ import (
 
 func newSynologyTestStore(t *testing.T) *repo.Store {
 	t.Helper()
-	cfg := &config.Config{DBPath: ":memory:", DevMode: true}
+	cfg := &config.Config{DBPath: ":memory:"}
 	db, err := repo.Open(cfg, migrations.Files)
 	if err != nil {
 		t.Fatalf("open test db: %v", err)

--- a/internal/ingest/pipeline_test.go
+++ b/internal/ingest/pipeline_test.go
@@ -17,7 +17,7 @@ import (
 
 func newTestStore(t *testing.T) *repo.Store {
 	t.Helper()
-	cfg := &config.Config{DBPath: ":memory:", DevMode: true}
+	cfg := &config.Config{DBPath: ":memory:"}
 	db, err := repo.Open(cfg, migrations.Files)
 	if err != nil {
 		t.Fatalf("open test db: %v", err)

--- a/internal/jobs/resource_rollup_test.go
+++ b/internal/jobs/resource_rollup_test.go
@@ -18,7 +18,7 @@ import (
 // returns both the store and the underlying *sqlx.DB for direct queries in tests.
 func newTestStore(t *testing.T) (*repo.Store, *sqlx.DB) {
 	t.Helper()
-	cfg := &config.Config{DBPath: ":memory:", DevMode: true}
+	cfg := &config.Config{DBPath: ":memory:"}
 	db, err := repo.Open(cfg, migrations.Files)
 	if err != nil {
 		t.Fatalf("open test db: %v", err)

--- a/internal/repo/discovery_test.go
+++ b/internal/repo/discovery_test.go
@@ -16,7 +16,7 @@ import (
 // This ensures apps and infrastructure_components tables exist for FK constraints.
 func openDiscoveryTestDB(t *testing.T) *sqlx.DB {
 	t.Helper()
-	cfg := &config.Config{DBPath: ":memory:", DevMode: true}
+	cfg := &config.Config{DBPath: ":memory:"}
 	db, err := Open(cfg, migrations.Files)
 	if err != nil {
 		t.Fatalf("open discovery test db: %v", err)

--- a/internal/repo/users.go
+++ b/internal/repo/users.go
@@ -17,6 +17,8 @@ type UserRepo interface {
 	Create(ctx context.Context, u *models.User, passwordHash string) error
 	Delete(ctx context.Context, id string) error
 	GetByID(ctx context.Context, id string) (*models.User, error)
+	GetByEmail(ctx context.Context, email string) (*models.User, string, error)
+	Count(ctx context.Context) (int, error)
 }
 
 type sqliteUserRepo struct {
@@ -76,4 +78,31 @@ func (r *sqliteUserRepo) GetByID(ctx context.Context, id string) (*models.User, 
 		return nil, fmt.Errorf("get user: %w", err)
 	}
 	return &u, nil
+}
+
+// GetByEmail returns the user and their stored password hash for the given email.
+func (r *sqliteUserRepo) GetByEmail(ctx context.Context, email string) (*models.User, string, error) {
+	var row struct {
+		models.User
+		PasswordHash string `db:"password_hash"`
+	}
+	err := r.db.GetContext(ctx, &row, `
+		SELECT id, email, role, created_at, password_hash FROM users WHERE email = ?`, email)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, "", ErrNotFound
+		}
+		return nil, "", fmt.Errorf("get user by email: %w", err)
+	}
+	return &row.User, row.PasswordHash, nil
+}
+
+// Count returns the total number of users.
+func (r *sqliteUserRepo) Count(ctx context.Context) (int, error) {
+	var n int
+	err := r.db.GetContext(ctx, &n, `SELECT COUNT(*) FROM users`)
+	if err != nil {
+		return 0, fmt.Errorf("count users: %w", err)
+	}
+	return n, nil
 }


### PR DESCRIPTION
## What
Implements real JWT-based authentication, replacing the dev mode bypass entirely.

## Why
Closes T-30. Auth was deferred while the app was built with `NORA_DEV_MODE=true` — this task removes that bypass and wires in production-grade session management.

## How
- **`/internal/auth/auth.go`** — `GenerateToken` / `ValidateToken` using `golang-jwt/jwt/v5`, 24-hour expiry, HS256
- **`/internal/auth/middleware.go`** — `RequireAuth(secret)` and `RequireAdmin(secret)` read JWT from `Authorization: Bearer` header or `nora_session` cookie; inject `userID` + `role` into context
- **`/internal/api/auth.go`** — five endpoints:
  - `GET /api/v1/auth/setup-required` → `{"required": true/false}`
  - `POST /api/v1/auth/register` — open for first user (auto-promoted to admin), requires admin JWT after that
  - `POST /api/v1/auth/login` — bcrypt verify, returns JWT in body + sets `nora_session` HttpOnly cookie
  - `POST /api/v1/auth/logout` — clears cookie
  - `GET /api/v1/auth/me` — returns current user from context
- **`UserRepo`** extended with `GetByEmail` and `Count`
- **Password hashing** upgraded from SHA-256 placeholder to bcrypt throughout
- **`NORA_DEV_MODE`** removed from `Config`; setting it logs a deprecation warning
- All protected routes now use `RequireAuth(cfg.Secret)`

## Test coverage
- 11 unit tests in `internal/auth/`: token generation, validation, expiry, wrong-secret, malformed, bearer middleware, cookie middleware, missing token, invalid token, `RequireAdmin` enforcement, context helpers
- All `internal/...` tests pass

## Closes
Closes #30