### PR TITLE
feat: Docker image update checks hourly + Image Updates UI (DD-9)

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -267,7 +267,7 @@ func main() {
 	if imagePoller, err := docker.NewImageUpdatePoller(store); err != nil {
 		log.Printf("image update poller: socket not available, skipping (%v)", err)
 	} else {
-		go imagePoller.Start(imagePollerCtx)
+		go imagePoller.StartEvery(imagePollerCtx, scanner.DiscoveryInterval)
 	}
 
 	// Docker ResourcePoller — metrics collection is driven by the scan scheduler

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -543,6 +543,8 @@ export interface DiscoveredContainer {
   cpu_percent: number | null
   mem_percent: number | null
   last_seen_at: string
+  image_update_available: boolean
+  image_last_checked_at: string | null
 }
 
 export interface LinkAppInput {

--- a/frontend/src/components/DockerEngineDetail.css
+++ b/frontend/src/components/DockerEngineDetail.css
@@ -417,3 +417,128 @@
   color: var(--text2);
   border-color: var(--border2);
 }
+
+/* ── Wrapper (card grid + updates section stacked) ── */
+
+.de-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* ── Update available badge (amber, on cards) ── */
+
+.de-update-badge {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 500;
+  padding: 2px 7px;
+  border-radius: 3px;
+  background: rgba(234, 179, 8, 0.1);
+  border: 1px solid rgba(234, 179, 8, 0.3);
+  color: var(--yellow);
+  white-space: nowrap;
+  display: inline-block;
+  margin-top: 4px;
+}
+
+/* ── Up to date badge (green) ── */
+
+.de-uptodate-badge {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 2px 7px;
+  border-radius: 3px;
+  background: rgba(34, 197, 94, 0.08);
+  border: 1px solid rgba(34, 197, 94, 0.2);
+  color: var(--green);
+  white-space: nowrap;
+  display: inline-block;
+}
+
+/* ── Image Updates section ── */
+
+.de-updates-section {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.de-updates-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.de-updates-title {
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.de-updates-meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+}
+
+.de-updates-empty {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  padding: 16px 14px;
+  line-height: 1.6;
+}
+
+.de-updates-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.de-updates-table th {
+  text-align: left;
+  padding: 7px 14px;
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text3);
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.de-updates-table td {
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+
+.de-updates-table tr:last-child td {
+  border-bottom: none;
+}
+
+.de-updates-table tr:hover td {
+  background: var(--bg3);
+}
+
+.de-updates-name {
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.de-updates-image {
+  color: var(--text2);
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.de-updates-checked {
+  color: var(--text3);
+  white-space: nowrap;
+}

--- a/frontend/src/components/DockerEngineDetail.tsx
+++ b/frontend/src/components/DockerEngineDetail.tsx
@@ -201,7 +201,11 @@ export function DockerEngineDetail({ engineId, onCountsLoaded }: Props) {
     )
   }
 
+  const checked = containers.filter(c => c.image_last_checked_at !== null)
+  const updatesAvailable = checked.filter(c => c.image_update_available)
+
   return (
+    <div className="de-wrapper">
     <div className="de-card-grid">
       {containers.map(c => {
         const isLinked   = !!c.app_id
@@ -236,6 +240,9 @@ export function DockerEngineDetail({ engineId, onCountsLoaded }: Props) {
                 )}
                 {isUnlinked && (
                   <span className="de-image">{c.image}</span>
+                )}
+                {c.image_update_available && (
+                  <span className="de-update-badge">Update available</span>
                 )}
               </div>
 
@@ -391,6 +398,58 @@ export function DockerEngineDetail({ engineId, onCountsLoaded }: Props) {
           </div>
         )
       })}
+    </div>
+
+    {/* ── Image Updates section ── */}
+    <div className="de-updates-section">
+      <div className="de-updates-header">
+        <span className="de-updates-title">Image Updates</span>
+        {checked.length === 0 ? (
+          <span className="de-updates-meta">Not yet checked — runs every hour</span>
+        ) : (
+          <span className="de-updates-meta">
+            {updatesAvailable.length > 0
+              ? `${updatesAvailable.length} update${updatesAvailable.length !== 1 ? 's' : ''} available`
+              : 'All images up to date'}
+          </span>
+        )}
+      </div>
+
+      {checked.length === 0 ? (
+        <div className="de-updates-empty">
+          The image update check runs every hour alongside container discovery.<br />
+          Results will appear here after the first pass completes.
+        </div>
+      ) : (
+        <table className="de-updates-table">
+          <thead>
+            <tr>
+              <th>Container</th>
+              <th>Image</th>
+              <th>Status</th>
+              <th>Last checked</th>
+            </tr>
+          </thead>
+          <tbody>
+            {checked.map(c => (
+              <tr key={c.id}>
+                <td className="de-updates-name">{c.container_name}</td>
+                <td className="de-updates-image">{c.image}</td>
+                <td>
+                  {c.image_update_available
+                    ? <span className="de-update-badge">Update available</span>
+                    : <span className="de-uptodate-badge">Up to date</span>
+                  }
+                </td>
+                <td className="de-updates-checked">
+                  {c.image_last_checked_at ? timeAgo(c.image_last_checked_at) : '—'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
     </div>
   )
 }

--- a/internal/docker/image_poller.go
+++ b/internal/docker/image_poller.go
@@ -250,6 +250,37 @@ func extractRepoDigest(repoDigests []string, imageName string) string {
 	return ""
 }
 
+// StartEvery runs the image update poller on the given interval.  It waits 60 s
+// before the first run (same startup gate as Start), then fires every interval.
+// Use this when the caller wants the check to align with another scan cadence
+// (e.g. the hourly discovery pass) rather than the default daily 02:00 UTC schedule.
+func (p *ImageUpdatePoller) StartEvery(ctx context.Context, interval time.Duration) {
+	log.Printf("image update poller: starting on %s interval (60s startup delay)", interval)
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(60 * time.Second):
+	}
+
+	if err := p.Run(ctx); err != nil && ctx.Err() == nil {
+		log.Printf("image update poller: startup run error: %v", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := p.Run(ctx); err != nil && ctx.Err() == nil {
+				log.Printf("image update poller: run error: %v", err)
+			}
+		}
+	}
+}
+
 // imagePollerDurationUntilNext2AM returns the duration from now until the next
 // 02:00 UTC.  Mirrors jobs.durationUntilNext2AM without importing the jobs package.
 func imagePollerDurationUntilNext2AM() time.Duration {


### PR DESCRIPTION
## What
Surfaces the existing DD-9 image update detection in the UI and fixes the polling schedule.

## Why
The backend already stored image digest comparison results in the DB but nothing showed them to the user. The poller also ran on a daily 02:00 UTC schedule, making the data go stale for up to 24 hours.

## How

**Backend — scheduler fix**
- Added `ImageUpdatePoller.StartEvery(ctx, interval)` — runs on a caller-supplied interval instead of the hardcoded daily ticker
- `main.go` now calls `StartEvery(ctx, scanner.DiscoveryInterval)` so image checks run every hour alongside container discovery (was: once daily at 02:00 UTC)

**Frontend — Image Updates UI**
- Added `image_update_available` + `image_last_checked_at` to the `DiscoveredContainer` TypeScript type (fields were already returned by the API)
- Amber **"Update available"** badge on container cards where an update is detected
- New **"Image Updates"** section below the container grid:
  - Table: container name · image · status badge (amber/green) · last checked time
  - Summary line: "N updates available" or "All images up to date"
  - Empty state with explanation when the first check hasn't run yet

## Limitations
The check compares digest hashes for the **same tag** — it knows *an* update exists but not *what version* it is (no semantic version info stored). That would require a separate registry metadata lookup.

## Test coverage
- `go test ./internal/... ./cmd/...` — all pass
- `npm run build` — zero TypeScript errors

## Closes
Closes #DD-9 (image update detection UI)