### PR TITLE
fix: always overwrite builtin templates on startup to pick up upgrades

### DIFF
--- a/internal/apptemplate/apptemplate.go
+++ b/internal/apptemplate/apptemplate.go
@@ -140,9 +140,9 @@ func NewRegistry(fsys fs.FS) (*Registry, error) {
 	return reg, nil
 }
 
-// ExportBuiltins writes each embedded YAML from fsys into destDir.
-// Existing files are skipped so user edits are preserved across restarts.
-// New files added to the embedded set are written on the first startup after an upgrade.
+// ExportBuiltins writes each embedded YAML from fsys into destDir, always
+// overwriting existing files so upgraded containers land fresh builtin templates.
+// User-editable templates belong in the custom dir, not here.
 func ExportBuiltins(fsys fs.FS, destDir string) error {
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return fmt.Errorf("create builtin dir: %w", err)
@@ -157,14 +157,11 @@ func ExportBuiltins(fsys fs.FS, destDir string) error {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
 			continue
 		}
-		dest := filepath.Join(destDir, e.Name())
-		if _, err := os.Stat(dest); err == nil {
-			continue // already exists — preserve any user edits
-		}
 		data, err := fs.ReadFile(fsys, e.Name())
 		if err != nil {
 			return fmt.Errorf("read embedded %s: %w", e.Name(), err)
 		}
+		dest := filepath.Join(destDir, e.Name())
 		if err := os.WriteFile(dest, data, 0644); err != nil {
 			return fmt.Errorf("write %s: %w", dest, err)
 		}

--- a/internal/docker/enrichment_test.go
+++ b/internal/docker/enrichment_test.go
@@ -64,6 +64,7 @@ func (m *enrichMockCheckRepo) UpsertForComponent(_ context.Context, _ *models.Mo
 func (m *enrichMockCheckRepo) ExistsForTypeAndTarget(_ context.Context, _, target string) (bool, error) {
 	return m.existsByTarget[target], nil
 }
+func (m *enrichMockCheckRepo) SetDNSBaseline(_ context.Context, _, _ string) error { return nil }
 
 type enrichMockContainerRepo struct {
 	containers map[string]*models.DiscoveredContainer


### PR DESCRIPTION
## What
`ExportBuiltins` previously skipped files that already existed on disk. This meant any container running against a pre-existing `/data` mount would never receive updated or newly added builtin templates after an upgrade.

## Why
When moving from the old embedded-only approach to the new disk-based approach (#188), users with existing `/data` volumes would get stale (or completely missing) builtin templates. The skip-existing logic was designed to preserve user edits, but builtins aren't user-editable — that's what `/data/templates/custom/` is for.

## How
Removed the `os.Stat` early-continue check in `ExportBuiltins` so the embedded YAML is always written on startup. The custom dir remains untouched.

Also fixed a pre-existing compile failure in `internal/docker/enrichment_test.go` — the `enrichMockCheckRepo` mock was missing the `SetDNSBaseline` method added to the `CheckRepo` interface.

## Test coverage
- `go test ./...` passes cleanly
- `ExportBuiltins` is exercised by existing apptemplate tests

## Closes
Fixes templates not landing on containers with a pre-existing `/data` mount after upgrade.