### PR TITLE
feat(digest-registry): AP-01 — Digest Registry

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/digitalcheffe/nora/internal/jobs"
 	"github.com/digitalcheffe/nora/internal/models"
 	"github.com/digitalcheffe/nora/internal/monitor"
+	"github.com/digitalcheffe/nora/internal/profile"
 	"github.com/digitalcheffe/nora/internal/push"
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/digitalcheffe/nora/internal/rules"
@@ -94,6 +95,7 @@ func main() {
 	webPushSubscriptionRepo := repo.NewWebPushSubscriptionRepo(db)
 	snapshotRepo := repo.NewSnapshotRepo(db)
 	ruleRepo := repo.NewRuleRepo(db)
+	digestRegistryRepo := repo.NewDigestRegistryRepo(db)
 	store := repo.NewStore(
 		appRepo, eventRepo, checkRepo,
 		rollupRepo, resourceRepo, resourceRollupRepo,
@@ -104,6 +106,7 @@ func main() {
 		webPushSubscriptionRepo,
 		snapshotRepo,
 		ruleRepo,
+		digestRegistryRepo,
 	)
 
 	// Bootstrap admin account — only runs when the users table is empty and
@@ -150,6 +153,13 @@ func main() {
 		log.Fatalf("app template registry init failed: %v", err)
 	}
 	log.Printf("  templates: %d loaded from %s", len(registry.List()), cfg.TemplatesPath)
+
+	// Digest registry reconciliation — runs synchronously at startup.
+	// Inserts/updates entries for all profile digest categories and deactivates orphans.
+	reconciler := profile.NewRegistryReconciler(digestRegistryRepo, registry)
+	if err := reconciler.Reconcile(context.Background()); err != nil {
+		log.Printf("digest registry reconcile: %v", err)
+	}
 
 	// Propagate any check_url changes from updated built-in profiles to existing
 	// checks. Runs in the background so startup is not blocked; the monitor
@@ -437,6 +447,7 @@ func main() {
 		pushHandler.Routes(r)
 		api.NewRulesHandler(store, rulesEngine).Routes(r)
 		api.NewJobsHandler(jobRegistry).Routes(r)
+		api.NewDigestRegistryHandler(store).Routes(r)
 		api.NewPortainerHandler(store).Routes(r)
 		authHandler.Routes(r)
 	})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -16,6 +16,7 @@ import type {
   UpdateUserInput,
   CustomProfile,
   DashboardSummaryResponse,
+  DigestRegistryListResponse,
   DigestSchedule,
   DiscoverResult,
   DiscoveredContainer,
@@ -353,6 +354,9 @@ export const appTemplates = {
 
   reload: () =>
     request<{ loaded: number }>('POST', '/app-templates/reload'),
+
+  getRaw: (id: string) =>
+    request<{ yaml: string }>('GET', `/app-templates/${id}/raw`),
 }
 
 // ── Infrastructure Integrations ───────────────────────────────────────────────
@@ -638,4 +642,17 @@ export const portainer = {
 
   endpointContainers: (componentId: string, endpointId: number) =>
     request<ListResponse<PortainerContainerResource>>('GET', `/integrations/portainer/${componentId}/endpoints/${endpointId}/containers`),
+}
+
+// ── Digest Registry ───────────────────────────────────────────────────────────
+
+export const digestRegistry = {
+  list: () =>
+    request<DigestRegistryListResponse>('GET', '/digest-registry'),
+
+  setActive: (id: string, active: boolean) =>
+    request<void>('PUT', `/digest-registry/${id}/active`, { active }),
+
+  delete: (id: string) =>
+    request<void>('DELETE', `/digest-registry/${id}`),
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -831,3 +831,23 @@ export interface PortainerContainerResource {
   image_update_available: boolean
   stack?: string
 }
+
+
+export interface DigestRegistryEntry {
+  id: string
+  profile_id: string
+  source: 'webhook' | 'api'
+  entry_type: 'category' | 'widget'
+  name: string
+  label: string
+  config: Record<string, string>
+  profile_source: string
+  active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface DigestRegistryListResponse {
+  data: DigestRegistryEntry[]
+  total: number
+}

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -589,6 +589,206 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* ── Digest Registry tab ──────────────────────────────────────────────────── */
+
+.dr-overview {
+  font-family: var(--sans);
+  font-size: 13px;
+  color: var(--text2);
+  line-height: 1.6;
+  margin: 0 0 16px;
+}
+
+.settings-empty {
+  font-family: var(--sans);
+  font-size: 13px;
+  color: var(--text3);
+  padding: 8px 0;
+}
+
+.dr-table-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.dr-row--inactive td {
+  opacity: 0.45;
+}
+
+.dr-profile-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.dr-table-scroll .settings-metrics-table td {
+  white-space: nowrap;
+}
+
+.dr-label-editable {
+  cursor: pointer;
+  border-bottom: 1px dashed var(--border2);
+  color: var(--text1);
+  white-space: nowrap;
+}
+
+.dr-label-editable:hover {
+  border-bottom-color: var(--text2);
+  color: var(--text);
+}
+
+.settings-btn.danger:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* ── Digest Registry split layout (desktop) ──────────────────────────────── */
+
+.dr-split {
+  display: grid;
+  grid-template-columns: 1fr;
+  transition: grid-template-columns 0.2s ease;
+}
+
+.dr-split--open {
+  grid-template-columns: 1fr 380px;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.dr-split-list {
+  min-width: 0;
+}
+
+.dr-split--open .dr-split-list {
+  border-right: 1px solid var(--border);
+}
+
+.dr-split-detail {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--bg2);
+}
+
+.dr-split-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.dr-split-detail-title {
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dr-split-detail-scroll {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.dr-row--selected td {
+  background: var(--accent-dim);
+}
+
+.dr-status-dot {
+  font-size: 11px;
+  font-family: var(--sans);
+  white-space: nowrap;
+}
+
+.dr-status-dot--on  { color: var(--green, #4ade80); }
+.dr-status-dot--off { color: var(--text3); }
+
+/* ── Digest Registry entry panel ──────────────────────────────────────────── */
+
+.dr-panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+}
+
+.dr-panel-profile {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.dr-panel-profile-name {
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  flex: 1;
+}
+
+.dr-panel-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dr-panel-label {
+  font-family: var(--sans);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text2);
+}
+
+.dr-panel-code {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text);
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 5px 10px;
+  align-self: flex-start;
+}
+
+.dr-panel-yaml {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text2);
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px 14px;
+  overflow-x: auto;
+  white-space: pre;
+  margin: 0;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.dr-panel-danger-zone {
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.dr-panel-confirm {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 /* ── Web Push section ─────────────────────────────────────────────────────── */
 
 .push-status-row {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useRef } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Topbar } from '../components/Topbar'
 import { InfraIntegrations } from './Integrations'
-import { appTemplates, digestSettings, digestReport, smtpSettings, metrics, users, push, notifyRules, jobsApi, passwordPolicy as passwordPolicyApi, mfaSettings, totp as totpApi } from '../api/client'
+import { appTemplates, digestSettings, digestReport, smtpSettings, metrics, users, push, notifyRules, jobsApi, passwordPolicy as passwordPolicyApi, mfaSettings, totp as totpApi, digestRegistry } from '../api/client'
+import { SlidePanel } from '../components/SlidePanel'
 import { useAuth } from '../context/AuthContext'
 import { usePushSubscription } from '../hooks/usePushSubscription'
 import type {
@@ -10,6 +11,7 @@ import type {
   CreateRuleInput,
   CustomProfile,
   DigestFrequency,
+  DigestRegistryEntry,
   DigestSchedule,
   InstanceMetrics,
   Job,
@@ -69,7 +71,7 @@ function AppTemplateIcon({ id, icon, name }: { id: string; icon?: string; name: 
   )
 }
 
-type Tab = 'apps' | 'notifications' | 'notify_rules' | 'metrics' | 'users' | 'jobs'
+type Tab = 'apps' | 'notifications' | 'notify_rules' | 'metrics' | 'users' | 'jobs' | 'digest_registry'
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'apps', label: 'Apps' },
@@ -78,6 +80,7 @@ const TABS: { id: Tab; label: string }[] = [
   { id: 'metrics', label: 'Instance Metrics' },
   { id: 'users', label: 'Users' },
   { id: 'jobs', label: 'Jobs' },
+  { id: 'digest_registry', label: 'Digest Registry' },
 ]
 
 // ── Delete confirmation modal ─────────────────────────────────────────────────
@@ -1911,6 +1914,279 @@ function JobsTab() {
   )
 }
 
+// ── Digest Registry tab ───────────────────────────────────────────────────────
+
+// ── useIsMobile ───────────────────────────────────────────────────────────────
+
+function useIsMobile(breakpoint = 768) {
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < breakpoint)
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${breakpoint - 1}px)`)
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [breakpoint])
+  return isMobile
+}
+
+// ── DigestRegistryEntryBody ───────────────────────────────────────────────────
+
+function DigestRegistryEntryBody({
+  entry,
+  onClose,
+  onUpdate,
+  onDelete,
+}: {
+  entry: DigestRegistryEntry
+  onClose: () => void
+  onUpdate: (updated: DigestRegistryEntry) => void
+  onDelete: (id: string) => void
+}) {
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  useEffect(() => {
+    setConfirmDelete(false)
+  }, [entry.id])
+
+  const handleActiveToggle = async () => {
+    try {
+      await digestRegistry.setActive(entry.id, !entry.active)
+      onUpdate({ ...entry, active: !entry.active })
+    } catch { /* leave unchanged */ }
+  }
+
+  const handleDelete = async () => {
+    setDeleting(true)
+    try {
+      await digestRegistry.delete(entry.id)
+      onDelete(entry.id)
+      onClose()
+    } catch {
+      setDeleting(false)
+      setConfirmDelete(false)
+    }
+  }
+
+  return (
+    <div className="dr-panel-body">
+
+      {/* App icon + profile */}
+      <div className="dr-panel-profile">
+        <AppTemplateIcon id={entry.profile_id} name={entry.profile_id} />
+        <span className="dr-panel-profile-name">{entry.profile_id}</span>
+        <span className="app-pill-type">{entry.entry_type}</span>
+        <span className="app-pill-type">{entry.source}</span>
+      </div>
+
+      {/* Stable name (read-only) */}
+      <div className="dr-panel-field">
+        <label className="dr-panel-label">Name</label>
+        <code className="dr-panel-code">{entry.name}</code>
+      </div>
+
+      {/* Active toggle */}
+      <div className="dr-panel-field">
+        <label className="dr-panel-label">Status</label>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <button
+            className={`settings-btn ${entry.active ? 'primary' : 'secondary'}`}
+            onClick={handleActiveToggle}
+          >
+            {entry.active ? 'Active' : 'Inactive'}
+          </button>
+          {!entry.active && (
+            <span className="settings-hint">Not included in digest generation.</span>
+          )}
+        </div>
+      </div>
+
+      {/* Profile source path */}
+      <div className="dr-panel-field">
+        <label className="dr-panel-label">App profile</label>
+        {entry.profile_source
+          ? <code className="dr-panel-code">{entry.profile_source}</code>
+          : <span className="settings-hint">Source path not recorded.</span>
+        }
+      </div>
+
+      {/* Delete */}
+      <div className="dr-panel-danger-zone">
+        {!confirmDelete ? (
+          <button
+            className="settings-btn danger"
+            disabled={entry.active}
+            title={entry.active ? 'Deactivate before deleting' : undefined}
+            onClick={() => setConfirmDelete(true)}
+          >
+            Delete entry
+          </button>
+        ) : (
+          <div className="dr-panel-confirm">
+            <p className="modal-delete-warning">
+              Permanently remove <strong>{entry.profile_id}/{entry.name}</strong>? This cannot be undone.
+            </p>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button className="settings-btn secondary" onClick={() => setConfirmDelete(false)}>Cancel</button>
+              <button className="settings-btn danger" onClick={handleDelete} disabled={deleting}>
+                {deleting ? 'Deleting…' : 'Delete permanently'}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function DigestRegistryTab() {
+  const [entries, setEntries] = useState<DigestRegistryEntry[]>([])
+  const [loadError, setLoadError] = useState('')
+  const [selected, setSelected] = useState<DigestRegistryEntry | null>(null)
+  const isMobile = useIsMobile()
+
+  useEffect(() => {
+    digestRegistry.list()
+      .then(r => {
+        const data = r.data ?? []
+        setEntries(data)
+        if (!isMobile && data.length > 0) setSelected(data[0])
+      })
+      .catch(() => setLoadError('Failed to load digest registry'))
+  }, [isMobile])
+
+  const handleUpdate = (updated: DigestRegistryEntry) => {
+    setEntries(prev => prev.map(e => e.id === updated.id ? updated : e))
+    setSelected(updated)
+  }
+
+  const handleDelete = (id: string) => {
+    setEntries(prev => prev.filter(e => e.id !== id))
+    setSelected(null)
+  }
+
+  if (loadError) {
+    return <div className="tab-content"><p style={{ color: 'var(--red)' }}>{loadError}</p></div>
+  }
+
+  const table = (
+    <div className="dr-table-scroll">
+      <table className="settings-metrics-table">
+        <thead>
+          <tr>
+            <th>Profile</th>
+            <th>Label</th>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map(entry => (
+            <tr
+              key={entry.id}
+              className={[
+                entry.active ? '' : 'dr-row--inactive',
+                selected?.id === entry.id ? 'dr-row--selected' : '',
+              ].join(' ').trim()}
+              style={{ cursor: 'pointer' }}
+              onClick={() => setSelected(selected?.id === entry.id ? null : entry)}
+            >
+              <td>
+                <div className="dr-profile-cell">
+                  <AppTemplateIcon id={entry.profile_id} name={entry.profile_id} />
+                  <span>{entry.profile_id}</span>
+                </div>
+              </td>
+              <td>{entry.label}</td>
+              <td><span className="app-pill-type">{entry.name}</span></td>
+              <td><span className="app-pill-type">{entry.entry_type}</span></td>
+              <td>
+                <span className={`dr-status-dot ${entry.active ? 'dr-status-dot--on' : 'dr-status-dot--off'}`}>
+                  {entry.active ? '● Active' : '● Inactive'}
+                </span>
+              </td>
+              <td style={{ textAlign: 'right' }}>
+                <button
+                  className="check-settings-btn"
+                  title="Settings"
+                  onClick={e => { e.stopPropagation(); setSelected(selected?.id === entry.id ? null : entry) }}
+                >
+                  ⚙
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+
+  return (
+    <div className="tab-content">
+      <section className="settings-section">
+        <div className="section-header">
+          <span className="section-title">Digest Registry</span>
+        </div>
+        <p className="dr-overview">
+          A persistent record of every digest entry declared across all app profiles. Entries are
+          automatically reconciled at startup — new categories are inserted, renamed labels are
+          updated, and categories removed from a profile are deactivated rather than deleted.
+          Click the settings icon on any row to edit its label, toggle its active state, or view
+          its full profile definition.
+        </p>
+
+        {entries.length === 0 ? (
+          <p className="settings-empty">
+            No digest entries registered. Add apps with profiles to populate the registry.
+          </p>
+        ) : isMobile ? (
+          <>
+            {table}
+            {selected && (
+              <SlidePanel
+                open
+                onClose={() => setSelected(null)}
+                title={selected.label}
+                subtitle={`${selected.profile_id} / ${selected.name}`}
+                width={520}
+              >
+                <DigestRegistryEntryBody
+                  entry={selected}
+                  onClose={() => setSelected(null)}
+                  onUpdate={handleUpdate}
+                  onDelete={handleDelete}
+                />
+              </SlidePanel>
+            )}
+          </>
+        ) : (
+          <div className={`dr-split${selected ? ' dr-split--open' : ''}`}>
+            <div className="dr-split-list">{table}</div>
+            {selected && (
+              <div className="dr-split-detail">
+                <div className="dr-split-detail-header">
+                  <span className="dr-split-detail-title">{selected.label}</span>
+                  <button className="modal-close" onClick={() => setSelected(null)}>✕</button>
+                </div>
+                <div className="dr-split-detail-scroll">
+                  <DigestRegistryEntryBody
+                    entry={selected}
+                    onClose={() => setSelected(null)}
+                    onUpdate={handleUpdate}
+                    onDelete={handleDelete}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 
 export function Settings() {
@@ -1945,6 +2221,7 @@ export function Settings() {
         {activeTab === 'metrics' && <MetricsTab />}
         {activeTab === 'users' && <UsersTab />}
         {activeTab === 'jobs' && <JobsTab />}
+        {activeTab === 'digest_registry' && <DigestRegistryTab />}
       </div>
     </>
   )

--- a/internal/api/apptemplates.go
+++ b/internal/api/apptemplates.go
@@ -37,6 +37,7 @@ func (h *AppTemplatesHandler) Routes(r chi.Router) {
 	r.Get("/app-templates/custom", h.ListCustom)
 	r.Delete("/app-templates/custom/{id}", h.DeleteCustom)
 	r.Get("/app-templates/{id}", h.Get)
+	r.Get("/app-templates/{id}/raw", h.GetRaw)
 }
 
 // appTemplateMeta is the list-response shape — meta fields only, no internals.
@@ -114,6 +115,25 @@ func (h *AppTemplatesHandler) Get(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, http.StatusOK, detail)
+}
+
+// GetRaw handles GET /app-templates/{id}/raw — returns the full template marshaled as YAML.
+func (h *AppTemplatesHandler) GetRaw(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	t, err := h.registry.Get(id)
+	if err != nil || t == nil {
+		writeError(w, http.StatusNotFound, "app template not found")
+		return
+	}
+
+	raw, err := yaml.Marshal(t)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to marshal template")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"yaml": string(raw)})
 }
 
 // Reload handles POST /app-templates/reload — re-reads all templates from disk.

--- a/internal/api/digest_registry.go
+++ b/internal/api/digest_registry.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/digitalcheffe/nora/internal/auth"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/go-chi/chi/v5"
+)
+
+// DigestRegistryHandler handles CRUD for the digest registry.
+type DigestRegistryHandler struct {
+	store *repo.Store
+}
+
+// NewDigestRegistryHandler creates a DigestRegistryHandler.
+func NewDigestRegistryHandler(store *repo.Store) *DigestRegistryHandler {
+	return &DigestRegistryHandler{store: store}
+}
+
+// Routes registers the digest registry endpoints.
+func (h *DigestRegistryHandler) Routes(r chi.Router) {
+	r.Get("/digest-registry", h.List)
+	r.Put("/digest-registry/{id}/active", h.SetActive)
+	r.Delete("/digest-registry/{id}", h.Delete)
+}
+
+// List returns all digest registry entries (active and inactive).
+// GET /api/v1/digest-registry
+func (h *DigestRegistryHandler) List(w http.ResponseWriter, r *http.Request) {
+	if auth.Role(r.Context()) != "admin" {
+		writeError(w, http.StatusForbidden, "admin role required")
+		return
+	}
+
+	entries, err := h.store.DigestRegistry.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if entries == nil {
+		entries = []models.DigestRegistryEntry{}
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"data":  entries,
+		"total": len(entries),
+	})
+}
+
+// SetActive sets the active flag for an entry.
+// PUT /api/v1/digest-registry/{id}/active
+func (h *DigestRegistryHandler) SetActive(w http.ResponseWriter, r *http.Request) {
+	if auth.Role(r.Context()) != "admin" {
+		writeError(w, http.StatusForbidden, "admin role required")
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	var req struct {
+		Active bool `json:"active"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if err := h.store.DigestRegistry.SetActiveByID(r.Context(), id, req.Active); err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "entry not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Delete removes an inactive entry.
+// DELETE /api/v1/digest-registry/{id}
+func (h *DigestRegistryHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	if auth.Role(r.Context()) != "admin" {
+		writeError(w, http.StatusForbidden, "admin role required")
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	if err := h.store.DigestRegistry.Delete(r.Context(), id); err != nil {
+		if errors.Is(err, repo.ErrConflict) {
+			writeError(w, http.StatusConflict, "entry is still active — deactivate before deleting")
+			return
+		}
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "entry not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/digest_test.go
+++ b/internal/api/digest_test.go
@@ -40,6 +40,7 @@ func newDigestRouter(t *testing.T) (http.Handler, *repo.Store) {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	digestJob := jobs.NewDigestJob(store, &config.Config{}, nil)
 	h := api.NewDigestHandler(store, digestJob)
@@ -65,6 +66,7 @@ func newDigestRouterWithSMTP(t *testing.T) (http.Handler, *repo.Store) {
 		repo.NewDockerEngineRepo(db),
 		repo.NewInfraRepo(db),
 		repo.NewSettingsRepo(db),
+		nil,
 		nil,
 		nil,
 		nil,

--- a/internal/api/docker_discovery_link_test.go
+++ b/internal/api/docker_discovery_link_test.go
@@ -44,6 +44,7 @@ func newDiscoveryLinkRouter(t *testing.T, profiles apptemplate.Loader) (http.Han
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	h := api.NewDockerDiscoveryHandler(store, profiles)
 	r := chi.NewRouter()

--- a/internal/api/infra_components_test.go
+++ b/internal/api/infra_components_test.go
@@ -28,7 +28,7 @@ func newInfraComponentRouter(t *testing.T) http.Handler {
 		repo.NewInfraRepo(db), repo.NewSettingsRepo(db), repo.NewMetricsRepo(db),
 		repo.NewUserRepo(db), tc,
 		repo.NewTraefikOverviewRepo(db), repo.NewTraefikServiceRepo(db),
-		repo.NewDiscoveredContainerRepo(db), repo.NewDiscoveredRouteRepo(db), nil, nil, nil,
+		repo.NewDiscoveredContainerRepo(db), repo.NewDiscoveredRouteRepo(db), nil, nil, nil, nil,
 	)
 	h := api.NewInfraComponentHandler(ic, rollups, checks, events, store)
 	r := chi.NewRouter()

--- a/internal/api/ingest_test.go
+++ b/internal/api/ingest_test.go
@@ -21,7 +21,7 @@ func newIngestRouter(t *testing.T) (http.Handler, *repo.Store) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 	profiler := &apptemplate.NoopLoader{}
 
@@ -44,7 +44,7 @@ func TestHandleIngest_HappyPath(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()
@@ -131,7 +131,7 @@ func TestHandleIngest_RateLimit(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s := repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	limiter := ingest.NewRateLimiter()
 
 	r := chi.NewRouter()

--- a/internal/api/rules_test.go
+++ b/internal/api/rules_test.go
@@ -38,6 +38,7 @@ func newRulesRouter(t *testing.T) http.Handler {
 		repo.NewWebPushSubscriptionRepo(db),
 		repo.NewSnapshotRepo(db),
 		repo.NewRuleRepo(db),
+		nil,
 	)
 	cfg := &config.Config{Secret: "test"}
 	engine := rules.NewEngine(store, nil, cfg)

--- a/internal/api/topology_test.go
+++ b/internal/api/topology_test.go
@@ -188,7 +188,7 @@ func TestGetTopology_FullChain(t *testing.T) {
 		repo.NewInfraRepo(db), repo.NewSettingsRepo(db), repo.NewMetricsRepo(db),
 		repo.NewUserRepo(db), tc,
 		repo.NewTraefikOverviewRepo(db), repo.NewTraefikServiceRepo(db),
-		repo.NewDiscoveredContainerRepo(db), repo.NewDiscoveredRouteRepo(db), nil, nil, nil,
+		repo.NewDiscoveredContainerRepo(db), repo.NewDiscoveredRouteRepo(db), nil, nil, nil, nil,
 	)
 	icHandler := api.NewInfraComponentHandler(ic, rollups, checks, repo.NewEventRepo(db), store)
 	r := chi.NewRouter()

--- a/internal/apptemplate/apptemplate.go
+++ b/internal/apptemplate/apptemplate.go
@@ -98,6 +98,10 @@ type AppTemplate struct {
 	Webhook Webhook         `yaml:"webhook"`
 	Monitor Monitor         `yaml:"monitor"`
 	Digest  Digest          `yaml:"digest"`
+
+	// SourcePath is the absolute path to the YAML file this template was loaded from.
+	// Set at load time; not serialized to YAML.
+	SourcePath string `yaml:"-" json:"-"`
 }
 
 // Registry loads all bundled YAML app templates from an embedded filesystem.
@@ -225,7 +229,8 @@ func loadDirIntoMap(dir string, m map[string]*AppTemplate) error {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
 			continue
 		}
-		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("read %s: %w", e.Name(), err)
 		}
@@ -233,6 +238,7 @@ func loadDirIntoMap(dir string, m map[string]*AppTemplate) error {
 		if err := yaml.Unmarshal(data, &t); err != nil {
 			return fmt.Errorf("parse %s: %w", e.Name(), err)
 		}
+		t.SourcePath = path
 		id := strings.TrimSuffix(e.Name(), ".yaml")
 		m[id] = &t
 	}

--- a/internal/docker/image_poller_test.go
+++ b/internal/docker/image_poller_test.go
@@ -151,7 +151,7 @@ func makePollerStore(infraComponents []models.InfrastructureComponent, container
 		nil, nil, nil, nil, nil, nil,
 		&mockInfraComponentRepo{components: infraComponents},
 		nil, nil, nil, nil, nil, nil, nil, nil,
-		dc, nil, nil, nil, nil,
+		dc, nil, nil, nil, nil, nil,
 	)
 	return store, dc
 }

--- a/internal/docker/resources_test.go
+++ b/internal/docker/resources_test.go
@@ -57,7 +57,7 @@ func (r *mockResourceReadingRepo) BackfillAppID(_ context.Context, _, _ string) 
 // --- helpers --------------------------------------------------------------
 
 func newTestResourcePoller(appRepo repo.AppRepo, eventRepo repo.EventRepo, resRepo repo.ResourceReadingRepo, cli resourcePollerAPI) *ResourcePoller {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, resRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	return newResourcePollerWithClient(store, "", cli)
 }
 

--- a/internal/docker/watcher_test.go
+++ b/internal/docker/watcher_test.go
@@ -97,7 +97,7 @@ func (r *mockEventRepo) Timeseries(_ context.Context, _, _ time.Time, _, _, _ st
 // --- helpers -------------------------------------------------------------
 
 func newTestWatcher(appRepo repo.AppRepo, eventRepo repo.EventRepo, dc dockerAPI) *Watcher {
-	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	store := repo.NewStore(appRepo, eventRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	return &Watcher{store: store, client: dc}
 }
 

--- a/internal/infra/portainer_enrichment_test.go
+++ b/internal/infra/portainer_enrichment_test.go
@@ -48,6 +48,7 @@ func newPortainerTestStore(t *testing.T) *repo.Store {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 }
 

--- a/internal/infra/proxmox_test.go
+++ b/internal/infra/proxmox_test.go
@@ -46,6 +46,7 @@ func newProxmoxTestStore(t *testing.T) *repo.Store {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 }
 

--- a/internal/infra/snmp_test.go
+++ b/internal/infra/snmp_test.go
@@ -45,6 +45,7 @@ func newSNMPTestStore(t *testing.T) *repo.Store {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 }
 

--- a/internal/infra/synology_test.go
+++ b/internal/infra/synology_test.go
@@ -46,6 +46,7 @@ func newSynologyTestStore(t *testing.T) *repo.Store {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 }
 

--- a/internal/ingest/pipeline_test.go
+++ b/internal/ingest/pipeline_test.go
@@ -25,7 +25,7 @@ func newTestStore(t *testing.T) *repo.Store {
 	t.Cleanup(func() { db.Close() })
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
-	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	return repo.NewStore(appRepo, eventRepo, repo.NewCheckRepo(db), repo.NewRollupRepo(db), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func seedApp(t *testing.T, store *repo.Store, token string, rateLimit int) models.App {

--- a/internal/jobs/resource_rollup_test.go
+++ b/internal/jobs/resource_rollup_test.go
@@ -31,7 +31,7 @@ func newTestStore(t *testing.T) (*repo.Store, *sqlx.DB) {
 		repo.NewRollupRepo(db),
 		repo.NewResourceReadingRepo(db),
 		repo.NewResourceRollupRepo(db),
-		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
 	)
 	return store, db
 }

--- a/internal/models/digest_registry.go
+++ b/internal/models/digest_registry.go
@@ -1,0 +1,56 @@
+package models
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// JSONText is a json.RawMessage that can be scanned from a SQLite TEXT column.
+type JSONText json.RawMessage
+
+func (j *JSONText) Scan(src interface{}) error {
+	switch v := src.(type) {
+	case string:
+		*j = JSONText(v)
+	case []byte:
+		*j = JSONText(v)
+	case nil:
+		*j = JSONText("{}")
+	default:
+		return fmt.Errorf("JSONText: unsupported type %T", src)
+	}
+	return nil
+}
+
+func (j JSONText) Value() (driver.Value, error) {
+	if j == nil {
+		return "{}", nil
+	}
+	return string(j), nil
+}
+
+func (j JSONText) MarshalJSON() ([]byte, error) {
+	if j == nil {
+		return []byte("{}"), nil
+	}
+	return json.RawMessage(j).MarshalJSON()
+}
+
+// DigestRegistryEntry is a named, managed record for every digest entry declared
+// across all app profiles. Entries are reconciled at startup and managed via
+// the Settings → Digest Registry tab.
+type DigestRegistryEntry struct {
+	ID            string    `db:"id"             json:"id"`
+	ProfileID     string    `db:"profile_id"     json:"profile_id"`
+	Source        string    `db:"source"         json:"source"`
+	EntryType     string    `db:"entry_type"     json:"entry_type"`
+	Name          string    `db:"name"           json:"name"`
+	Label         string    `db:"label"          json:"label"`
+	Config        JSONText  `db:"config"         json:"config"`
+	ProfileSource string    `db:"profile_source" json:"profile_source"`
+	Active        bool      `db:"active"         json:"active"`
+	CreatedAt     time.Time `db:"created_at"     json:"created_at"`
+	UpdatedAt     time.Time `db:"updated_at"     json:"updated_at"`
+}

--- a/internal/profile/registry_reconciler.go
+++ b/internal/profile/registry_reconciler.go
@@ -1,0 +1,122 @@
+package profile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/apptemplate"
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/google/uuid"
+)
+
+
+var nonAlphanumRe = regexp.MustCompile(`[^a-z0-9_]+`)
+
+// slugify converts a label to a stable name: lowercase, spaces to underscores,
+// strip non-alphanumeric except underscores.
+func slugify(label string) string {
+	s := strings.ToLower(label)
+	s = strings.ReplaceAll(s, " ", "_")
+	s = nonAlphanumRe.ReplaceAllString(s, "")
+	return s
+}
+
+// RegistryReconciler reconciles digest entries from app templates into the digest registry.
+// It runs once at startup after all templates are loaded.
+type RegistryReconciler struct {
+	repo     repo.DigestRegistryRepo
+	registry *apptemplate.Registry
+}
+
+// NewRegistryReconciler creates a RegistryReconciler.
+func NewRegistryReconciler(r repo.DigestRegistryRepo, registry *apptemplate.Registry) *RegistryReconciler {
+	return &RegistryReconciler{repo: r, registry: registry}
+}
+
+// Reconcile iterates over all loaded app templates, upserts their digest categories
+// into the registry, and deactivates entries no longer present in the template.
+func (rc *RegistryReconciler) Reconcile(ctx context.Context) error {
+	templates := rc.registry.List()
+	now := time.Now().UTC()
+
+	for profileID, tmpl := range templates {
+		if len(tmpl.Digest.Categories) == 0 {
+			continue
+		}
+
+		profileSource := tmpl.SourcePath
+
+		// Build the set of names declared in the current template.
+		currentNames := make(map[string]struct{}, len(tmpl.Digest.Categories))
+
+		for _, cat := range tmpl.Digest.Categories {
+			name := slugify(cat.Label)
+			if name == "" {
+				continue
+			}
+			currentNames[name] = struct{}{}
+
+			config, err := categoryConfig(cat)
+			if err != nil {
+				return fmt.Errorf("reconcile %s/%s: %w", profileID, name, err)
+			}
+
+			entry := models.DigestRegistryEntry{
+				ID:            uuid.NewString(),
+				ProfileID:     profileID,
+				Source:        "webhook",
+				EntryType:     "category",
+				Name:          name,
+				Label:         cat.Label,
+				Config:        config,
+				ProfileSource: profileSource,
+				Active:        true,
+				CreatedAt:     now,
+				UpdatedAt:     now,
+			}
+
+			if err := rc.repo.Upsert(ctx, entry); err != nil {
+				return fmt.Errorf("upsert %s/%s: %w", profileID, name, err)
+			}
+			log.Printf("digest registry: upserted %s/%s (%s)", profileID, name, cat.Label)
+		}
+
+		// Deactivate entries present in DB but not in the current template.
+		existing, err := rc.repo.ListByProfile(ctx, profileID)
+		if err != nil {
+			return fmt.Errorf("list registry for %s: %w", profileID, err)
+		}
+		for _, e := range existing {
+			if _, ok := currentNames[e.Name]; !ok && e.Active {
+				if err := rc.repo.SetActive(ctx, profileID, e.Name, false); err != nil {
+					return fmt.Errorf("deactivate %s/%s: %w", profileID, e.Name, err)
+				}
+				log.Printf("digest registry: deactivated %s/%s (not in current template)", profileID, e.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+// categoryConfig encodes the match fields from a DigestCategory as a JSON config blob.
+func categoryConfig(cat apptemplate.DigestCategory) (models.JSONText, error) {
+	m := map[string]string{
+		"match_field": cat.MatchField,
+		"match_value": cat.MatchValue,
+	}
+	if cat.MatchSeverity != "" {
+		m["match_severity"] = cat.MatchSeverity
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return models.JSONText(b), nil
+}

--- a/internal/repo/apps.go
+++ b/internal/repo/apps.go
@@ -13,6 +13,9 @@ import (
 // ErrNotFound is returned when a requested record does not exist.
 var ErrNotFound = errors.New("not found")
 
+// ErrConflict is returned when an operation is not permitted due to the current state of the record.
+var ErrConflict = errors.New("conflict")
+
 // AppRepo defines CRUD operations for apps.
 type AppRepo interface {
 	List(ctx context.Context) ([]models.App, error)

--- a/internal/repo/digest_registry.go
+++ b/internal/repo/digest_registry.go
@@ -1,0 +1,133 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalcheffe/nora/internal/models"
+	"github.com/jmoiron/sqlx"
+)
+
+// DigestRegistryRepo defines operations for the digest registry.
+type DigestRegistryRepo interface {
+	Upsert(ctx context.Context, entry models.DigestRegistryEntry) error
+	SetActive(ctx context.Context, profileID string, name string, active bool) error
+	List(ctx context.Context) ([]models.DigestRegistryEntry, error)
+	ListByProfile(ctx context.Context, profileID string) ([]models.DigestRegistryEntry, error)
+	Delete(ctx context.Context, id string) error
+	SetActiveByID(ctx context.Context, id string, active bool) error
+}
+
+type sqliteDigestRegistryRepo struct {
+	db *sqlx.DB
+}
+
+// NewDigestRegistryRepo returns a DigestRegistryRepo backed by the given SQLite database.
+func NewDigestRegistryRepo(db *sqlx.DB) DigestRegistryRepo {
+	return &sqliteDigestRegistryRepo{db: db}
+}
+
+// Upsert inserts or replaces a digest registry entry on the UNIQUE(profile_id, name) constraint.
+func (r *sqliteDigestRegistryRepo) Upsert(ctx context.Context, entry models.DigestRegistryEntry) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO digest_registry (id, profile_id, source, entry_type, name, label, config, profile_source, active, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(profile_id, name) DO UPDATE SET
+			label          = excluded.label,
+			config         = excluded.config,
+			profile_source = excluded.profile_source,
+			active         = excluded.active,
+			updated_at     = excluded.updated_at`,
+		entry.ID, entry.ProfileID, entry.Source, entry.EntryType,
+		entry.Name, entry.Label, string(entry.Config), entry.ProfileSource, entry.Active,
+		entry.CreatedAt.UTC(), entry.UpdatedAt.UTC(),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert digest registry entry: %w", err)
+	}
+	return nil
+}
+
+// SetActive updates the active flag for an entry identified by profile_id+name.
+func (r *sqliteDigestRegistryRepo) SetActive(ctx context.Context, profileID string, name string, active bool) error {
+	activeInt := 0
+	if active {
+		activeInt = 1
+	}
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE digest_registry SET active = ?, updated_at = datetime('now')
+		WHERE profile_id = ? AND name = ?`,
+		activeInt, profileID, name,
+	)
+	if err != nil {
+		return fmt.Errorf("set active digest registry entry: %w", err)
+	}
+	return nil
+}
+
+// List returns all digest registry entries ordered by profile_id, entry_type, name.
+func (r *sqliteDigestRegistryRepo) List(ctx context.Context) ([]models.DigestRegistryEntry, error) {
+	var entries []models.DigestRegistryEntry
+	err := r.db.SelectContext(ctx, &entries, `
+		SELECT id, profile_id, source, entry_type, name, label, config, profile_source, active, created_at, updated_at
+		FROM digest_registry
+		ORDER BY profile_id, entry_type, name`)
+	if err != nil {
+		return nil, fmt.Errorf("list digest registry entries: %w", err)
+	}
+	return entries, nil
+}
+
+// ListByProfile returns all entries for a given profile_id.
+func (r *sqliteDigestRegistryRepo) ListByProfile(ctx context.Context, profileID string) ([]models.DigestRegistryEntry, error) {
+	var entries []models.DigestRegistryEntry
+	err := r.db.SelectContext(ctx, &entries, `
+		SELECT id, profile_id, source, entry_type, name, label, config, profile_source, active, created_at, updated_at
+		FROM digest_registry
+		WHERE profile_id = ?
+		ORDER BY entry_type, name`, profileID)
+	if err != nil {
+		return nil, fmt.Errorf("list digest registry entries by profile: %w", err)
+	}
+	return entries, nil
+}
+
+// Delete removes an inactive entry. Returns ErrConflict if the entry is still active.
+func (r *sqliteDigestRegistryRepo) Delete(ctx context.Context, id string) error {
+	// Check active status first.
+	var active int
+	err := r.db.QueryRowContext(ctx, `SELECT active FROM digest_registry WHERE id = ?`, id).Scan(&active)
+	if err != nil {
+		return fmt.Errorf("check digest registry entry: %w", err)
+	}
+	if active == 1 {
+		return ErrConflict
+	}
+	res, err := r.db.ExecContext(ctx, `DELETE FROM digest_registry WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete digest registry entry: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// SetActiveByID updates the active flag for an entry identified by id.
+func (r *sqliteDigestRegistryRepo) SetActiveByID(ctx context.Context, id string, active bool) error {
+	activeInt := 0
+	if active {
+		activeInt = 1
+	}
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE digest_registry SET active = ?, updated_at = datetime('now') WHERE id = ?`,
+		activeInt, id,
+	)
+	if err != nil {
+		return fmt.Errorf("set active by id digest registry: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/internal/repo/store.go
+++ b/internal/repo/store.go
@@ -22,6 +22,7 @@ type Store struct {
 	WebPushSubscriptions WebPushSubscriptionRepo
 	Snapshots            SnapshotRepo
 	Rules                RuleRepo
+	DigestRegistry       DigestRegistryRepo
 }
 
 // NewStore creates a Store backed by the given repositories.
@@ -46,6 +47,7 @@ func NewStore(
 	webPushSubscriptions WebPushSubscriptionRepo,
 	snapshots SnapshotRepo,
 	rules RuleRepo,
+	digestRegistry DigestRegistryRepo,
 ) *Store {
 	return &Store{
 		Apps:                 apps,
@@ -68,5 +70,6 @@ func NewStore(
 		WebPushSubscriptions: webPushSubscriptions,
 		Snapshots:            snapshots,
 		Rules:                rules,
+		DigestRegistry:       digestRegistry,
 	}
 }

--- a/internal/scanner/discovery/resource_rollup_test.go
+++ b/internal/scanner/discovery/resource_rollup_test.go
@@ -29,7 +29,7 @@ func newTestStore(t *testing.T) (*repo.Store, *sqlx.DB) {
 		repo.NewRollupRepo(db),
 		repo.NewResourceReadingRepo(db),
 		repo.NewResourceRollupRepo(db),
-		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
 	)
 	return store, db
 }

--- a/migrations/031_digest_registry.sql
+++ b/migrations/031_digest_registry.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS digest_registry (
+    id          TEXT PRIMARY KEY,
+    profile_id  TEXT NOT NULL,
+    source      TEXT NOT NULL CHECK(source IN ('webhook', 'api')),
+    entry_type  TEXT NOT NULL CHECK(entry_type IN ('category', 'widget')),
+    name        TEXT NOT NULL,
+    label       TEXT NOT NULL,
+    config      TEXT NOT NULL DEFAULT '{}',
+    active      INTEGER NOT NULL DEFAULT 1,
+    created_at  TIMESTAMP NOT NULL,
+    updated_at  TIMESTAMP NOT NULL,
+
+    UNIQUE(profile_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_digest_registry_profile ON digest_registry(profile_id);
+CREATE INDEX IF NOT EXISTS idx_digest_registry_active  ON digest_registry(active);

--- a/migrations/032_digest_registry_profile_yaml.sql
+++ b/migrations/032_digest_registry_profile_yaml.sql
@@ -1,0 +1,2 @@
+-- Store the source file path of the originating app profile template.
+ALTER TABLE digest_registry ADD COLUMN profile_source TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## Summary

- **SQLite migrations** (031, 032): `digest_registry` table with `UNIQUE(profile_id, name)`, active/profile indexes, and `profile_source` column storing the originating template file path
- **Go backend**: model, repo (Upsert/SetActive/Delete with active-entry guard), `RegistryReconciler` (runs at startup, upserts entries from app templates, deactivates orphans), and 3 admin-gated REST endpoints (`GET`, `PUT /{id}/active`, `DELETE /{id}`)
- **`AppTemplate.SourcePath`**: set at disk-load time so the reconciler can persist the template file path on each registry entry
- **Settings → Digest Registry tab**: responsive split layout (desktop: table + inline detail panel; mobile: SlidePanel), auto-selects first entry on load, read-only detail panel (active toggle + delete with confirmation requiring deactivation first), displays template file path

## Key decisions

- Labels are **owned by app profiles** — no manual editing in the UI; reconciler sets them from the template on every startup
- **Delete requires deactivation first** — active entries return HTTP 409; Delete button is disabled while active
- `profile_source` is stored in the DB at reconcile time — no separate API call needed from the UI

## Test plan

- [ ] Restart backend — migration 032 runs and reconciler populates `profile_source` on all existing entries
- [ ] Settings → Digest Registry: table lists all entries with Profile, Label, Name, Type, Status columns
- [ ] Click a row or gear icon — detail panel opens inline (desktop) or as slide panel (mobile)
- [ ] Toggle Active/Inactive — persists on refresh
- [ ] Delete: button disabled while active; deactivate first, then delete with confirmation
- [ ] Detail panel shows correct `profile_source` file path after backend restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)