### PR TITLE
fix: v1.0.0 UI bug fixes

### DIFF
--- a/frontend/src/pages/Apps.css
+++ b/frontend/src/pages/Apps.css
@@ -41,11 +41,12 @@
 .app-widget::before {
   content: '';
   position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 2px;
-  background: var(--green);
-  opacity: 0;
+  top: 0; left: 0; bottom: 0;
+  width: 3px;
+  background: var(--accent);
+  opacity: 0.18;
   transition: opacity 0.15s;
+  border-radius: 8px 0 0 8px;
 }
 
 .app-widget:hover {
@@ -54,7 +55,7 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
-.app-widget:hover::before { opacity: 1; }
+.app-widget:hover::before { opacity: 0.8; }
 .app-widget.warn::before  { background: var(--yellow); opacity: 1; }
 .app-widget.down::before  { background: var(--red);    opacity: 1; }
 
@@ -65,19 +66,26 @@
 }
 
 .app-icon {
-  width: 28px;
-  height: 28px;
-  border-radius: 6px;
-  background: var(--bg4);
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, var(--bg4) 0%, var(--bg3) 100%);
   border: 1px solid var(--border);
   display: flex;
   align-items: center;
   justify-content: center;
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 12px;
   font-weight: 600;
   color: var(--text2);
   flex-shrink: 0;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.04);
+}
+
+.app-widget .app-icon-img {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
 }
 
 .app-name {
@@ -104,6 +112,25 @@
 .app-status.down    { color: var(--red); }
 .app-status.unknown { color: var(--text3); }
 
+.app-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.app-status-dot.online { background: var(--green); box-shadow: 0 0 4px var(--green); }
+.app-status-dot.warn   { background: var(--yellow); }
+.app-status-dot.down   { background: var(--red); }
+
+.app-url {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .app-profile-badge {
   font-family: var(--mono);
   font-size: 9px;
@@ -116,6 +143,7 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   flex-shrink: 0;
+  align-self: flex-start;
 }
 
 .app-widget-stats {

--- a/frontend/src/pages/Apps.tsx
+++ b/frontend/src/pages/Apps.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { Topbar } from '../components/Topbar'
-import { apps as appsApi, appTemplates as templatesApi } from '../api/client'
+import { apps as appsApi, appTemplates as templatesApi, dashboard as dashboardApi } from '../api/client'
 import type { App, AppTemplate } from '../api/types'
 import { AppSettingsModal } from './AppDetail'
 import '../styles/Modal.css'
@@ -283,6 +283,7 @@ function AddAppModal({ onClose, onCreated }: AddAppModalProps) {
 export function Apps() {
   const navigate = useNavigate()
   const [appList, setAppList] = useState<App[]>([])
+  const [statusMap, setStatusMap] = useState<Record<string, 'online' | 'warn' | 'down'>>({})
   const [loading, setLoading] = useState(true)
   const [showAdd, setShowAdd] = useState(false)
 
@@ -294,6 +295,13 @@ export function Apps() {
       .then(res => setAppList(res.data))
       .catch(console.error)
       .finally(() => setLoading(false))
+    dashboardApi.summary()
+      .then(res => {
+        const map: Record<string, 'online' | 'warn' | 'down'> = {}
+        for (const a of res.apps) map[a.id] = a.status
+        setStatusMap(map)
+      })
+      .catch(() => { /* status is best-effort */ })
   }, [tick])
 
   return (
@@ -318,16 +326,23 @@ export function Apps() {
               </button>
             </div>
           ) : (
-            appList.map(app => (
+            appList.map(app => {
+              const status = statusMap[app.id]
+              const baseUrl = app.config?.base_url as string | undefined
+              return (
               <div
                 key={app.id}
-                className="app-widget"
+                className={`app-widget${status === 'warn' ? ' warn' : status === 'down' ? ' down' : ''}`}
                 onClick={() => navigate(`/apps/${app.id}`)}
               >
                 <div className="app-widget-header">
                   <div className="app-icon"><AppIcon name={app.name} profileId={app.profile_id} /></div>
                   <div className="app-name">{app.name}</div>
+                  {status && <span className={`app-status-dot ${status}`} />}
                 </div>
+                {baseUrl && (
+                  <div className="app-url">{baseUrl}</div>
+                )}
                 {app.profile_id && (
                   <div className="app-profile-badge">{app.profile_id}</div>
                 )}
@@ -348,7 +363,8 @@ export function Apps() {
                   </svg>
                 </button>
               </div>
-            ))
+              )
+            })
           )}
         </div>
       </div>

--- a/frontend/src/pages/Infrastructure.css
+++ b/frontend/src/pages/Infrastructure.css
@@ -315,6 +315,7 @@
   justify-content: space-between;
   gap: 8px;
   margin-top: auto;
+  padding-right: 32px;
 }
 
 .infra-last-updated {

--- a/frontend/src/pages/Infrastructure.tsx
+++ b/frontend/src/pages/Infrastructure.tsx
@@ -240,7 +240,7 @@ export function Infrastructure() {
           </div>
           <div className="infra-card-actions">
             <button
-              className="infra-card-btn"
+              className="infra-card-btn accent"
               onClick={() => void handleScan(c.id)}
               disabled={isDeleting || isScanning || scanningId !== null}
             >
@@ -294,7 +294,7 @@ export function Infrastructure() {
           </div>
           <div className="infra-card-actions">
             <button
-              className="infra-card-btn"
+              className="infra-card-btn accent"
               onClick={() => void handleScan(c.id)}
               disabled={isDeleting || isScanning || scanningId !== null}
             >
@@ -354,7 +354,7 @@ export function Infrastructure() {
           </div>
           <div className="infra-card-actions">
             <button
-              className="infra-card-btn"
+              className="infra-card-btn accent"
               onClick={() => void handleScan(c.id)}
               disabled={isDeleting || isScanning || scanningId !== null}
             >

--- a/internal/infra/proxmox.go
+++ b/internal/infra/proxmox.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -314,6 +315,16 @@ func (p *ProxmoxPoller) Poll(ctx context.Context, store *repo.Store) error {
 	polledAt := now.Format(time.RFC3339Nano)
 	if err := store.InfraComponents.UpdateStatus(ctx, p.componentID, status, polledAt); err != nil {
 		log.Printf("proxmox poller %s: update status: %v", p.componentID, err)
+	}
+
+	// Auto-populate the parent node's IP from the base_url credential so it
+	// appears on the detail page even if the user left the IP field blank.
+	if u, err := url.Parse(p.creds.BaseURL); err == nil {
+		if host := u.Hostname(); host != "" {
+			if ipErr := store.InfraComponents.UpdateIP(ctx, p.componentID, host); ipErr != nil {
+				log.Printf("proxmox poller %s: update parent ip: %v", p.componentID, ipErr)
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Fix infra card gear icon overlapping Discover Now button (added `padding-right` to card footer)
- Add missing `accent` class to Discover Now button on Traefik, Docker Engine, and Portainer cards
- Auto-populate Proxmox node IP from `base_url` credential on each poll cycle
- Fix app profile badge stretching full card width (`align-self: flex-start`)
- App card polish: left accent stripe, larger icon (36px + gradient bg), URL line from config, status dot from dashboard summary

## Test plan
- [ ] Verify gear icon is no longer overlapped by Discover Now button on infra cards
- [ ] Verify Traefik, Docker, and Portainer Discover Now buttons match accent styling of other cards
- [ ] Add/edit a Proxmox component — IP should auto-populate after next poll
- [ ] Confirm app profile badge is text-width only, not full card width
- [ ] Confirm app cards show left stripe, larger icon, URL line (if configured), and status dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)