### PR TITLE
fix(migration): retain traefik source_type in 034 resource_readings/rollups constraints

### DIFF
--- a/migrations/034_type_system_cleanup.sql
+++ b/migrations/034_type_system_cleanup.sql
@@ -11,8 +11,8 @@
 --
 -- Also updates source_type CHECK constraints in:
 --   events            (virtual_host → vm_other, physical_host kept for scanner compat)
---   resource_readings (vm → vm_other)
---   resource_rollups  (vm → vm_other)
+--   resource_readings (vm → vm_other; traefik retained — was valid in 030, historical rows exist)
+--   resource_rollups  (vm → vm_other; traefik retained — same reason)
 
 PRAGMA foreign_keys = OFF;
 
@@ -147,7 +147,8 @@ CREATE TABLE resource_readings_new (
                               'vm_other',
                               'proxmox_node',
                               'synology',
-                              'snmp_host'
+                              'snmp_host',
+                              'traefik'
                           )),
     metric      TEXT      NOT NULL,
     value       REAL      NOT NULL,
@@ -183,7 +184,8 @@ CREATE TABLE resource_rollups_new (
                                'vm_other',
                                'proxmox_node',
                                'synology',
-                               'snmp_host'
+                               'snmp_host',
+                               'traefik'
                            )),
     metric       TEXT      NOT NULL,
     period_type  TEXT      NOT NULL CHECK (period_type IN ('hour', 'day')),


### PR DESCRIPTION
## Summary

- Adds `traefik` to the `source_type` CHECK constraints in `resource_readings_new` and `resource_rollups_new` within migration 034

## Root Cause

Migration 030 added `traefik` as a valid `source_type` for `resource_readings` and `resource_rollups`. Migration 034 rewrote those tables but dropped `traefik` from the new constraints without mapping or filtering those rows.

Any instance with Traefik metric history hits this panic on startup:

```
panic: migration 034_type_system_cleanup.sql failed: CHECK constraint failed: source_type IN (
    'docker_container', 'host', 'vm_linux', 'vm_windows', 'vm_other',
    'proxmox_node', 'synology', 'snmp_host'
)
```

## Fix

Added `traefik` to both `resource_readings_new` and `resource_rollups_new` constraints. The `ELSE` passthrough in the `CASE` statement already preserves the value — only the constraint acceptance was missing.

Follows the drop-guard fix landed in #261.

## Test plan

- [ ] Deploy to an instance with historical Traefik metric rows and verify startup completes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)