### PR TITLE
fix: v1.0.0 bug fixes — template substitution, config sync, check pause

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -503,7 +503,7 @@ func main() {
 			api.NewIconsHandler(iconFetcher, registry).Routes(r)
 		}
 		api.NewEventsHandler(eventRepo).Routes(r)
-		api.NewChecksHandler(checkRepo, eventRepo).Routes(r)
+		api.NewChecksHandler(checkRepo, eventRepo, monitorScheduler).Routes(r)
 		api.NewDashboardHandler(appRepo, eventRepo, checkRepo, rollupRepo, registry).Routes(r)
 		api.NewTopologyHandler(infraComponentRepo, dockerEngineRepo, appRepo, resourceRollupRepo).Routes(r)
 		api.NewInfraComponentHandler(infraComponentRepo, resourceRollupRepo, checkRepo, eventRepo, store).Routes(r)

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"time"
 
@@ -195,6 +196,7 @@ func (h *AppsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		h.iconsFetcher.EnsureIcon(existing.ProfileID, h.iconSlugForProfile(existing.ProfileID))
 	}
 	h.syncMonitorCheck(r.Context(), existing, monitorURLFromConfig(existing.Config))
+	h.syncProfileMonitorCheck(r.Context(), existing)
 	writeJSON(w, http.StatusOK, existing)
 }
 
@@ -275,6 +277,40 @@ func (h *AppsHandler) syncMonitorCheck(ctx context.Context, app *models.App, mon
 		CreatedAt:    time.Now().UTC(),
 	}
 	_ = h.checks.Create(ctx, check)
+}
+
+// syncProfileMonitorCheck re-resolves the check target for any profile-derived
+// URL check when the app's config (e.g. base_url) has changed. Called on every
+// app update so the stored target stays in sync with the configured base_url.
+func (h *AppsHandler) syncProfileMonitorCheck(ctx context.Context, app *models.App) {
+	if h.checks == nil || h.profiler == nil || app.ProfileID == "" {
+		return
+	}
+	tmpl, err := h.profiler.Get(app.ProfileID)
+	if err != nil || tmpl == nil || tmpl.Monitor.CheckURL == "" {
+		return
+	}
+	newTarget, err := app.Config.ResolveTemplateVars(tmpl.Monitor.CheckURL)
+	if err != nil {
+		log.Printf("apps: cannot resolve profile check URL for app %q: %v", app.Name, err)
+		return
+	}
+	all, err := h.checks.List(ctx)
+	if err != nil {
+		return
+	}
+	for i := range all {
+		c := &all[i]
+		if c.AppID == app.ID && c.Type == tmpl.Monitor.CheckType {
+			if c.Target != newTarget {
+				c.Target = newTarget
+				if updateErr := h.checks.Update(ctx, c); updateErr != nil {
+					log.Printf("apps: update profile check target for app %q: %v", app.Name, updateErr)
+				}
+			}
+			return
+		}
+	}
 }
 
 // monitorURLFromConfig extracts the monitor_url string from app config JSON.

--- a/internal/api/checks.go
+++ b/internal/api/checks.go
@@ -16,15 +16,24 @@ import (
 	"github.com/google/uuid"
 )
 
+// syncer is the minimal interface ChecksHandler needs from the scheduler —
+// just enough to trigger an immediate re-sync when a check is disabled.
+type syncer interface {
+	TriggerSync()
+}
+
 // ChecksHandler holds dependencies for the monitor checks resource handlers.
 type ChecksHandler struct {
-	checks repo.CheckRepo
-	events repo.EventRepo
+	checks    repo.CheckRepo
+	events    repo.EventRepo
+	scheduler syncer // may be nil; used to push pause/resume immediately to the runner
 }
 
 // NewChecksHandler creates a ChecksHandler with the given repositories.
-func NewChecksHandler(checks repo.CheckRepo, events repo.EventRepo) *ChecksHandler {
-	return &ChecksHandler{checks: checks, events: events}
+// Pass a non-nil scheduler so that pausing or resuming a check takes effect
+// immediately instead of waiting for the next 5-minute scheduler poll.
+func NewChecksHandler(checks repo.CheckRepo, events repo.EventRepo, scheduler syncer) *ChecksHandler {
+	return &ChecksHandler{checks: checks, events: events, scheduler: scheduler}
 }
 
 // Routes registers all check endpoints on r.
@@ -301,6 +310,14 @@ func (h *ChecksHandler) Update(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+
+	// When the enabled flag changed, nudge the scheduler immediately so the
+	// goroutine for a paused check is cancelled (or started for a resumed one)
+	// without waiting for the next 5-minute periodic sync.
+	if req.Enabled != nil && h.scheduler != nil {
+		h.scheduler.TriggerSync()
+	}
+
 	writeJSON(w, http.StatusOK, existing)
 }
 

--- a/internal/api/checks_test.go
+++ b/internal/api/checks_test.go
@@ -19,7 +19,7 @@ func newChecksRouter(t *testing.T) http.Handler {
 	db := newTestDB(t)
 	checkRepo := repo.NewCheckRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	h := api.NewChecksHandler(checkRepo, eventRepo)
+	h := api.NewChecksHandler(checkRepo, eventRepo, nil)
 	r := chi.NewRouter()
 	h.Routes(r)
 	return r

--- a/internal/docker/enrichment.go
+++ b/internal/docker/enrichment.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -62,7 +61,15 @@ func EnrichAppOnLink(
 // enrichMonitorCheck creates a monitor check from the profile's monitor config
 // if one with the same type and target does not already exist.
 func enrichMonitorCheck(ctx context.Context, store *repo.Store, app *models.App, tmpl *apptemplate.AppTemplate) {
-	target := substituteBaseURL(tmpl.Monitor.CheckURL, app.Config)
+	target, err := substituteBaseURL(tmpl.Monitor.CheckURL, app.Config)
+	if err != nil {
+		log.Printf("enrichment: resolve check URL for app %q: %v — skipping monitor check creation", app.Name, err)
+		return
+	}
+	if !strings.HasPrefix(target, "http://") && !strings.HasPrefix(target, "https://") {
+		log.Printf("enrichment: resolved check URL %q for app %q has no http/https scheme — skipping", target, app.Name)
+		return
+	}
 	exists, err := store.Checks.ExistsForTypeAndTarget(ctx, tmpl.Monitor.CheckType, target)
 	if err != nil {
 		log.Printf("enrichment: check existence query for app %q: %v", app.Name, err)
@@ -148,19 +155,11 @@ func enrichResourceReadings(ctx context.Context, store *repo.Store, app *models.
 }
 
 // substituteBaseURL replaces {base_url} in tmplURL with the base_url value
-// from the app config JSON. Returns tmplURL unchanged if no base_url is found.
-func substituteBaseURL(tmplURL string, cfg models.ConfigJSON) string {
-	if !strings.Contains(tmplURL, "{base_url}") {
-		return tmplURL
-	}
-	var m map[string]interface{}
-	if err := json.Unmarshal(cfg, &m); err != nil {
-		return tmplURL
-	}
-	if v, ok := m["base_url"].(string); ok {
-		return strings.ReplaceAll(tmplURL, "{base_url}", v)
-	}
-	return tmplURL
+// from the app config JSON. Returns an error when the placeholder is present
+// but base_url is missing or empty — this prevents an unresolved template from
+// being stored as a check target.
+func substituteBaseURL(tmplURL string, cfg models.ConfigJSON) (string, error) {
+	return cfg.ResolveTemplateVars(tmplURL)
 }
 
 // parseIntervalSecs converts a duration string (e.g. "5m", "1h", "30s") to

--- a/internal/docker/enrichment_test.go
+++ b/internal/docker/enrichment_test.go
@@ -406,21 +406,76 @@ func TestParseIntervalSecs(t *testing.T) {
 }
 
 func TestSubstituteBaseURL(t *testing.T) {
-	cases := []struct {
-		tmpl string
-		cfg  string
-		want string
-	}{
-		{"{base_url}/ping", `{"base_url":"http://host:8989"}`, "http://host:8989/ping"},
-		{"{base_url}/api", `{}`, "{base_url}/api"},             // no base_url in config
-		{"/health", `{"base_url":"http://x"}`, "/health"},      // no placeholder in template
-		{"{base_url}", `{"base_url":"http://x"}`, "http://x"},
-		{"{base_url}", `not-json`, "{base_url}"},               // bad JSON — return as-is
+	type tc struct {
+		tmpl    string
+		cfg     string
+		want    string
+		wantErr bool
+	}
+	cases := []tc{
+		// Happy path: placeholder fully resolved.
+		{"{base_url}/ping", `{"base_url":"http://host:8989"}`, "http://host:8989/ping", false},
+		// No placeholder in template — returned unchanged, no error.
+		{"/health", `{"base_url":"http://x"}`, "/health", false},
+		// Placeholder resolved to bare domain (no scheme) — still returned; scheme
+		// validation is the caller's responsibility.
+		{"{base_url}", `{"base_url":"http://x"}`, "http://x", false},
+		// Missing base_url in config — must error, not return unresolved template.
+		{"{base_url}/api", `{}`, "", true},
+		// Empty base_url value — must error.
+		{"{base_url}/api", `{"base_url":""}`, "", true},
+		// Unparseable config JSON — must error.
+		{"{base_url}", `not-json`, "", true},
 	}
 	for _, tc := range cases {
-		got := substituteBaseURL(tc.tmpl, models.ConfigJSON(tc.cfg))
+		got, err := substituteBaseURL(tc.tmpl, models.ConfigJSON(tc.cfg))
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("substituteBaseURL(%q, %q) expected error, got %q", tc.tmpl, tc.cfg, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("substituteBaseURL(%q, %q) unexpected error: %v", tc.tmpl, tc.cfg, err)
+			continue
+		}
 		if got != tc.want {
 			t.Errorf("substituteBaseURL(%q, %q) = %q, want %q", tc.tmpl, tc.cfg, got, tc.want)
 		}
+	}
+}
+
+// TestEnrichMonitorCheck_MissingBaseURL verifies that enrichment skips check
+// creation (rather than storing an unresolved {base_url} template) when the
+// app config has no base_url set.
+func TestEnrichMonitorCheck_MissingBaseURL(t *testing.T) {
+	appID := "app-no-baseurl"
+
+	apps := &enrichMockAppRepo{apps: map[string]*models.App{
+		appID: {
+			ID:        appID,
+			Name:      "Maubot",
+			ProfileID: "maubot",
+			Config:    models.ConfigJSON(`{}`), // base_url intentionally absent
+		},
+	}}
+	checks := &enrichMockCheckRepo{existsByTarget: map[string]bool{}}
+
+	profiles := &mockProfileLoader{templates: map[string]*apptemplate.AppTemplate{
+		"maubot": {
+			Meta:    apptemplate.AppTemplateMeta{Name: "Maubot"},
+			Monitor: apptemplate.Monitor{CheckType: "url", CheckURL: "{base_url}/_matrix/maubot/v1/", CheckInterval: "5m", HealthyStatus: 200},
+		},
+	}}
+
+	store := buildEnrichStore(apps, checks, nil, nil, nil)
+	if err := EnrichAppOnLink(context.Background(), store, profiles, appID, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// No check should be created — storing {base_url}/... would break the runner.
+	if len(checks.created) != 0 {
+		t.Errorf("expected 0 checks created when base_url missing, got %d (target=%q)",
+			len(checks.created), checks.created[0].Target)
 	}
 }

--- a/internal/models/config_json.go
+++ b/internal/models/config_json.go
@@ -2,8 +2,10 @@ package models
 
 import (
 	"database/sql/driver"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // ConfigJSON is stored as a TEXT JSON string in SQLite but serialises as a
@@ -46,6 +48,25 @@ func (c *ConfigJSON) Scan(src any) error {
 		return fmt.Errorf("ConfigJSON: cannot scan type %T", src)
 	}
 	return nil
+}
+
+// ResolveTemplateVars replaces {base_url} in tmplURL with the base_url value
+// from the config JSON. Returns an error when the placeholder is present but
+// the corresponding key is missing or empty — this prevents an unresolved
+// template from being persisted as a check target or executed by the runner.
+func (c ConfigJSON) ResolveTemplateVars(tmplURL string) (string, error) {
+	if !strings.Contains(tmplURL, "{base_url}") {
+		return tmplURL, nil
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(c, &m); err != nil {
+		return "", fmt.Errorf("parse app config: %w", err)
+	}
+	v, ok := m["base_url"].(string)
+	if !ok || v == "" {
+		return "", errors.New("app config missing base_url — configure base_url before creating checks from this profile")
+	}
+	return strings.ReplaceAll(tmplURL, "{base_url}", v), nil
 }
 
 // Value implements driver.Valuer — stores the JSON as TEXT in SQLite.

--- a/internal/monitor/scheduler.go
+++ b/internal/monitor/scheduler.go
@@ -14,6 +14,10 @@ import (
 // configured interval. Every check runs in its own goroutine, so a slow or
 // blocked check cannot delay others. The check list is refreshed every 5
 // minutes to pick up newly added or disabled checks without a restart.
+//
+// Callers can also trigger an immediate reload via TriggerSync — used by the
+// API handler so a disabled check's goroutine is cancelled within milliseconds
+// rather than waiting up to 5 minutes for the periodic poll.
 type Scheduler struct {
 	store *repo.Store
 	ping  *PingChecker
@@ -23,6 +27,10 @@ type Scheduler struct {
 
 	mu     sync.Mutex
 	active map[string]context.CancelFunc // check ID → cancel for that goroutine
+
+	// syncCh is a buffered channel used by TriggerSync to request an immediate
+	// syncChecks without blocking the caller.
+	syncCh chan struct{}
 }
 
 // NewScheduler returns a Scheduler wired to store.
@@ -34,6 +42,17 @@ func NewScheduler(store *repo.Store) *Scheduler {
 		ssl:    NewSSLChecker(store),
 		dns:    NewDNSChecker(store),
 		active: make(map[string]context.CancelFunc),
+		syncCh: make(chan struct{}, 1),
+	}
+}
+
+// TriggerSync requests an immediate syncChecks. It is non-blocking: if a sync
+// is already queued the call is a no-op (the buffered channel absorbs the
+// signal without blocking). Safe to call from any goroutine.
+func (s *Scheduler) TriggerSync() {
+	select {
+	case s.syncCh <- struct{}{}:
+	default:
 	}
 }
 
@@ -56,6 +75,10 @@ func (s *Scheduler) Start(ctx context.Context) {
 			log.Printf("monitor scheduler: context cancelled — shutting down")
 			s.cancelAll()
 			return
+		case <-s.syncCh:
+			if err := s.syncChecks(ctx); err != nil {
+				log.Printf("monitor scheduler: triggered sync: %v", err)
+			}
 		case <-reloadTicker.C:
 			if err := s.syncChecks(ctx); err != nil {
 				log.Printf("monitor scheduler: reload: %v", err)

--- a/internal/monitor/scheduler_test.go
+++ b/internal/monitor/scheduler_test.go
@@ -88,6 +88,110 @@ func TestScheduler_StartsCheckGoroutine(t *testing.T) {
 	}
 }
 
+// TestScheduler_TriggerSync_CancelsGoroutine verifies that calling TriggerSync
+// after a check is disabled causes its goroutine to be cancelled without
+// waiting for the 5-minute periodic reload. This is the core of the fix for
+// "pause silently no-ops on non-URL checks".
+func TestScheduler_TriggerSync_CancelsGoroutine(t *testing.T) {
+	check := models.MonitorCheck{
+		ID:           "chk-trigger",
+		Name:         "Ping Target",
+		Type:         "ping",
+		Target:       "127.0.0.1",
+		IntervalSecs: 300,
+		Enabled:      true, // starts enabled
+	}
+
+	// mr is a mutable repo — the test swaps the check list between syncs to
+	// simulate the API writing enabled=false to the database.
+	mr := &mockListCheckRepo{checks: []models.MonitorCheck{check}}
+
+	store := &repo.Store{
+		Checks: mr,
+		Events: &mockEventRepo{},
+	}
+
+	sched := NewScheduler(store)
+	sched.ping.pinger = alwaysUp
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start the scheduler in the background.
+	go sched.Start(ctx)
+
+	// Wait for the initial sync to register the goroutine.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		sched.mu.Lock()
+		n := len(sched.active)
+		sched.mu.Unlock()
+		if n == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	sched.mu.Lock()
+	if len(sched.active) != 1 {
+		sched.mu.Unlock()
+		t.Fatalf("expected 1 active goroutine before disable, got %d", len(sched.active))
+	}
+	sched.mu.Unlock()
+
+	// Simulate the API disabling the check: update the list the repo returns,
+	// then call TriggerSync — the goroutine should be cancelled promptly.
+	disabled := check
+	disabled.Enabled = false
+	mr.checks = []models.MonitorCheck{disabled}
+	sched.TriggerSync()
+
+	// The goroutine should be gone well within 1 second — not the 5-minute wait.
+	deadline = time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		sched.mu.Lock()
+		n := len(sched.active)
+		sched.mu.Unlock()
+		if n == 0 {
+			return // pass
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	sched.mu.Lock()
+	remaining := len(sched.active)
+	sched.mu.Unlock()
+	if remaining != 0 {
+		t.Errorf("expected 0 active goroutines after TriggerSync disable, got %d", remaining)
+	}
+}
+
+// TestScheduler_TriggerSync_NonBlocking verifies that TriggerSync never blocks
+// even when called multiple times rapidly without the scheduler draining the channel.
+func TestScheduler_TriggerSync_NonBlocking(t *testing.T) {
+	store := &repo.Store{
+		Checks: &mockListCheckRepo{checks: []models.MonitorCheck{}},
+		Events: &mockEventRepo{},
+	}
+	sched := NewScheduler(store)
+
+	// Call many times in a tight loop — must not block or panic.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			sched.TriggerSync()
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// pass
+	case <-time.After(1 * time.Second):
+		t.Fatal("TriggerSync blocked")
+	}
+}
+
 // TestScheduler_DisabledCheckNotStarted verifies that a disabled check does not
 // get a goroutine in the active map.
 func TestScheduler_DisabledCheckNotStarted(t *testing.T) {

--- a/internal/monitor/url.go
+++ b/internal/monitor/url.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/digitalcheffe/nora/internal/models"
@@ -72,6 +73,12 @@ func (u *URLChecker) Run(ctx context.Context, check *models.MonitorCheck) error 
 	expected := check.ExpectedStatus
 	if expected == 0 {
 		expected = 200
+	}
+
+	// Guard against unresolved template variables or missing scheme — Go's HTTP
+	// client URL-encodes curly braces and fails with "unsupported protocol scheme".
+	if !strings.HasPrefix(check.Target, "http://") && !strings.HasPrefix(check.Target, "https://") {
+		return u.recordError(ctx, check, "invalid check target: URL missing scheme — check configuration")
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, check.Target, nil)

--- a/internal/monitor/url_test.go
+++ b/internal/monitor/url_test.go
@@ -258,6 +258,38 @@ func TestURLChecker_EventWithoutApp(t *testing.T) {
 	}
 }
 
+// TestURLChecker_MissingScheme verifies that a target without an http/https
+// scheme is recorded as "down" with a descriptive error — the unresolved
+// {base_url} template scenario that produced "%7Bbase_url%7D/..." errors.
+func TestURLChecker_MissingScheme(t *testing.T) {
+	checks := &mockCheckRepo{}
+	events := &mockEventRepo{}
+	checker := newURLChecker(checks, events)
+
+	// Simulate an unresolved template — this is what gets stored when base_url
+	// is missing from the app config at check-creation time.
+	check := makeURLCheck("{base_url}/_matrix/maubot/v1/", "up", "app-1", 200)
+	err := checker.Run(context.Background(), check)
+	// Run may return a non-nil error; either way the check must be recorded as down.
+	_ = err
+
+	if len(checks.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 UpdateStatus call, got %d", len(checks.updateStatusCalls))
+	}
+	if checks.updateStatusCalls[0].status != "down" {
+		t.Errorf("expected status=down for missing-scheme target, got %s", checks.updateStatusCalls[0].status)
+	}
+
+	// Confirm the stored error message is descriptive, not a raw Go URL parse error.
+	var result urlResult
+	if jsonErr := json.Unmarshal([]byte(checks.updateStatusCalls[0].details), &result); jsonErr != nil {
+		t.Fatalf("last_result not valid JSON: %v", jsonErr)
+	}
+	if result.Error == nil || *result.Error == "" {
+		t.Error("expected non-empty error in last_result")
+	}
+}
+
 // TestURLChecker_NoEventOnFirstRun verifies no event on first execution (LastStatus="").
 func TestURLChecker_NoEventOnFirstRun(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary

- **`{base_url}` template stored unresolved in DB** — `ConfigJSON.ResolveTemplateVars` now returns an error when `base_url` is missing; `enrichMonitorCheck` skips check creation rather than persisting the raw placeholder. URL runner also guards against missing scheme before calling the HTTP client.
- **App config update doesn't re-sync profile check target** — new `syncProfileMonitorCheck` re-resolves and updates the stored check target when `PUT /apps/{id}` changes `base_url`.
- **Pausing a non-URL check silently no-ops for up to 5 minutes** — `Scheduler` gains `TriggerSync()` backed by a buffered channel; `ChecksHandler` calls it after any `enabled` toggle so ping/ssl/dns checks pause immediately, not at the next 5-minute poll.

## Test plan

- [ ] Pause a ping check and confirm it stops executing within seconds (not minutes)
- [ ] Pause a URL check — same expectation
- [ ] Resume a paused check and confirm it resumes
- [ ] Create a check from an app profile that has no `base_url` configured — expect a clear log/error, no check created with `{base_url}` in the target
- [ ] Update an app's `base_url` via PUT /apps/{id} and confirm the associated profile check target updates to the new URL
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)