### PR TITLE
fix(security): resolve all 10 CodeQL alerts (SEC-01)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test-backend:
     name: Go tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     name: Build and push Docker image

--- a/internal/api/apptemplates.go
+++ b/internal/api/apptemplates.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/digitalcheffe/nora/internal/apptemplate"
@@ -219,7 +220,15 @@ func (h *AppTemplatesHandler) ListCustom(w http.ResponseWriter, r *http.Request)
 // DeleteCustom handles DELETE /app-templates/custom/{id} — removes a custom app template file.
 func (h *AppTemplatesHandler) DeleteCustom(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
+	if !isSafeFilename(id) {
+		writeError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
 	path := filepath.Join(h.customDir, id+".yaml")
+	if !strings.HasPrefix(path, filepath.Clean(h.customDir)+string(os.PathSeparator)) {
+		writeError(w, http.StatusBadRequest, "invalid id")
+		return
+	}
 
 	if err := os.Remove(path); errors.Is(err, os.ErrNotExist) {
 		writeError(w, http.StatusNotFound, "custom app template not found")
@@ -233,6 +242,22 @@ func (h *AppTemplatesHandler) DeleteCustom(w http.ResponseWriter, r *http.Reques
 	_ = h.registry.Reload()
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// isSafeFilename returns true if s is a non-empty string containing only
+// alphanumeric characters, hyphens, and underscores — safe to use as a
+// filename component with no path traversal risk.
+func isSafeFilename(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '-' || c == '_') {
+			return false
+		}
+	}
+	return true
 }
 
 // readCustomProfiles reads all *.yaml files from dir and returns them as CustomProfile records.

--- a/internal/api/apptemplates_test.go
+++ b/internal/api/apptemplates_test.go
@@ -204,3 +204,28 @@ func TestAppTemplatesCreateCustom_InvalidYAML(t *testing.T) {
 		t.Fatalf("expected 422 got %d: %s", rr.Code, rr.Body.String())
 	}
 }
+
+// TestDeleteCustom_PathTraversal ensures a traversal ID is rejected with 400.
+func TestDeleteCustom_PathTraversal(t *testing.T) {
+	router := newAppTemplatesRouter(t)
+
+	attacks := []string{
+		"../../../etc/passwd",
+		"..%2F..%2Fetc%2Fpasswd",
+		"foo/bar",
+		"foo\\bar",
+		"..",
+	}
+	for _, id := range attacks {
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/app-templates/custom/"+id, nil)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		// chi will strip the traversal segments from the URL before routing,
+		// so the router may return 404 (no match) or 400 (our validation);
+		// either is acceptable — what must NOT happen is 204 (success).
+		if rr.Code == http.StatusNoContent {
+			t.Errorf("DELETE /app-templates/custom/%s: got 204 (traversal succeeded)", id)
+		}
+	}
+}

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -224,6 +224,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		Value:    token,
 		Path:     "/",
 		HttpOnly: true,
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 		Expires:  time.Now().Add(24 * time.Hour),
 	})
@@ -252,6 +253,7 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 		Value:    "",
 		Path:     "/",
 		HttpOnly: true,
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 		Expires:  time.Unix(0, 0),
 		MaxAge:   -1,

--- a/internal/api/totp.go
+++ b/internal/api/totp.go
@@ -174,6 +174,7 @@ func (h *TOTPHandler) Verify(w http.ResponseWriter, r *http.Request) {
 		Value:    token,
 		Path:     "/",
 		HttpOnly: true,
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 		Expires:  time.Now().Add(24 * time.Hour),
 	})

--- a/internal/icons/fetcher.go
+++ b/internal/icons/fetcher.go
@@ -36,10 +36,14 @@ func New(iconsDir string) (*Fetcher, error) {
 // if non-empty it is tried first on the CDN before falling back to profileID.
 // The result is always stored as profileID.svg so the icon URL stays stable.
 func (f *Fetcher) EnsureIcon(profileID, iconSlug string) {
-	if profileID == "" {
+	if !isValidIconID(profileID) {
 		return
 	}
-	if _, err := os.Stat(f.iconPath(profileID)); err == nil {
+	p, err := f.safeIconPath(profileID)
+	if err != nil {
+		return
+	}
+	if _, err := os.Stat(p); err == nil {
 		return // already cached
 	}
 	go f.fetch(context.Background(), profileID, iconSlug)
@@ -51,11 +55,15 @@ func (f *Fetcher) EnsureIcon(profileID, iconSlug string) {
 func (f *Fetcher) FetchAll(ctx context.Context, profileIDs []string, slugOverrides map[string]string) {
 	seen := make(map[string]bool)
 	for _, id := range profileIDs {
-		if id == "" || seen[id] {
+		if !isValidIconID(id) || seen[id] {
 			continue
 		}
 		seen[id] = true
-		if _, err := os.Stat(f.iconPath(id)); err == nil {
+		p, err := f.safeIconPath(id)
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(p); err == nil {
 			continue // already cached
 		}
 		id := id
@@ -66,7 +74,14 @@ func (f *Fetcher) FetchAll(ctx context.Context, profileIDs []string, slugOverrid
 
 // ServeIcon writes the cached SVG to w, returning true on success.
 func (f *Fetcher) ServeIcon(w http.ResponseWriter, profileID string) bool {
-	data, err := os.ReadFile(f.iconPath(profileID))
+	if !isValidIconID(profileID) {
+		return false
+	}
+	p, err := f.safeIconPath(profileID)
+	if err != nil {
+		return false
+	}
+	data, err := os.ReadFile(p)
 	if err != nil {
 		return false
 	}
@@ -77,8 +92,30 @@ func (f *Fetcher) ServeIcon(w http.ResponseWriter, profileID string) bool {
 	return true
 }
 
-func (f *Fetcher) iconPath(profileID string) string {
-	return filepath.Join(f.iconsDir, profileID+".svg")
+// isValidIconID returns true if id contains only alphanumeric characters,
+// hyphens, or underscores — safe to use as a filename component.
+func isValidIconID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, c := range id {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '-' || c == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+// safeIconPath returns the absolute path for profileID's cached SVG file,
+// validating that the resolved path stays within iconsDir.
+func (f *Fetcher) safeIconPath(profileID string) (string, error) {
+	base := filepath.Clean(f.iconsDir)
+	candidate := filepath.Join(base, profileID+".svg")
+	if !strings.HasPrefix(candidate, base+string(os.PathSeparator)) {
+		return "", fmt.Errorf("icons: path traversal detected for id %q", profileID)
+	}
+	return candidate, nil
 }
 
 func (f *Fetcher) fetch(ctx context.Context, profileID, iconSlug string) {
@@ -98,13 +135,19 @@ func (f *Fetcher) fetch(ctx context.Context, profileID, iconSlug string) {
 		candidates = append(candidates, profileID[:len(profileID)-4]+"-home")
 	}
 
+	dest, err := f.safeIconPath(profileID)
+	if err != nil {
+		log.Printf("icons: %v", err)
+		return
+	}
+
 	for _, name := range candidates {
 		url := fmt.Sprintf("%s/%s.svg", cdnBase, name)
 		data, err := f.download(ctx, url)
 		if err != nil {
 			continue
 		}
-		if err := os.WriteFile(f.iconPath(profileID), data, 0644); err != nil {
+		if err := os.WriteFile(dest, data, 0644); err != nil {
 			log.Printf("icons: write %s: %v", profileID, err)
 			return
 		}

--- a/internal/icons/fetcher_test.go
+++ b/internal/icons/fetcher_test.go
@@ -1,0 +1,104 @@
+package icons
+
+import (
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestIsValidIconID verifies the allowlist for safe icon identifiers.
+func TestIsValidIconID(t *testing.T) {
+	valid := []string{
+		"wireguard",
+		"adguard-home",
+		"my_app",
+		"App123",
+		"a",
+	}
+	for _, id := range valid {
+		if !isValidIconID(id) {
+			t.Errorf("isValidIconID(%q) = false; want true", id)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"../etc/passwd",
+		"../../secret",
+		"foo/bar",
+		"foo\\bar",
+		"foo.bar",
+		"foo bar",
+		"foo\x00bar",
+	}
+	for _, id := range invalid {
+		if isValidIconID(id) {
+			t.Errorf("isValidIconID(%q) = true; want false", id)
+		}
+	}
+}
+
+// TestSafeIconPath verifies that safeIconPath rejects traversal attempts.
+func TestSafeIconPath(t *testing.T) {
+	dir := t.TempDir()
+	f := &Fetcher{iconsDir: dir}
+
+	good, err := f.safeIconPath("wireguard")
+	if err != nil {
+		t.Fatalf("safeIconPath(wireguard): unexpected error: %v", err)
+	}
+	want := filepath.Join(dir, "wireguard.svg")
+	if good != want {
+		t.Errorf("safeIconPath(wireguard) = %q; want %q", good, want)
+	}
+
+	traversals := []string{
+		"../secret",
+		"../../etc/passwd",
+	}
+	for _, id := range traversals {
+		_, err := f.safeIconPath(id)
+		if err == nil {
+			t.Errorf("safeIconPath(%q) should have returned error", id)
+		}
+	}
+}
+
+// TestServeIcon_TraversalRejected verifies that ServeIcon returns false for
+// path traversal inputs without serving any file content.
+func TestServeIcon_TraversalRejected(t *testing.T) {
+	dir := t.TempDir()
+	f := &Fetcher{iconsDir: dir, client: nil}
+
+	attacks := []string{
+		"../../../etc/passwd",
+		"../../secret",
+		"foo/bar",
+		"foo\\bar",
+	}
+	for _, id := range attacks {
+		w := httptest.NewRecorder()
+		if f.ServeIcon(w, id) {
+			t.Errorf("ServeIcon(%q) returned true; expected false (path traversal)", id)
+		}
+		// Body must be empty — no file content was served.
+		if w.Body.Len() > 0 {
+			t.Errorf("ServeIcon(%q) wrote body content; expected empty response", id)
+		}
+	}
+}
+
+// TestEnsureIcon_TraversalRejected verifies EnsureIcon is a no-op for invalid IDs.
+func TestEnsureIcon_TraversalRejected(t *testing.T) {
+	dir := t.TempDir()
+	f := &Fetcher{iconsDir: dir, client: nil}
+
+	// Plant a sentinel file that a traversal might try to reach.
+	sentinel := filepath.Join(dir, "sentinel.txt")
+	_ = os.WriteFile(sentinel, []byte("secret"), 0600)
+
+	// These should silently no-op; they must not panic or access sentinel.
+	f.EnsureIcon("../sentinel", "")
+	f.EnsureIcon("../../etc/passwd", "")
+}

--- a/internal/jobs/smtp.go
+++ b/internal/jobs/smtp.go
@@ -76,12 +76,27 @@ func SendMail(host string, port int, user, pass, from string, to []string, subje
 	return c.Quit()
 }
 
+// sanitizeHeader strips CR and LF characters from a header value to prevent
+// email header injection attacks.
+func sanitizeHeader(v string) string {
+	v = strings.ReplaceAll(v, "\r", "")
+	v = strings.ReplaceAll(v, "\n", "")
+	return v
+}
+
 // buildMIMEMessage constructs an RFC 2822 MIME message with a text/html part.
+// All user-supplied header values are sanitized to strip CRLF sequences before
+// being written into the message, preventing header injection attacks.
 func buildMIMEMessage(from string, to []string, subject, htmlBody string) string {
+	sanitizedTo := make([]string, len(to))
+	for i, addr := range to {
+		sanitizedTo[i] = sanitizeHeader(addr)
+	}
+
 	var b strings.Builder
-	b.WriteString("From: " + from + "\r\n")
-	b.WriteString("To: " + strings.Join(to, ", ") + "\r\n")
-	b.WriteString("Subject: " + subject + "\r\n")
+	b.WriteString("From: " + sanitizeHeader(from) + "\r\n")
+	b.WriteString("To: " + strings.Join(sanitizedTo, ", ") + "\r\n")
+	b.WriteString("Subject: " + sanitizeHeader(subject) + "\r\n")
 	b.WriteString("MIME-Version: 1.0\r\n")
 	b.WriteString("Content-Type: text/html; charset=\"UTF-8\"\r\n")
 	b.WriteString("\r\n")

--- a/internal/jobs/smtp_test.go
+++ b/internal/jobs/smtp_test.go
@@ -1,0 +1,61 @@
+package jobs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeHeader_StripsCRLF(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"normal value", "normal value"},
+		{"injected\r\nBCC: attacker@evil.com", "injectedBCC: attacker@evil.com"},
+		{"injected\nBCC: attacker@evil.com", "injectedBCC: attacker@evil.com"},
+		{"injected\rBCC: attacker@evil.com", "injectedBCC: attacker@evil.com"},
+		{"\r\n", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := sanitizeHeader(tc.input)
+		if got != tc.want {
+			t.Errorf("sanitizeHeader(%q) = %q; want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestBuildMIMEMessage_HeaderInjectionPrevented(t *testing.T) {
+	maliciousSubject := "Hello\r\nBCC: attacker@evil.com"
+	maliciousFrom := "legit@example.com\r\nX-Injected: header"
+	maliciousTo := []string{"victim@example.com\r\nBCC: third@evil.com"}
+
+	msg := buildMIMEMessage(maliciousFrom, maliciousTo, maliciousSubject, "<p>body</p>")
+
+	// Split into header and body sections.
+	parts := strings.SplitN(msg, "\r\n\r\n", 2)
+	if len(parts) < 2 {
+		t.Fatal("message has no header/body separator")
+	}
+	headers := parts[0]
+
+	// No bare CR or LF should appear in the headers (CRLF pairs are fine as
+	// they are the RFC 2822 line terminator that we wrote explicitly).
+	for _, line := range strings.Split(headers, "\r\n") {
+		if strings.ContainsAny(line, "\r\n") {
+			t.Errorf("header line contains bare CR or LF: %q", line)
+		}
+	}
+
+	// Injected field names must not appear as standalone header lines.
+	// After CRLF stripping the content is still present but cannot start a
+	// new header line, so we check that no line *begins* with the field name.
+	for _, line := range strings.Split(headers, "\r\n") {
+		if strings.HasPrefix(line, "BCC:") {
+			t.Errorf("injected BCC appeared as a standalone header line: %q", line)
+		}
+		if strings.HasPrefix(line, "X-Injected:") {
+			t.Errorf("injected X-Injected appeared as a standalone header line: %q", line)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Resolves all 10 CodeQL security alerts identified in SEC-01, grouped by vulnerability type.

- **Group 1 — Email header injection** (`internal/jobs/smtp.go`): Added `sanitizeHeader()` to strip `\r`/`\n` from all user-supplied values before they reach SMTP headers, preventing CRLF injection attacks
- **Group 2 — Path traversal** (`internal/api/apptemplates.go`, `internal/icons/fetcher.go`): Added `isSafeFilename()` / `isValidIconID()` allowlist validators and `safeIconPath()` with filepath prefix checks at all four alert locations; traversal attempts now return early/false before any filesystem operation
- **Group 3 — Cookie Secure attribute** (`internal/api/auth.go`, `internal/api/totp.go`): Set `Secure: true` on all three session cookie writes (Login, Logout, TOTP Verify); `HttpOnly` and `SameSiteLaxMode` were already present
- **Group 4 — GitHub Actions permissions** (`.github/workflows/ci.yml`, `.github/workflows/release.yml`): Added top-level `permissions: contents: read` to both workflow files; release job-level `packages: write` override preserved

## Test plan

- [x] `go build ./...` passes with zero errors
- [x] `go test ./...` passes — all 14 packages green
- [x] New `internal/jobs/smtp_test.go` — covers `sanitizeHeader` and full CRLF injection attempt
- [x] New `internal/icons/fetcher_test.go` — covers `isValidIconID`, `safeIconPath`, `ServeIcon` traversal rejection, and `EnsureIcon` traversal rejection
- [x] `TestDeleteCustom_PathTraversal` added to `internal/api/apptemplates_test.go`
- [ ] Re-run CodeQL scan via GitHub Security tab to confirm all 10 alerts closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)