### PR TITLE
fix: migration 030 panic — drop temp tables before create

### DIFF
--- a/migrations/030_traefik_source_type.sql
+++ b/migrations/030_traefik_source_type.sql
@@ -5,6 +5,7 @@
 
 -- ── resource_readings ─────────────────────────────────────────────────────────
 
+DROP TABLE IF EXISTS resource_readings_new;
 CREATE TABLE resource_readings_new (
     id          TEXT      PRIMARY KEY,
     source_id   TEXT      NOT NULL,
@@ -31,6 +32,7 @@ CREATE INDEX IF NOT EXISTS idx_resource_readings_app         ON resource_reading
 
 -- ── resource_rollups ──────────────────────────────────────────────────────────
 
+DROP TABLE IF EXISTS resource_rollups_new;
 CREATE TABLE resource_rollups_new (
     source_id    TEXT      NOT NULL,
     source_type  TEXT      NOT NULL CHECK (source_type IN (


### PR DESCRIPTION
## Summary

- Hotfix for panic on startup when migration 030 was previously interrupted mid-run, leaving `resource_readings_new` and `resource_rollups_new` behind
- Adds `DROP TABLE IF EXISTS` before each `CREATE TABLE` in migration 030 to make it idempotent

## Root Cause

Migration 030 creates temp tables, copies data, drops the originals, then renames. If the process was killed mid-migration the temp tables were left in place. On the next startup the migration runner tries to run 030 again and hits `table resource_readings_new already exists`.

## Test plan
- [ ] Deploy — server should start without panic
- [ ] Migration 030 applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)