### PR TITLE
fix: send-now context bug, period wiring, and button labels

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -344,8 +344,8 @@ export const digestSettings = {
   putSchedule: (s: DigestSchedule) =>
     request<DigestSchedule>('PUT', '/digest/schedule', s),
 
-  sendNow: () =>
-    request<SendNowResult>('POST', '/digest/send-now'),
+  sendNow: (period?: string) =>
+    request<SendNowResult>('POST', `/digest/send-now${period ? `?period=${encodeURIComponent(period)}` : ''}`),
 }
 
 export const smtpSettings = {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -407,11 +407,29 @@ function NotificationsTab() {
     }
   }
 
+  // Compute period string from the currently selected frequency so both
+  // Send now and Preview report always reflect what's shown in the UI.
+  const currentPeriod = (): string => {
+    const now = new Date()
+    if (schedule.frequency === 'daily') {
+      return now.toISOString().slice(0, 10) // YYYY-MM-DD
+    }
+    if (schedule.frequency === 'weekly') {
+      const d = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()))
+      const day = d.getUTCDay() || 7
+      d.setUTCDate(d.getUTCDate() + 4 - day)
+      const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1))
+      const week = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7)
+      return `${d.getUTCFullYear()}-W${String(week).padStart(2, '0')}`
+    }
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}` // YYYY-MM
+  }
+
   const sendNow = async () => {
     setSendingNow(true)
     setSendNowMsg('')
     try {
-      const res = await digestSettings.sendNow()
+      const res = await digestSettings.sendNow(currentPeriod())
       setSendNowMsg(`Queued for period ${res.period}`)
     } catch (e: unknown) {
       setSendNowMsg(e instanceof Error ? e.message : 'Failed to send')
@@ -592,15 +610,16 @@ function NotificationsTab() {
             className="settings-btn secondary"
             onClick={sendNow}
             disabled={sendingNow || !smtpConfigured}
-            title={!smtpConfigured ? 'Configure SMTP first' : undefined}
+            title={!smtpConfigured ? 'Configure SMTP first' : 'Email the digest for the current period'}
           >
-            {sendingNow ? 'Sending…' : 'Send test digest now'}
+            {sendingNow ? 'Sending…' : 'Send now'}
           </button>
           <button
             className="settings-btn secondary"
-            onClick={() => window.open(digestReport.url(), '_blank')}
+            onClick={() => window.open(digestReport.url(currentPeriod()), '_blank')}
+            title="Preview the digest report for the current period"
           >
-            View Report
+            Preview report
           </button>
           {schedMsg && <span className="settings-status-msg">{schedMsg}</span>}
           {sendNowMsg && <span className="settings-status-msg">{sendNowMsg}</span>}

--- a/internal/api/digest.go
+++ b/internal/api/digest.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -88,26 +89,32 @@ func (h *DigestHandler) PutSchedule(w http.ResponseWriter, r *http.Request) {
 }
 
 // SendNow triggers an immediate digest for the current period: POST /api/v1/digest/send-now
+// Optional query param ?period= overrides the schedule-derived period so the UI
+// can send for whichever frequency is currently selected without saving first.
 func (h *DigestHandler) SendNow(w http.ResponseWriter, r *http.Request) {
 	if !h.digestJob.SMTPConfigured(r.Context()) {
 		writeError(w, http.StatusUnprocessableEntity, "SMTP is not configured — set up SMTP before sending a digest")
 		return
 	}
 
-	var sched models.DigestSchedule
-	err := h.store.Settings.GetJSON(r.Context(), digestScheduleKey, &sched)
-	if errors.Is(err, repo.ErrNotFound) {
-		sched = models.DigestSchedule{Frequency: "monthly", DayOfWeek: 1, DayOfMonth: 1}
-	} else if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
+	// Use caller-supplied period if provided, otherwise derive from saved schedule.
+	period := r.URL.Query().Get("period")
+	if period == "" {
+		var sched models.DigestSchedule
+		err := h.store.Settings.GetJSON(r.Context(), digestScheduleKey, &sched)
+		if errors.Is(err, repo.ErrNotFound) {
+			sched = models.DigestSchedule{Frequency: "monthly", DayOfWeek: 1, DayOfMonth: 1}
+		} else if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		period = periodLabelFromSchedule(sched.Frequency, time.Now())
 	}
 
-	period := periodLabelFromSchedule(sched.Frequency, time.Now())
-
-	// Run in background — send-now is fire-and-forget from the HTTP perspective.
+	// Detach from the request context — it is cancelled as soon as the 202
+	// response is written, which would abort every DB query in buildDigestData.
 	go func() {
-		if err := h.digestJob.Send(r.Context(), period); err != nil {
+		if err := h.digestJob.Send(context.Background(), period); err != nil {
 			_ = err
 		}
 	}()


### PR DESCRIPTION
## What
Three fixes to the digest Send now / Preview report flow.

## Fixes

### 1. Send now was silently doing nothing
The goroutine used `r.Context()` which is cancelled by the HTTP server the moment the 202 response is written. Every single DB query inside `buildDigestData` was failing immediately with `context cancelled` — no email was ever sent. Fixed with `context.Background()`.

### 2. Send now and Preview report ignored the UI selection
Both buttons derived the period from the **saved** schedule in the DB, so changing Daily/Weekly/Monthly in the UI had no effect until you saved. Fixed by computing the period client-side from `schedule.frequency` via `currentPeriod()` and passing it as `?period=` to both endpoints.

### 3. Button labels
- `Send test digest now` → `Send now`
- `View Report` → `Preview report`

## Test coverage
- `go build ./...` clean
- `go test ./internal/api/...` passes
- `npm run build` zero TypeScript errors

## Closes
Follow-up to #197