### PR TITLE
feat(ui): Settings tab reorder + Instance tab overhaul

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -37,7 +37,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-const version = "1.0.0"
+const version = "1.1.0"
 
 func main() {
 	cfg := config.Load()
@@ -441,7 +441,7 @@ func main() {
 		api.NewDigestHandler(store, digestJob).Routes(r)
 		api.NewSettingsHandler(store).Routes(r)
 		api.NewIntegrationDriversHandler(settingsRepo).Routes(r)
-		api.NewMetricsHandler(eventRepo, appRepo, metricsRepo, cfg.DBPath, startTime).Routes(r)
+		api.NewMetricsHandler(eventRepo, appRepo, metricsRepo, db, cfg.DBPath, startTime, version).Routes(r)
 		api.NewUsersHandler(userRepo, store.Settings).Routes(r)
 		totpHandler.Routes(r)
 		api.NewProxmoxDetailHandler(infraComponentRepo).Routes(r)

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -785,7 +785,17 @@ export interface AppEventItem {
   count: number
 }
 
+export interface DepItem {
+  name: string
+  version: string
+  label: string
+}
+
 export interface InstanceMetrics {
+  version: string
+  go_version: string
+  sqlite_version: string
+  deps: DepItem[]
   db_size_bytes: number
   events_last_24h: number
   uptime_seconds: number

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -33,6 +33,25 @@
   border-bottom-color: var(--accent);
 }
 
+/* ── Instance tab two-up layout ──────────────────────────────────────────── */
+
+.instance-top-row {
+  display: flex;
+  gap: 24px;
+  align-items: stretch;
+}
+
+.instance-top-row > .settings-section {
+  flex: 1;
+  min-width: 0;
+}
+
+@media (max-width: 640px) {
+  .instance-top-row {
+    flex-direction: column;
+  }
+}
+
 /* ── Tab content ──────────────────────────────────────────────────────────── */
 
 .tab-content {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, Fragment } from 'react'
+import pkgJson from '../../package.json'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Topbar } from '../components/Topbar'
 import { InfraIntegrations } from './Integrations'
@@ -77,10 +78,10 @@ const TABS: { id: Tab; label: string }[] = [
   { id: 'apps', label: 'Apps' },
   { id: 'notifications', label: 'Notifications' },
   { id: 'notify_rules', label: 'Notify Rules' },
-  { id: 'metrics', label: 'Instance Metrics' },
-  { id: 'users', label: 'Users' },
-  { id: 'jobs', label: 'Jobs' },
   { id: 'digest_registry', label: 'Digest Registry' },
+  { id: 'jobs', label: 'Jobs' },
+  { id: 'users', label: 'Users' },
+  { id: 'metrics', label: 'Instance' },
 ]
 
 // ── Delete confirmation modal ─────────────────────────────────────────────────
@@ -790,25 +791,65 @@ function MetricsTab() {
 
   return (
     <div className="tab-content">
-      <section className="settings-section">
-        <div className="section-header">
-          <span className="section-title">Instance</span>
-        </div>
-        {loading ? (
-          <div className="settings-placeholder">Loading…</div>
-        ) : error ? (
-          <div className="settings-placeholder" style={{ color: 'var(--red)' }}>{error}</div>
-        ) : data ? (
-          <div className="settings-kv-grid">
-            <span className="settings-kv-key">DB size</span>
-            <span className="settings-kv-val">{formatBytes(data.db_size_bytes)}</span>
-            <span className="settings-kv-key">Events last 24h</span>
-            <span className="settings-kv-val">{data.events_last_24h.toLocaleString()}</span>
-            <span className="settings-kv-key">Uptime</span>
-            <span className="settings-kv-val">{formatUptime(data.uptime_seconds)}</span>
+      <div className="instance-top-row">
+        <section className="settings-section">
+          <div className="section-header">
+            <span className="section-title">Instance</span>
           </div>
-        ) : null}
-      </section>
+          {loading ? (
+            <div className="settings-placeholder">Loading…</div>
+          ) : error ? (
+            <div className="settings-placeholder" style={{ color: 'var(--red)' }}>{error}</div>
+          ) : data ? (
+            <div className="settings-kv-grid">
+              <span className="settings-kv-key">Version</span>
+              <span className="settings-kv-val">v{data.version}</span>
+              <span className="settings-kv-key">Go</span>
+              <span className="settings-kv-val">{data.go_version}</span>
+              <span className="settings-kv-key">SQLite</span>
+              <span className="settings-kv-val">{data.sqlite_version}</span>
+              <span className="settings-kv-key">DB size</span>
+              <span className="settings-kv-val">{formatBytes(data.db_size_bytes)}</span>
+              <span className="settings-kv-key">Events last 24h</span>
+              <span className="settings-kv-val">{data.events_last_24h.toLocaleString()}</span>
+              <span className="settings-kv-key">Uptime</span>
+              <span className="settings-kv-val">{formatUptime(data.uptime_seconds)}</span>
+              <span className="settings-kv-key">GitHub</span>
+              <span className="settings-kv-val">
+                <a href="https://github.com/Digitalcheffe/N.O.R.A" target="_blank" rel="noopener noreferrer">Digitalcheffe/N.O.R.A</a>
+              </span>
+              <span className="settings-kv-key">Wiki</span>
+              <span className="settings-kv-val">
+                <a href="https://github.com/Digitalcheffe/N.O.R.A/wiki" target="_blank" rel="noopener noreferrer">N.O.R.A Wiki</a>
+              </span>
+            </div>
+          ) : null}
+        </section>
+
+        <section className="settings-section">
+          <div className="section-header">
+            <span className="section-title">Tech Stack</span>
+          </div>
+          <div className="settings-kv-grid">
+            {/* Frontend deps — read live from package.json at build time */}
+            <span className="settings-kv-key">React</span>
+            <span className="settings-kv-val">Frontend UI ({pkgJson.dependencies['react']})</span>
+            <span className="settings-kv-key">React Router</span>
+            <span className="settings-kv-val">Client-side routing ({pkgJson.dependencies['react-router-dom']})</span>
+            <span className="settings-kv-key">Vite</span>
+            <span className="settings-kv-val">Build tool ({pkgJson.devDependencies['vite']})</span>
+            <span className="settings-kv-key">TypeScript</span>
+            <span className="settings-kv-val">Type safety ({pkgJson.devDependencies['typescript']})</span>
+            {/* Backend deps — read live from binary via debug.ReadBuildInfo() */}
+            {data?.deps.map(dep => (
+              <Fragment key={dep.name}>
+                <span className="settings-kv-key">{dep.label}</span>
+                <span className="settings-kv-val">{dep.version}</span>
+              </Fragment>
+            ))}
+          </div>
+        </section>
+      </div>
 
       <section className="settings-section">
         <div className="section-header">

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -3,10 +3,13 @@ package api
 import (
 	"net/http"
 	"os"
+	"runtime"
+	"runtime/debug"
 	"time"
 
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
 )
 
 // MetricsHandler serves instance-wide and per-app metrics.
@@ -14,18 +17,22 @@ type MetricsHandler struct {
 	events  repo.EventRepo
 	apps    repo.AppRepo
 	metrics repo.MetricsRepo
+	db      *sqlx.DB
 	dbPath  string
 	started time.Time
+	version string
 }
 
 // NewMetricsHandler creates a MetricsHandler.
-func NewMetricsHandler(events repo.EventRepo, apps repo.AppRepo, metrics repo.MetricsRepo, dbPath string, started time.Time) *MetricsHandler {
+func NewMetricsHandler(events repo.EventRepo, apps repo.AppRepo, metrics repo.MetricsRepo, db *sqlx.DB, dbPath string, started time.Time, version string) *MetricsHandler {
 	return &MetricsHandler{
 		events:  events,
 		apps:    apps,
 		metrics: metrics,
+		db:      db,
 		dbPath:  dbPath,
 		started: started,
+		version: version,
 	}
 }
 
@@ -49,12 +56,60 @@ type appEventItem struct {
 	Count   int    `json:"count"`
 }
 
+type depItem struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Label   string `json:"label"`
+}
+
 type instanceMetricsResponse struct {
+	Version       string         `json:"version"`
+	GoVersion     string         `json:"go_version"`
+	SQLiteVersion string         `json:"sqlite_version"`
+	Deps          []depItem      `json:"deps"`
 	DBSizeBytes   int64          `json:"db_size_bytes"`
 	EventsLast24h int            `json:"events_last_24h"`
 	UptimeSeconds int64          `json:"uptime_seconds"`
 	TopApps       []topAppItem   `json:"top_apps"`
 	AppEvents24h  []appEventItem `json:"app_events_24h"`
+}
+
+// trackedDeps lists the backend modules we surface in the tech stack UI.
+var trackedDeps = []struct {
+	path  string
+	label string
+}{
+	{"github.com/mattn/go-sqlite3", "SQLite (mattn/go-sqlite3)"},
+	{"github.com/go-chi/chi/v5", "go-chi/chi"},
+	{"github.com/golang-jwt/jwt/v5", "golang-jwt/jwt"},
+	{"github.com/SherClockHolmes/webpush-go", "webpush-go"},
+	{"github.com/gosnmp/gosnmp", "gosnmp"},
+	{"github.com/docker/docker", "Docker SDK"},
+	{"github.com/jmoiron/sqlx", "sqlx"},
+}
+
+func buildDepItems() []depItem {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil
+	}
+	index := make(map[string]string, len(info.Deps))
+	for _, m := range info.Deps {
+		v := m.Version
+		if m.Replace != nil {
+			v = m.Replace.Version
+		}
+		index[m.Path] = v
+	}
+	items := make([]depItem, 0, len(trackedDeps))
+	for _, td := range trackedDeps {
+		v := index[td.path]
+		if v == "" {
+			v = "—"
+		}
+		items = append(items, depItem{Name: td.path, Version: v, Label: td.label})
+	}
+	return items
 }
 
 // GetInstance returns instance-wide metrics: GET /api/v1/metrics
@@ -101,7 +156,14 @@ func (h *MetricsHandler) GetInstance(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	var sqliteVersion string
+	_ = h.db.QueryRowContext(ctx, "SELECT sqlite_version()").Scan(&sqliteVersion)
+
 	writeJSON(w, http.StatusOK, instanceMetricsResponse{
+		Version:       h.version,
+		GoVersion:     runtime.Version(),
+		SQLiteVersion: sqliteVersion,
+		Deps:          buildDepItems(),
 		DBSizeBytes:   dbSize,
 		EventsLast24h: total24h,
 		UptimeSeconds: int64(time.Since(h.started).Seconds()),

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -18,7 +18,7 @@ func newMetricsRouter(t *testing.T) http.Handler {
 	eventRepo := repo.NewEventRepo(db)
 	appRepo := repo.NewAppRepo(db)
 	metricsRepo := repo.NewMetricsRepo(db)
-	h := api.NewMetricsHandler(eventRepo, appRepo, metricsRepo, ":memory:", time.Now())
+	h := api.NewMetricsHandler(eventRepo, appRepo, metricsRepo, db, ":memory:", time.Now(), "test")
 	r := chi.NewRouter()
 	h.Routes(r)
 	return r
@@ -100,7 +100,7 @@ func TestGetAppMetrics_EmptyTrend(t *testing.T) {
 	metricsRepo := repo.NewMetricsRepo(db)
 
 	appsHandler := api.NewAppsHandler(appRepo, nil, nil, nil, nil)
-	metricsHandler := api.NewMetricsHandler(eventRepo, appRepo, metricsRepo, ":memory:", time.Now())
+	metricsHandler := api.NewMetricsHandler(eventRepo, appRepo, metricsRepo, db, ":memory:", time.Now(), "test")
 
 	r := chi.NewRouter()
 	appsHandler.Routes(r)


### PR DESCRIPTION
## Summary

- **Tab reorder** — Apps, Notifications, Notify Rules, Digest Registry, Jobs, Users, Instance (was Instance Metrics)
- **Instance tab** — merged into a single card with Version (`v1.1.0`), Go runtime, SQLite version (queried live from DB), GitHub repo link, and Wiki link
- **Tech Stack card** — sits side-by-side with Instance card on desktop, stacks on mobile; backend dep versions read at runtime via `debug.ReadBuildInfo()`, frontend dep versions read from `package.json` at build time — both auto-update when dependencies change
- **Version bump** — `const version` updated to `1.1.0` in `cmd/nora/main.go`
- **Backend** — `MetricsHandler` extended with `db *sqlx.DB`, `go_version`, `sqlite_version`, and `deps` fields in the API response; `NewMetricsHandler` signature updated and tests fixed

## Test plan

- [ ] Navigate to Settings → Instance tab, confirm tab order matches spec
- [ ] Verify Instance card shows correct version, Go runtime, SQLite version, GitHub/Wiki links
- [ ] Verify Tech Stack card shows live dep versions (backend via binary, frontend via package.json)
- [ ] Resize to mobile — confirm cards stack vertically
- [ ] Run `go test ./internal/api/...` — metrics tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)