### PR TITLE
feat: sidebar logout button + dynamic avatar initial

### DIFF
--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -73,6 +73,18 @@
   gap: 4px;
 }
 
+.sidebar-logout {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.sidebar-logout:hover {
+  color: var(--red);
+  background: rgba(239, 68, 68, 0.08);
+}
+
 .sidebar-avatar {
   width: 24px;
   height: 24px;

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
-import { NavLink, Link, useLocation } from 'react-router-dom'
+import { NavLink, Link, useLocation, useNavigate } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
 import './Sidebar.css'
 
 const NAV_ITEMS = [
@@ -62,8 +63,15 @@ const NAV_ITEMS = [
 
 export function Sidebar() {
   const location = useLocation()
+  const navigate = useNavigate()
+  const { user, logout } = useAuth()
   const settingsActive = location.pathname === '/settings'
   const profileActive = location.pathname === '/profile'
+
+  async function handleLogout() {
+    await logout()
+    navigate('/login', { replace: true })
+  }
 
   return (
     <nav className="sidebar">
@@ -100,8 +108,20 @@ export function Sidebar() {
           title="Profile"
           className={`nav-item${profileActive ? ' active' : ''}`}
         >
-          <div className="sidebar-avatar">A</div>
+          <div className="sidebar-avatar">{user?.email?.[0].toUpperCase() ?? 'A'}</div>
         </Link>
+
+        <button
+          className="nav-item sidebar-logout"
+          title="Sign out"
+          onClick={handleLogout}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+            <polyline points="16 17 21 12 16 7" />
+            <line x1="21" y1="12" x2="9" y2="12" />
+          </svg>
+        </button>
       </div>
     </nav>
   )


### PR DESCRIPTION
## What
Adds a logout button (power/exit icon) to the bottom of the sidebar and makes the avatar initial dynamic from the logged-in user's email.

## Why
Previously there was no way to sign out from the UI. Avatar showed hardcoded "A" instead of the real user's initial.

## How
- Added `useAuth()` and `useNavigate()` to `Sidebar`
- `handleLogout` calls `await logout()` then navigates to `/login`
- Avatar initial derived from `user?.email?.[0].toUpperCase()`
- Logout button styled with `.sidebar-logout` — red tint on hover

## Test coverage
- Manually verified: clicking logout clears session cookie and redirects to `/login`
- After logout, revisiting `/` redirects back to `/login` (AuthGuard working)
- Login page shows "Sign in" (not setup) since account already exists
- Build passes with zero TypeScript errors

## Closes
N/A — follow-up to #182 (T-31 auth UI)