### PR TITLE
feat(relationships): Traefik route linking and component_links consolidation

### DIFF
--- a/appprofiles/adguard-home.yaml
+++ b/appprofiles/adguard-home.yaml
@@ -3,7 +3,6 @@ meta:
   category: Network
   icon: adguard-home
   description: Network-wide ad and tracker blocking DNS server
-  capability: monitor_only
   homepage: https://adguard.com/adguard-home
 
 webhook:

--- a/appprofiles/cloudflare-ddns.yaml
+++ b/appprofiles/cloudflare-ddns.yaml
@@ -3,7 +3,6 @@ meta:
   category: Network
   icon: cloudflare
   description: Automatic Cloudflare DNS updater for dynamic IP addresses
-  capability: docker_only
 
 webhook:
   setup_instructions: |

--- a/appprofiles/diun.yaml
+++ b/appprofiles/diun.yaml
@@ -3,7 +3,6 @@ meta:
   category: Infrastructure
   icon: diun
   description: Docker image update notifier
-  capability: webhook_only
   homepage: https://crazymax.dev/diun
 
 webhook:

--- a/appprofiles/duplicati.yaml
+++ b/appprofiles/duplicati.yaml
@@ -3,7 +3,6 @@ meta:
   category: Storage
   icon: duplicati
   description: Open-source backup software
-  capability: webhook_only
   homepage: https://duplicati.com
 
 webhook:

--- a/appprofiles/ghost.yaml
+++ b/appprofiles/ghost.yaml
@@ -3,7 +3,6 @@ meta:
   category: Content
   icon: ghost
   description: Headless CMS for blogs and newsletters
-  capability: full
   homepage: https://ghost.org
 
 webhook:

--- a/appprofiles/gotify.yaml
+++ b/appprofiles/gotify.yaml
@@ -3,7 +3,6 @@ meta:
   category: Infrastructure
   icon: gotify
   description: Self-hosted push notification server
-  capability: monitor_only
   homepage: https://gotify.net
 
 webhook:

--- a/appprofiles/home-assistant.yaml
+++ b/appprofiles/home-assistant.yaml
@@ -3,7 +3,6 @@ meta:
   category: Automation
   icon: home-assistant
   description: Open-source home automation platform
-  capability: full
   homepage: https://www.home-assistant.io
 
 webhook:

--- a/appprofiles/homepage.yaml
+++ b/appprofiles/homepage.yaml
@@ -3,7 +3,6 @@ meta:
   category: Infrastructure
   icon: homepage
   description: Highly customisable application dashboard
-  capability: monitor_only
 
 webhook:
   setup_instructions: |

--- a/appprofiles/lidarr.yaml
+++ b/appprofiles/lidarr.yaml
@@ -3,7 +3,6 @@ meta:
   category: Media
   icon: lidarr
   description: Music management and download automation
-  capability: full
   homepage: https://lidarr.audio
 
 webhook:

--- a/appprofiles/matrix.yaml
+++ b/appprofiles/matrix.yaml
@@ -3,5 +3,4 @@ meta:
   category: Communication
   icon: matrix
   description: Synapse Matrix homeserver
-  capability: monitor_only
 

--- a/appprofiles/matrixadmin.yaml
+++ b/appprofiles/matrixadmin.yaml
@@ -3,7 +3,6 @@ meta:
   category: Infrastructure
   icon: matrix
   description: Synapse Admin UI for Matrix homeserver administration
-  capability: monitor_only
 
 webhook:
   setup_instructions: |

--- a/appprofiles/maubot.yaml
+++ b/appprofiles/maubot.yaml
@@ -3,7 +3,6 @@ meta:
   category: Automation
   icon: maubot
   description: Plugin-based Matrix bot manager
-  capability: monitor_only
 
 webhook:
   setup_instructions: |

--- a/appprofiles/mealie.yaml
+++ b/appprofiles/mealie.yaml
@@ -3,7 +3,6 @@ meta:
   category: Automation
   icon: mealie
   description: Self-hosted recipe manager and meal planner
-  capability: monitor_only
   homepage: https://mealie.io
 
 webhook:

--- a/appprofiles/n8n.yaml
+++ b/appprofiles/n8n.yaml
@@ -3,7 +3,6 @@ meta:
   category: Automation
   icon: n8n
   description: Workflow automation platform
-  capability: full
   homepage: https://n8n.io
 
 webhook:

--- a/appprofiles/nzbget.yaml
+++ b/appprofiles/nzbget.yaml
@@ -3,7 +3,6 @@ meta:
   category: Media
   icon: nzbget
   description: Efficient Usenet downloader
-  capability: monitor_only
   homepage: https://nzbget.com
 
 webhook:

--- a/appprofiles/overseerr.yaml
+++ b/appprofiles/overseerr.yaml
@@ -3,7 +3,6 @@ meta:
   category: Media
   icon: overseerr
   description: Media request management for Plex
-  capability: full
   homepage: https://overseerr.dev
 
 webhook:

--- a/appprofiles/plex.yaml
+++ b/appprofiles/plex.yaml
@@ -3,7 +3,6 @@ meta:
   category: Media
   icon: plex
   description: Personal media server and streaming platform
-  capability: full
   homepage: https://www.plex.tv
 
 webhook:

--- a/appprofiles/prowlarr.yaml
+++ b/appprofiles/prowlarr.yaml
@@ -3,7 +3,6 @@ meta:
   category: Media
   icon: prowlarr
   description: Indexer manager and proxy for Usenet and torrents
-  capability: full
   homepage: https://prowlarr.com
 
 webhook:

--- a/appprofiles/radarr.yaml
+++ b/appprofiles/radarr.yaml
@@ -3,7 +3,6 @@ meta:
   category: Media
   icon: radarr
   description: Movie management and download automation
-  capability: full
   homepage: https://radarr.video
 
 webhook:

--- a/appprofiles/seerr.yaml
+++ b/appprofiles/seerr.yaml
@@ -3,7 +3,6 @@ meta:
   category: Media
   icon: seerr
   description: Media request management for Plex, Jellyfin, and Emby
-  capability: full
   homepage: https://overseerr.dev
 
 webhook:

--- a/appprofiles/sonarr.yaml
+++ b/appprofiles/sonarr.yaml
@@ -3,7 +3,6 @@ meta:
   category: Media
   icon: sonarr
   description: TV series management and download automation
-  capability: full
   homepage: https://sonarr.tv
 
 webhook:

--- a/appprofiles/tautulli.yaml
+++ b/appprofiles/tautulli.yaml
@@ -3,7 +3,6 @@ meta:
   category: Media
   icon: tautulli
   description: Plex media server monitoring and statistics
-  capability: full
   homepage: https://tautulli.com
 
 webhook:

--- a/appprofiles/traefik.yaml
+++ b/appprofiles/traefik.yaml
@@ -3,6 +3,5 @@ meta:
   category: Infrastructure
   icon: traefik
   description: Cloud-native reverse proxy and load balancer
-  capability: monitor_only
   homepage: https://traefik.io
 

--- a/appprofiles/tubesync.yaml
+++ b/appprofiles/tubesync.yaml
@@ -3,7 +3,6 @@ meta:
   category: Media
   icon: tubesync
   description: YouTube PVR — automatically downloads and syncs YouTube channels and playlists
-  capability: monitor_only
   homepage: https://github.com/meeb/tubesync
 
 webhook:

--- a/appprofiles/unifi.yaml
+++ b/appprofiles/unifi.yaml
@@ -3,7 +3,6 @@ meta:
   category: Network
   icon: unifi
   description: Ubiquiti UniFi network controller
-  capability: monitor_only
   homepage: https://ui.com
 
 webhook:

--- a/appprofiles/uptime-kuma.yaml
+++ b/appprofiles/uptime-kuma.yaml
@@ -3,7 +3,6 @@ meta:
   category: Monitoring
   icon: uptime-kuma
   description: Self-hosted uptime monitoring tool
-  capability: webhook_only
   homepage: https://github.com/louislam/uptime-kuma
 
 webhook:

--- a/appprofiles/vaultwarden.yaml
+++ b/appprofiles/vaultwarden.yaml
@@ -3,7 +3,6 @@ meta:
   category: Security
   icon: vaultwarden
   description: Lightweight self-hosted Bitwarden-compatible password manager
-  capability: monitor_only
   homepage: https://github.com/dani-garcia/vaultwarden
 
 webhook:

--- a/appprofiles/watchtower.yaml
+++ b/appprofiles/watchtower.yaml
@@ -3,7 +3,6 @@ meta:
   category: Infrastructure
   icon: watchtower
   description: Automatic Docker container base image updates
-  capability: webhook_only
   homepage: https://containrrr.dev/watchtower
 
 webhook:

--- a/appprofiles/wgeasy.yaml
+++ b/appprofiles/wgeasy.yaml
@@ -3,7 +3,6 @@ meta:
   category: Network
   icon: wireguard
   description: Easy WireGuard VPN server with web UI
-  capability: monitor_only
   homepage: https://github.com/wg-easy/wg-easy
 
 webhook:

--- a/appprofiles/zwavejs2mqtt.yaml
+++ b/appprofiles/zwavejs2mqtt.yaml
@@ -3,7 +3,6 @@ meta:
   category: Automation
   icon: zwave-js-to-mqtt
   description: Z-Wave to MQTT gateway with web UI
-  capability: monitor_only
 
 webhook:
   setup_instructions: |

--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -428,7 +428,7 @@ func main() {
 	// API v1 — protected by auth middleware
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(auth.RequireAuth(cfg.Secret))
-		api.NewAppsHandler(appRepo, iconFetcher, checkRepo, registry, appMetricSnapshotRepo).Routes(r)
+		api.NewAppsHandler(appRepo, iconFetcher, checkRepo, registry, appMetricSnapshotRepo, store).Routes(r)
 		if iconFetcher != nil {
 			api.NewIconsHandler(iconFetcher, registry).Routes(r)
 		}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,6 +4,7 @@
 
 import type {
   App,
+  AppChainResponse,
   ComponentLink,
   AppMetricSnapshot,
   AppTemplate,
@@ -223,6 +224,12 @@ export const apps = {
 
   metrics: (id: string) =>
     request<ListResponse<AppMetricSnapshot>>('GET', `/apps/${id}/metrics`),
+
+  pollNow: (id: string) =>
+    request<void>('POST', `/apps/${id}/poll`),
+
+  chain: (id: string) =>
+    request<AppChainResponse>('GET', `/apps/${id}/chain`),
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -557,6 +564,15 @@ export const discovery = {
 
   unlinkContainerApp: (containerId: string) =>
     request<void>('DELETE', `/discovered-containers/${containerId}/link-app`),
+
+  allRoutes: () =>
+    request<ListResponse<DiscoveredRoute>>('GET', `/routes`),
+
+  linkRouteApp: (routeId: string, appId: string) =>
+    request<unknown>('POST', `/discovered-routes/${routeId}/link-app`, { mode: 'existing', app_id: appId }),
+
+  unlinkRouteApp: (routeId: string) =>
+    request<void>('DELETE', `/discovered-routes/${routeId}/link-app`),
 }
 
 // ── Traefik expanded (Infra-10/11) ────────────────────────────────────────────

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -346,7 +346,7 @@ export interface DashboardSummaryResponse {
 
 // ── App Template Library ──────────────────────────────────────────────────────
 
-export type AppTemplateCapability = 'full' | 'webhook_only' | 'monitor_only' | 'docker_only' | 'limited'
+export type AppTemplateCapability = 'full' | 'webhook_only' | 'api_only' | 'monitor_only'
 
 export interface AppTemplate {
   id: string
@@ -885,3 +885,27 @@ export interface DigestRegistryListResponse {
   data: DigestRegistryEntry[]
   total: number
 }
+
+// ── App Infrastructure Chain ──────────────────────────────────────────────────
+
+export interface ChainNode {
+  type: string
+  id: string
+  name: string
+  status: string
+  detail?: string
+  icon_url?: string
+}
+
+export interface ChainTraefikRoute {
+  router: string
+  rule: string
+  service: string
+  status: string
+}
+
+export interface AppChainResponse {
+  chain: ChainNode[]
+  traefik: ChainTraefikRoute[]
+}
+

--- a/frontend/src/components/AppChain.css
+++ b/frontend/src/components/AppChain.css
@@ -1,0 +1,299 @@
+/* ── App Infrastructure Chain ─────────────────────────────────────────────── */
+
+.app-chain-wrap {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 18px 16px;
+  margin-bottom: 16px;
+  animation: fadeUp 0.2s ease both;
+}
+
+.app-chain-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text3);
+  margin-bottom: 14px;
+}
+
+/* ── Chain row ──────────────────────────────────────────────────────────────── */
+
+.app-chain-row {
+  display: flex;
+  align-items: stretch;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  gap: 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.app-chain-step {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  flex-shrink: 0;
+}
+
+/* ── Individual node card — horizontal layout, consistent height ─────────────── */
+
+.app-chain-node {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  background: var(--bg3);
+  border: 1px solid var(--border2);
+  border-radius: 8px;
+  padding: 10px 14px 10px 10px;
+  width: 160px;        /* fixed width */
+  height: 64px;        /* fixed height — keeps all cards identical */
+  box-sizing: border-box;
+  flex-shrink: 0;
+  position: relative;
+  transition: border-color 0.15s, box-shadow 0.15s, background 0.15s;
+}
+
+.app-chain-node--link {
+  cursor: pointer;
+}
+
+.app-chain-node--link:hover {
+  border-color: var(--accent);
+  background: var(--bg4);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.app-chain-node--link:hover .chain-name {
+  color: var(--accent);
+}
+
+/* ── Icon container — colored background per type ────────────────────────────── */
+
+.chain-icon-wrap {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+/* Use the badge color classes for the icon wrap background */
+.chain-icon-wrap.chain-badge--app       { background: color-mix(in srgb, var(--accent) 15%, transparent); border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent); }
+.chain-icon-wrap.chain-badge--container { background: color-mix(in srgb, #5b9cf6 12%, transparent);       border: 1px solid color-mix(in srgb, #5b9cf6 25%, transparent); }
+.chain-icon-wrap.chain-badge--portainer { background: color-mix(in srgb, #4f86c6 12%, transparent);       border: 1px solid color-mix(in srgb, #4f86c6 25%, transparent); }
+.chain-icon-wrap.chain-badge--docker    { background: color-mix(in srgb, #0db7ed 12%, transparent);       border: 1px solid color-mix(in srgb, #0db7ed 25%, transparent); }
+.chain-icon-wrap.chain-badge--vm        { background: color-mix(in srgb, #e09755 12%, transparent);       border: 1px solid color-mix(in srgb, #e09755 25%, transparent); }
+.chain-icon-wrap.chain-badge--proxmox   { background: color-mix(in srgb, #e07b39 12%, transparent);       border: 1px solid color-mix(in srgb, #e07b39 25%, transparent); }
+.chain-icon-wrap.chain-badge--synology  { background: color-mix(in srgb, #5ba8a0 12%, transparent);       border: 1px solid color-mix(in srgb, #5ba8a0 25%, transparent); }
+.chain-icon-wrap.chain-badge--traefik   { background: color-mix(in srgb, #24a1c1 12%, transparent);       border: 1px solid color-mix(in srgb, #24a1c1 25%, transparent); }
+.chain-icon-wrap.chain-badge--default   { background: var(--bg4);                                         border: 1px solid var(--border); }
+
+/* ── Node icon inside the wrap ───────────────────────────────────────────────── */
+
+.chain-node-icon {
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+  display: block;
+  flex-shrink: 0;
+}
+
+.chain-node-icon--letter {
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text2);
+  font-family: var(--mono);
+}
+
+/* ── Node body (right side of the horizontal card) ──────────────────────────── */
+
+.chain-node-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+/* ── Type label (replaces badge — simpler, muted) ────────────────────────────── */
+
+.chain-type-label {
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  white-space: nowrap;
+}
+
+.chain-type-label.chain-badge--app       { color: var(--accent); }
+.chain-type-label.chain-badge--container { color: #5b9cf6; }
+.chain-type-label.chain-badge--portainer { color: #4f86c6; }
+.chain-type-label.chain-badge--docker    { color: #0db7ed; }
+.chain-type-label.chain-badge--vm        { color: #e09755; }
+.chain-type-label.chain-badge--proxmox   { color: #e07b39; }
+.chain-type-label.chain-badge--synology  { color: #5ba8a0; }
+.chain-type-label.chain-badge--traefik   { color: #24a1c1; }
+.chain-type-label.chain-badge--default   { color: var(--text3); }
+
+/* ── Node name ───────────────────────────────────────────────────────────────── */
+
+.chain-name {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text);
+  font-family: var(--mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100px;
+  transition: color 0.15s;
+}
+
+/* ── Detail (IP / short image name) ─────────────────────────────────────────── */
+
+.chain-detail {
+  font-size: 9px;
+  color: var(--text3);
+  font-family: var(--mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100px;
+}
+
+/* ── Status row ──────────────────────────────────────────────────────────────── */
+
+.chain-status-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.chain-status-text {
+  font-size: 9px;
+  color: var(--text3);
+  font-family: var(--mono);
+}
+
+/* ── Status dot ──────────────────────────────────────────────────────────────── */
+
+.chain-dot {
+  display: block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.chain-dot--green  { background: var(--green);  box-shadow: 0 0 4px color-mix(in srgb, var(--green) 60%, transparent); }
+.chain-dot--red    { background: var(--red);    box-shadow: 0 0 4px color-mix(in srgb, var(--red) 60%, transparent); }
+.chain-dot--yellow { background: var(--yellow); box-shadow: 0 0 4px color-mix(in srgb, var(--yellow) 60%, transparent); }
+.chain-dot--dim    { background: var(--text3); }
+
+/* ── Connector ───────────────────────────────────────────────────────────────── */
+
+.chain-connector {
+  display: flex;
+  align-items: center;
+  width: 40px;
+  flex-shrink: 0;
+  padding: 0 2px;
+}
+
+.chain-connector--sm {
+  width: 28px;
+}
+
+.chain-connector-line {
+  flex: 1;
+  border-top: 2px dashed var(--border2);
+  margin-right: -1px;
+}
+
+.chain-connector-arrow {
+  font-size: 16px;
+  color: var(--text3);
+  line-height: 1;
+  user-select: none;
+}
+
+/* ── Traefik section ─────────────────────────────────────────────────────────── */
+
+.app-chain-traefik {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-top: 14px;
+  padding-top: 13px;
+  border-top: 1px solid var(--border);
+}
+
+.chain-traefik-header {
+  flex-shrink: 0;
+  padding-top: 2px;
+}
+
+.chain-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  padding: 3px 7px 3px 5px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.chain-badge--traefik { color: #24a1c1; background: color-mix(in srgb, #24a1c1 10%, transparent); border-color: color-mix(in srgb, #24a1c1 25%, transparent); }
+
+.chain-badge-icon {
+  width: 11px;
+  height: 11px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.app-chain-traefik-routes {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.chain-traefik-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: nowrap;
+}
+
+.chain-traefik-rule {
+  font-size: 11px;
+  font-family: var(--mono);
+  color: var(--text2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
+}
+
+.chain-traefik-service {
+  font-size: 11px;
+  font-family: var(--mono);
+  color: var(--text);
+  white-space: nowrap;
+  margin-right: 6px;
+}

--- a/frontend/src/components/AppChain.tsx
+++ b/frontend/src/components/AppChain.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { ChainNode, ChainTraefikRoute } from '../api/types'
+import './AppChain.css'
+
+const CDN = 'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg'
+
+// dashboard-icons CDN slug per infra type
+const TYPE_CDN_SLUG: Record<string, string> = {
+  portainer:    'portainer',
+  docker_engine:'docker',
+  proxmox_node: 'proxmox',
+  traefik:      'traefik',
+  synology:     'synology-dsm',
+  vm_linux:     'linux',
+  vm_windows:   'windows',
+  linux_host:   'linux',
+  windows_host: 'windows',
+}
+
+const INFRA_TYPES = new Set([
+  'portainer', 'docker_engine', 'vm_linux', 'vm_windows', 'vm_other',
+  'proxmox_node', 'synology', 'linux_host', 'windows_host', 'generic_host', 'traefik',
+])
+
+function nodeHref(node: ChainNode): string | null {
+  if (INFRA_TYPES.has(node.type)) return `/infrastructure/${node.id}`
+  return null
+}
+
+function statusClass(status: string): string {
+  const s = status.toLowerCase()
+  if (['online', 'running', 'enabled', 'up', 'ok'].includes(s)) return 'chain-dot--green'
+  if (['stopped', 'error', 'down', 'disabled', 'offline'].includes(s)) return 'chain-dot--red'
+  if (['warn', 'warning', 'degraded'].includes(s)) return 'chain-dot--yellow'
+  return 'chain-dot--dim'
+}
+
+function statusLabel(status: string): string {
+  if (!status) return ''
+  return status.charAt(0).toUpperCase() + status.slice(1).toLowerCase()
+}
+
+const TYPE_CLASS: Record<string, string> = {
+  app:          'chain-badge--app',
+  container:    'chain-badge--container',
+  portainer:    'chain-badge--portainer',
+  docker_engine:'chain-badge--docker',
+  vm_linux:     'chain-badge--vm',
+  vm_windows:   'chain-badge--vm',
+  proxmox_node: 'chain-badge--proxmox',
+  synology:     'chain-badge--synology',
+  traefik:      'chain-badge--traefik',
+}
+
+const TYPE_LABEL: Record<string, string> = {
+  app:          'App',
+  container:    'Container',
+  portainer:    'Portainer',
+  docker_engine:'Docker',
+  vm_linux:     'Linux VM',
+  vm_windows:   'Windows VM',
+  proxmox_node: 'Proxmox',
+  synology:     'Synology',
+  traefik:      'Traefik',
+  linux_host:   'Linux',
+  windows_host: 'Windows',
+  generic_host: 'Host',
+}
+
+// Resolves the best icon URL for a node: explicit backend url → CDN by type → null
+function resolveIconUrl(node: ChainNode): string | null {
+  if (node.icon_url) return node.icon_url
+  const slug = TYPE_CDN_SLUG[node.type]
+  if (slug) return `${CDN}/${slug}.svg`
+  return null
+}
+
+function NodeIcon({ node }: { node: ChainNode }) {
+  const [failed, setFailed] = useState(false)
+  const url = !failed ? resolveIconUrl(node) : null
+
+  if (url) {
+    return (
+      <img
+        src={url}
+        alt=""
+        className="chain-node-icon"
+        onError={() => setFailed(true)}
+      />
+    )
+  }
+  return (
+    <span className="chain-node-icon chain-node-icon--letter">
+      {node.name.charAt(0).toUpperCase()}
+    </span>
+  )
+}
+
+function TraefikBadgeIcon() {
+  const [failed, setFailed] = useState(false)
+  const url = !failed ? `${CDN}/traefik.svg` : null
+  if (url) return <img src={url} alt="" className="chain-badge-icon" onError={() => setFailed(true)} />
+  return null
+}
+
+interface AppChainProps {
+  chain: ChainNode[]
+  appStatus?: string
+  traefik: ChainTraefikRoute[]
+}
+
+export function AppChain({ chain, appStatus, traefik }: AppChainProps) {
+  const navigate = useNavigate()
+
+  if (chain.length === 0) return null
+
+  return (
+    <div className="app-chain-wrap">
+      <div className="app-chain-label">Infrastructure</div>
+
+      <div className="app-chain-row">
+        {chain.map((node, i) => {
+          const href = nodeHref(node)
+          const status = node.type === 'app' ? (appStatus ?? '') : node.status
+          const badgeClass = TYPE_CLASS[node.type] ?? 'chain-badge--default'
+
+          return (
+            <div key={node.id} className="app-chain-step">
+              <div
+                className={`app-chain-node${href ? ' app-chain-node--link' : ''}`}
+                onClick={href ? () => navigate(href) : undefined}
+                role={href ? 'button' : undefined}
+                tabIndex={href ? 0 : undefined}
+                onKeyDown={href ? (e) => { if (e.key === 'Enter') navigate(href) } : undefined}
+              >
+                {/* Icon */}
+                <div className={`chain-icon-wrap ${badgeClass}`}>
+                  <NodeIcon node={node} />
+                </div>
+
+                {/* Text content */}
+                <div className="chain-node-body">
+                  <span className={`chain-type-label ${badgeClass}`}>{TYPE_LABEL[node.type] ?? node.type}</span>
+                  <span className="chain-name" title={node.name}>{node.name}</span>
+                  {node.detail && (
+                    <span className="chain-detail" title={node.detail}>{node.detail}</span>
+                  )}
+                  {status && (
+                    <div className="chain-status-row">
+                      <span className={`chain-dot ${statusClass(status)}`} />
+                      <span className="chain-status-text">{statusLabel(status)}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {i < chain.length - 1 && (
+                <div className="chain-connector" aria-hidden>
+                  <span className="chain-connector-line" />
+                  <span className="chain-connector-arrow">›</span>
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {traefik.length > 0 && (
+        <div className="app-chain-traefik">
+          <div className="chain-traefik-header">
+            <div className="chain-badge chain-badge--traefik">
+              <TraefikBadgeIcon />
+              <span>Traefik</span>
+            </div>
+          </div>
+          <div className="app-chain-traefik-routes">
+            {traefik.map((r, i) => (
+              <div key={i} className="chain-traefik-row">
+                <span className="chain-traefik-rule" title={r.rule}>{r.rule}</span>
+                <div className="chain-connector chain-connector--sm" aria-hidden>
+                  <span className="chain-connector-line" />
+                  <span className="chain-connector-arrow">›</span>
+                </div>
+                <span className="chain-traefik-service">{r.service || r.router}</span>
+                <div className="chain-status-row">
+                  <span className={`chain-dot ${statusClass(r.status)}`} />
+                  <span className="chain-status-text">{statusLabel(r.status)}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/AppMetricCard.css
+++ b/frontend/src/components/AppMetricCard.css
@@ -45,6 +45,10 @@
 
 .amc-timestamp--stale { color: var(--yellow, #eab308); }
 
+.amc-value.color-green  { color: var(--green); }
+.amc-value.color-yellow { color: var(--yellow); }
+.amc-value.color-red    { color: var(--red); }
+
 /* ── Skeleton ──────────────────────────────────────────────────────────────── */
 
 .amc-card--skeleton {

--- a/frontend/src/pages/AppDetail.tsx
+++ b/frontend/src/pages/AppDetail.tsx
@@ -3,8 +3,9 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { DetailPageLayout } from '../components/DetailPageLayout'
 import { apps as appsApi, dashboard as dashboardApi, appTemplates as templatesApi, checks as checksApi, integrations as integrationsApi } from '../api/client'
-import type { App, AppMetricSnapshot, AppSummary, AppTemplate, MonitorCheck, InfraIntegration, TraefikCert } from '../api/types'
-import { AppMetricsGrid } from '../components/AppMetricsGrid'
+import type { App, AppChainResponse, AppMetricSnapshot, AppSummary, AppTemplate, MonitorCheck, InfraIntegration, TraefikCert } from '../api/types'
+import { AppChain } from '../components/AppChain'
+import { AppMetricCard, AppMetricCardSkeleton } from '../components/AppMetricCard'
 import { CheckTypeIcon } from '../components/CheckTypeIcon'
 import { CheckForm } from '../components/CheckForm'
 import { SlidePanel } from '../components/SlidePanel'
@@ -14,6 +15,7 @@ import {
   validateForm,
   formToInput,
 } from '../components/checkFormHelpers'
+import '../components/AppMetricsGrid.css'
 import './AppDetail.css'
 
 type TimeFilter = 'day' | 'week' | 'month'
@@ -49,11 +51,10 @@ export interface AppSettingsModalProps {
 }
 
 const CAPABILITY_LABEL: Record<string, string> = {
-  full:         'Webhook + Monitor',
+  full:         'Webhook + API',
   webhook_only: 'Webhook',
+  api_only:     'API',
   monitor_only: 'Monitor',
-  docker_only:  'Docker',
-  limited:      'Limited',
 }
 
 export function AppSettingsModal({ open, app, onClose, onUpdated, onDeleted }: AppSettingsModalProps) {
@@ -342,6 +343,9 @@ export function AppDetail() {
   const [traefikCerts, setTraefikCerts] = useState<TraefikCert[]>([])
   const [appMetrics, setAppMetrics] = useState<AppMetricSnapshot[]>([])
   const [metricsLoading, setMetricsLoading] = useState(true)
+  const [polling, setPolling] = useState(false)
+  const [pollError, setPollError] = useState<string | null>(null)
+  const [appChain, setAppChain] = useState<AppChainResponse | null>(null)
 
   const appId = id ?? ''
 
@@ -380,6 +384,13 @@ export function AppDetail() {
       .then(res => setAppMetrics(res.data))
       .catch(() => setAppMetrics([]))
       .finally(() => setMetricsLoading(false))
+  }, [appId, tick])
+
+  useEffect(() => {
+    if (!appId) return
+    appsApi.chain(appId)
+      .then(setAppChain)
+      .catch(() => {})
   }, [appId, tick])
 
   useEffect(() => {
@@ -429,6 +440,22 @@ export function AppDetail() {
     integrationsApi.certs(integrationId)
       .then(res => setTraefikCerts(res.data))
       .catch(() => {})
+  }
+
+  async function handlePollNow() {
+    setPolling(true)
+    setPollError(null)
+    try {
+      await appsApi.pollNow(appId)
+      setMetricsLoading(true)
+      const res = await appsApi.metrics(appId)
+      setAppMetrics(res.data)
+    } catch (err: unknown) {
+      setPollError(err instanceof Error ? err.message : 'Poll failed')
+    } finally {
+      setPolling(false)
+      setMetricsLoading(false)
+    }
   }
 
   if (!id) return null
@@ -487,50 +514,79 @@ export function AppDetail() {
         icon={appIcon}
         headerExtra={AppExtraHeader}
         actions={
-          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-            {baseUrl && (
-              <a className="detail-launch-btn" href={baseUrl} target="_blank" rel="noopener noreferrer">
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-                  <polyline points="15 3 21 3 21 9" />
-                  <line x1="10" y1="14" x2="21" y2="3" />
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6 }}>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              {baseUrl && (
+                <a className="detail-launch-btn" href={baseUrl} target="_blank" rel="noopener noreferrer">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                    <polyline points="15 3 21 3 21 9" />
+                    <line x1="10" y1="14" x2="21" y2="3" />
+                  </svg>
+                  Launch
+                </a>
+              )}
+              {app?.profile_id && (
+                <button
+                  className="detail-settings-btn"
+                  onClick={() => void handlePollNow()}
+                  disabled={polling}
+                  title="Run API polling now"
+                >
+                  {polling ? 'Polling…' : 'Discover Now'}
+                </button>
+              )}
+              <button className="detail-settings-btn" onClick={() => { setSettingsKey(k => k + 1); setShowSettings(true) }} title="App Settings">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <circle cx="12" cy="12" r="3" />
+                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
                 </svg>
-                Launch
-              </a>
+                Settings
+              </button>
+            </div>
+            {pollError && (
+              <div style={{ fontSize: 11, color: 'var(--red)', textAlign: 'right' }}>{pollError}</div>
             )}
-            <button className="detail-settings-btn" onClick={() => { setSettingsKey(k => k + 1); setShowSettings(true) }} title="App Settings">
-              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <circle cx="12" cy="12" r="3" />
-                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-              </svg>
-              Settings
-            </button>
           </div>
         }
         sourceType="app"
         sourceId={appId}
       >
-        {/* ── Live metric cards ── */}
-        <AppMetricsGrid metrics={appMetrics} loading={metricsLoading} />
-
-        {/* ── Stats row (when available) ── */}
-        {appSummary && (appSummary.stats ?? []).length > 0 && (
-          <div className="detail-stats-row">
-            {(appSummary.stats ?? []).map(stat => (
-              <div key={stat.label} className="detail-stat-card">
-                <div className="detail-stat-label">{stat.label}</div>
-                <div className={`detail-stat-value${stat.color ? ` color-${stat.color}` : ''}`}>
-                  {stat.value}
-                </div>
-              </div>
-            ))}
-            {appSummary.sparkline.some(v => v > 0) && (
-              <div className="detail-stat-card detail-stat-sparkline-card">
-                <div className="detail-stat-label">Activity</div>
-                <Sparkline data={Array.from(appSummary.sparkline)} />
-              </div>
-            )}
+        {/* ── Live metrics + stats ── */}
+        {(metricsLoading || appMetrics.length > 0 || (appSummary?.stats ?? []).length > 0) && (
+          <div className="amg-section">
+            {!metricsLoading && <div className="amg-label">Live Metrics</div>}
+            <div className="amg-grid">
+              {metricsLoading ? (
+                [0, 1, 2].map(i => <AppMetricCardSkeleton key={i} />)
+              ) : (
+                <>
+                  {appMetrics.map(m => <AppMetricCard key={m.id} metric={m} />)}
+                  {(appSummary?.stats ?? []).map(stat => (
+                    <div key={`stat-${stat.label}`} className="amc-card">
+                      <div className={`amc-value${stat.color ? ` color-${stat.color}` : ''}`}>{stat.value}</div>
+                      <div className="amc-label">{stat.label}</div>
+                    </div>
+                  ))}
+                  {appSummary?.sparkline.some(v => v > 0) && (
+                    <div className="amc-card">
+                      <div className="amc-label">Activity</div>
+                      <Sparkline data={Array.from(appSummary.sparkline)} />
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
           </div>
+        )}
+
+        {/* ── Infrastructure chain ── */}
+        {appChain && appChain.chain.length > 0 && (
+          <AppChain
+            chain={appChain.chain}
+            appStatus={appSummary?.status}
+            traefik={appChain.traefik ?? []}
+          />
         )}
 
         {/* ── Monitor checks — shown for all apps ── */}

--- a/frontend/src/pages/Relationships.css
+++ b/frontend/src/pages/Relationships.css
@@ -462,3 +462,67 @@
 }
 
 .rel-panel-unlink-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.rel-panel-divider {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 16px 0 12px;
+}
+
+.rel-panel-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 4px;
+}
+
+.rel-panel-table td {
+  padding: 4px 6px;
+  vertical-align: middle;
+}
+
+.rel-panel-table-rule {
+  font-size: 11px;
+  color: var(--text2);
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rel-panel-table-status {
+  width: 70px;
+}
+
+.rel-route-status {
+  font-size: 9px;
+  font-weight: 700;
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.rel-route-status--enabled  { color: var(--green); background: color-mix(in srgb, var(--green) 12%, transparent); }
+.rel-route-status--disabled { color: var(--red);   background: color-mix(in srgb, var(--red) 12%, transparent); }
+.rel-route-status--warning  { color: var(--yellow); background: color-mix(in srgb, var(--yellow) 12%, transparent); }
+
+.rel-panel-unlink-sm {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 3px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--border2);
+  background: none;
+  color: var(--text3);
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.rel-panel-unlink-sm:hover:not(:disabled) {
+  border-color: var(--red);
+  color: var(--red);
+}
+
+.rel-panel-unlink-sm:disabled { opacity: 0.4; cursor: not-allowed; }

--- a/frontend/src/pages/Relationships.tsx
+++ b/frontend/src/pages/Relationships.tsx
@@ -14,6 +14,7 @@ import type {
   ComponentLink,
   InfrastructureComponent,
   DiscoveredContainer,
+  DiscoveredRoute,
   MonitorCheck,
 } from '../api/types'
 import './Relationships.css'
@@ -119,14 +120,18 @@ export function Relationships() {
   const [allComponents, setAllComponents] = useState<InfrastructureComponent[]>([])
   const [allLinks,      setAllLinks]      = useState<ComponentLink[]>([])
   const [monitors,      setMonitors]      = useState<MonitorCheck[]>([])
+  const [allRoutes,     setAllRoutes]     = useState<DiscoveredRoute[]>([])
   const [loading,       setLoading]       = useState(true)
   const [error,         setError]         = useState('')
 
   // ── App panel state ─────────────────────────────────────────────────────────
-  const [appPanelApp,    setAppPanelApp]    = useState<App | null>(null)
-  const [appPanelCtrId,  setAppPanelCtrId]  = useState('')
-  const [appPanelBusy,   setAppPanelBusy]   = useState(false)
-  const [appPanelErr,    setAppPanelErr]    = useState('')
+  const [appPanelApp,       setAppPanelApp]       = useState<App | null>(null)
+  const [appPanelCtrId,     setAppPanelCtrId]     = useState('')
+  const [appPanelBusy,      setAppPanelBusy]      = useState(false)
+  const [appPanelErr,       setAppPanelErr]        = useState('')
+  const [appPanelRouteId,   setAppPanelRouteId]   = useState('')
+  const [appPanelRouteBusy, setAppPanelRouteBusy] = useState(false)
+  const [appPanelRouteErr,  setAppPanelRouteErr]  = useState('')
 
   // ── Infra panel state ───────────────────────────────────────────────────────
   const [infraPanelComp,     setInfraPanelComp]     = useState<InfrastructureComponent | null>(null)
@@ -147,12 +152,13 @@ export function Relationships() {
       setLoading(true)
       setError('')
       try {
-        const [appRes, ctrRes, infraRes, linkRes, moniRes] = await Promise.all([
+        const [appRes, ctrRes, infraRes, linkRes, moniRes, routeRes] = await Promise.all([
           appsApi.list(),
           discovery.allContainers(),
           infraApi.list(),
           linksApi.list(),
           checksApi.list(),
+          discovery.allRoutes(),
         ])
         if (cancelled) return
         setAllApps(appRes.data)
@@ -160,6 +166,7 @@ export function Relationships() {
         setAllComponents(infraRes.data)
         setAllLinks(linkRes.data)
         setMonitors(moniRes.data)
+        setAllRoutes(routeRes.data)
       } catch (e) {
         if (!cancelled) setError(String(e))
       } finally {
@@ -250,6 +257,49 @@ export function Relationships() {
     setAppPanelApp(app)
     setAppPanelCtrId(linkedCtr?.id ?? '')
     setAppPanelErr('')
+    setAppPanelRouteId('')
+    setAppPanelRouteErr('')
+  }
+
+  async function handleAppSave() {
+    if (!appPanelApp) return
+    const linkedCtr = containerByAppId.get(appPanelApp.id)
+    if (appPanelCtrId) {
+      await handleAppLink()
+    } else if (!appPanelCtrId && linkedCtr) {
+      await handleAppUnlink()
+    }
+    if (appPanelRouteId) await handleRouteLink()
+  }
+
+  async function handleRouteLink() {
+    if (!appPanelApp || !appPanelRouteId) return
+    setAppPanelRouteBusy(true); setAppPanelRouteErr('')
+    try {
+      await discovery.linkRouteApp(appPanelRouteId, appPanelApp.id)
+      setAllRoutes(prev => prev.map(r =>
+        r.id === appPanelRouteId ? { ...r, app_id: appPanelApp.id } : r
+      ))
+      setAppPanelRouteId('')
+    } catch (e) {
+      setAppPanelRouteErr(String(e))
+    } finally {
+      setAppPanelRouteBusy(false)
+    }
+  }
+
+  async function handleRouteUnlink(routeId: string) {
+    setAppPanelRouteBusy(true); setAppPanelRouteErr('')
+    try {
+      await discovery.unlinkRouteApp(routeId)
+      setAllRoutes(prev => prev.map(r =>
+        r.id === routeId ? { ...r, app_id: null } : r
+      ))
+    } catch (e) {
+      setAppPanelRouteErr(String(e))
+    } finally {
+      setAppPanelRouteBusy(false)
+    }
   }
 
   async function handleAppLink() {
@@ -344,6 +394,15 @@ export function Relationships() {
   // ── Unlinked containers: not yet linked to any app ──────────────────────────
   const unlinkedContainers = allContainers.filter(c => !c.app_id)
 
+  // ── Routes indexed by app_id ─────────────────────────────────────────────────
+  const routesByAppId = new Map<string, DiscoveredRoute[]>()
+  for (const r of allRoutes) {
+    if (r.app_id) {
+      const existing = routesByAppId.get(r.app_id) ?? []
+      routesByAppId.set(r.app_id, [...existing, r])
+    }
+  }
+
   // ── Containers linked to this app ───────────────────────────────────────────
   const appPanelLinkedCtr = appPanelApp ? containerByAppId.get(appPanelApp.id) : undefined
 
@@ -396,14 +455,16 @@ export function Relationships() {
                         <th>App</th>
                         <th>App Profile</th>
                         <th>Container</th>
+                        <th>Route</th>
                         <th>Status</th>
                         <th></th>
                       </tr>
                     </thead>
                     <tbody>
                       {[...allApps].sort((a, b) => a.name.localeCompare(b.name)).map(app => {
-                        const ctr  = containerByAppId.get(app.id)
-                        const comp = ctr ? componentById.get(ctr.infra_component_id) : undefined
+                        const ctr    = containerByAppId.get(app.id)
+                        const comp   = ctr ? componentById.get(ctr.infra_component_id) : undefined
+                        const routes = routesByAppId.get(app.id) ?? []
                         return (
                           <tr
                             key={app.id}
@@ -425,6 +486,17 @@ export function Relationships() {
                                 ? <span style={{ color: 'var(--text2)' }}>{ctr.container_name}</span>
                                 : <span className="rel-dim rel-unlinked-hint">Not linked</span>
                               }
+                            </td>
+
+                            <td className="rel-mono" style={{ fontSize: 11 }}>
+                              {routes.length > 0 ? (
+                                <span style={{ color: 'var(--accent)' }} title={routes.map(r => r.rule || r.router_name).join(', ')}>
+                                  {routes[0].rule || routes[0].router_name}
+                                  {routes.length > 1 && <span className="rel-dim"> +{routes.length - 1}</span>}
+                                </span>
+                              ) : (
+                                <span className="rel-dim">—</span>
+                              )}
                             </td>
 
                             <td>
@@ -650,23 +722,13 @@ export function Relationships() {
         subtitle={appPanelApp?.name}
         width={420}
         footer={
-          appPanelLinkedCtr ? (
-            <button
-              className="rel-panel-unlink-btn"
-              disabled={appPanelBusy}
-              onClick={() => void handleAppUnlink()}
-            >
-              {appPanelBusy ? 'Unlinking…' : 'Unlink'}
-            </button>
-          ) : (
-            <button
-              className="rel-panel-link-btn"
-              disabled={appPanelBusy || !appPanelCtrId}
-              onClick={() => void handleAppLink()}
-            >
-              {appPanelBusy ? 'Linking…' : 'Link'}
-            </button>
-          )
+          <button
+            className="rel-panel-link-btn"
+            disabled={appPanelBusy || appPanelRouteBusy}
+            onClick={() => void handleAppSave()}
+          >
+            {(appPanelBusy || appPanelRouteBusy) ? 'Saving…' : 'Save'}
+          </button>
         }
       >
         {appPanelApp && (
@@ -693,7 +755,7 @@ export function Relationships() {
               value={appPanelCtrId}
               onChange={e => setAppPanelCtrId(e.target.value)}
             >
-              <option value="">— Select container —</option>
+              <option value="">{appPanelLinkedCtr ? '— Remove container link —' : '— Select container —'}</option>
               {/* Show unlinked containers first, then all others */}
               {unlinkedContainers.length > 0 && (
                 <optgroup label="Available (unlinked)">
@@ -712,6 +774,68 @@ export function Relationships() {
             </select>
 
             {appPanelErr && <div className="rel-panel-error">{appPanelErr}</div>}
+
+            {/* ── Traefik Routes ── */}
+            <hr className="rel-panel-divider" />
+            <p className="rel-panel-label">Traefik Routes</p>
+
+            {(() => {
+              const linkedRoutes = allRoutes.filter(r => r.app_id === appPanelApp?.id)
+              const unlinkableRoutes = allRoutes.filter(r => !r.app_id)
+              const otherAppRoutes = allRoutes.filter(r => r.app_id && r.app_id !== appPanelApp?.id)
+              return (
+                <>
+                  {linkedRoutes.length > 0 && (
+                    <table className="rel-panel-table">
+                      <tbody>
+                        {linkedRoutes.map(r => (
+                          <tr key={r.id}>
+                            <td className="rel-mono rel-panel-table-rule" title={r.rule || r.router_name}>
+                              {r.domain ?? (r.rule || r.router_name)}
+                              <div style={{ fontSize: 10, color: 'var(--text3)', marginTop: 1 }}>{r.router_name}</div>
+                            </td>
+                            <td className="rel-panel-table-status">
+                              <span className={`rel-route-status rel-route-status--${r.router_status}`}>{r.router_status}</span>
+                            </td>
+                            <td>
+                              <button
+                                className="rel-panel-unlink-sm"
+                                disabled={appPanelRouteBusy}
+                                onClick={() => void handleRouteUnlink(r.id)}
+                              >Unlink</button>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+
+                  <select
+                    className="rel-panel-select"
+                    style={{ marginTop: 8 }}
+                    value={appPanelRouteId}
+                    onChange={e => setAppPanelRouteId(e.target.value)}
+                  >
+                    <option value="">— Link a route —</option>
+                    {unlinkableRoutes.length > 0 && (
+                      <optgroup label="Unlinked">
+                        {unlinkableRoutes.map(r => (
+                          <option key={r.id} value={r.id}>{r.rule || r.router_name}</option>
+                        ))}
+                      </optgroup>
+                    )}
+                    {otherAppRoutes.length > 0 && (
+                      <optgroup label="Linked to another app">
+                        {otherAppRoutes.map(r => (
+                          <option key={r.id} value={r.id}>{r.rule || r.router_name}</option>
+                        ))}
+                      </optgroup>
+                    )}
+                  </select>
+                  {appPanelRouteErr && <div className="rel-panel-error">{appPanelRouteErr}</div>}
+                </>
+              )
+            })()}
           </div>
         )}
       </SlidePanel>

--- a/frontend/src/styles/Modal.css
+++ b/frontend/src/styles/Modal.css
@@ -103,6 +103,7 @@
   margin-bottom: 8px;
 }
 
+
 .modal-label {
   display: block;
   font-family: var(--mono);

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
@@ -12,6 +13,7 @@ import (
 	"github.com/digitalcheffe/nora/internal/icons"
 	"github.com/digitalcheffe/nora/internal/models"
 	"github.com/digitalcheffe/nora/internal/repo"
+	"github.com/digitalcheffe/nora/internal/scanner/discovery"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
@@ -19,15 +21,16 @@ import (
 // AppsHandler holds dependencies for the apps resource handlers.
 type AppsHandler struct {
 	apps               repo.AppRepo
-	checks             repo.CheckRepo              // may be nil
-	iconsFetcher       *icons.Fetcher              // may be nil
-	profiler           apptemplate.Loader          // may be nil; used to resolve icon slug overrides
-	appMetricSnapshots repo.AppMetricSnapshotRepo  // may be nil
+	checks             repo.CheckRepo             // may be nil
+	iconsFetcher       *icons.Fetcher             // may be nil
+	profiler           apptemplate.Loader         // may be nil; used to resolve icon slug overrides
+	appMetricSnapshots repo.AppMetricSnapshotRepo // may be nil
+	store              *repo.Store                // may be nil; used for on-demand polling
 }
 
 // NewAppsHandler creates an AppsHandler with the given repository.
-func NewAppsHandler(apps repo.AppRepo, fetcher *icons.Fetcher, checks repo.CheckRepo, profiler apptemplate.Loader, appMetricSnapshots repo.AppMetricSnapshotRepo) *AppsHandler {
-	return &AppsHandler{apps: apps, iconsFetcher: fetcher, checks: checks, profiler: profiler, appMetricSnapshots: appMetricSnapshots}
+func NewAppsHandler(apps repo.AppRepo, fetcher *icons.Fetcher, checks repo.CheckRepo, profiler apptemplate.Loader, appMetricSnapshots repo.AppMetricSnapshotRepo, store *repo.Store) *AppsHandler {
+	return &AppsHandler{apps: apps, iconsFetcher: fetcher, checks: checks, profiler: profiler, appMetricSnapshots: appMetricSnapshots, store: store}
 }
 
 // Routes registers all app endpoints on r.
@@ -39,6 +42,154 @@ func (h *AppsHandler) Routes(r chi.Router) {
 	r.Delete("/apps/{id}", h.Delete)
 	r.Post("/apps/{id}/token/regenerate", h.RegenerateToken)
 	r.Get("/apps/{id}/metrics", h.GetMetrics)
+	r.Post("/apps/{id}/poll", h.PollNow)
+	r.Get("/apps/{id}/chain", h.GetChain)
+}
+
+// PollNow triggers an immediate API poll for a single app: POST /apps/{id}/poll.
+func (h *AppsHandler) PollNow(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if h.store == nil || h.profiler == nil {
+		http.Error(w, "polling not available", http.StatusServiceUnavailable)
+		return
+	}
+	if err := discovery.PollOneApp(r.Context(), h.store, h.profiler, id); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ── Infrastructure chain ──────────────────────────────────────────────────────
+
+type chainNode struct {
+	Type    string `json:"type"`
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Detail  string `json:"detail,omitempty"`  // IP for infra components, short image for containers
+	IconURL string `json:"icon_url,omitempty"` // profile icon URL for app/container nodes
+}
+
+type chainTraefikRoute struct {
+	Router  string `json:"router"`
+	Rule    string `json:"rule"`
+	Service string `json:"service"`
+	Status  string `json:"status"`
+}
+
+type getChainResponse struct {
+	Chain   []chainNode         `json:"chain"`
+	Traefik []chainTraefikRoute `json:"traefik"`
+}
+
+// GetChain handles GET /apps/{id}/chain.
+// Walks component_links upward from the app and resolves display names + statuses.
+// Also returns all Traefik routes linked to the app.
+func (h *AppsHandler) GetChain(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	ctx := r.Context()
+
+	if h.store == nil {
+		writeJSON(w, http.StatusOK, getChainResponse{Chain: []chainNode{}, Traefik: []chainTraefikRoute{}})
+		return
+	}
+
+	app, err := h.apps.Get(ctx, id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "app not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// App node — status comes from the caller (appSummary) so we leave it for
+	// the frontend to enrich; return empty string and let the UI substitute.
+	appIconURL := ""
+	if app.ProfileID != "" {
+		appIconURL = "/api/v1/icons/" + app.ProfileID
+	}
+	chain := []chainNode{{Type: "app", ID: app.ID, Name: app.Name, Status: "", IconURL: appIconURL}}
+
+	// Walk component_links upward, capped at 10 hops to prevent cycles.
+	curType, curID := "app", id
+	for i := 0; i < 10; i++ {
+		link, err := h.store.ComponentLinks.GetParent(ctx, curType, curID)
+		if errors.Is(err, repo.ErrNotFound) || link == nil {
+			break
+		}
+		if err != nil {
+			break // non-fatal; return what we have
+		}
+		node := h.resolveChainNode(ctx, link.ParentType, link.ParentID)
+		chain = append(chain, node)
+		curType, curID = link.ParentType, link.ParentID
+	}
+
+	// Traefik routes linked to this app.
+	routes, _ := h.store.DiscoveredRoutes.ListByAppID(ctx, id)
+	traefik := make([]chainTraefikRoute, 0, len(routes))
+	for _, ro := range routes {
+		svc := ""
+		if ro.ServiceName != nil {
+			svc = *ro.ServiceName
+		}
+		traefik = append(traefik, chainTraefikRoute{
+			Router:  ro.RouterName,
+			Rule:    ro.Rule,
+			Service: svc,
+			Status:  ro.RouterStatus,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, getChainResponse{Chain: chain, Traefik: traefik})
+}
+
+// resolveChainNode fetches the display name, status, detail, and icon for a component_links parent node.
+func (h *AppsHandler) resolveChainNode(ctx context.Context, nodeType, nodeID string) chainNode {
+	if nodeType == "container" {
+		if c, err := h.store.DiscoveredContainers.GetDiscoveredContainer(ctx, nodeID); err == nil {
+			iconURL := ""
+			if c.AppID != nil && *c.AppID != "" {
+				// Use the linked app's profile icon for the container node.
+				if linkedApp, err := h.store.Apps.Get(ctx, *c.AppID); err == nil && linkedApp.ProfileID != "" {
+					iconURL = "/api/v1/icons/" + linkedApp.ProfileID
+				}
+			}
+			return chainNode{Type: nodeType, ID: nodeID, Name: c.ContainerName, Status: c.Status, Detail: shortImage(c.Image), IconURL: iconURL}
+		}
+	} else {
+		if ic, err := h.store.InfraComponents.Get(ctx, nodeID); err == nil {
+			return chainNode{Type: nodeType, ID: nodeID, Name: ic.Name, Status: ic.LastStatus, Detail: ic.IP}
+		}
+	}
+	return chainNode{Type: nodeType, ID: nodeID, Name: nodeID, Status: ""}
+}
+
+// shortImage strips the registry prefix and tag from a container image string,
+// returning just the image name. E.g. "ghcr.io/linuxserver/sonarr:latest" → "sonarr".
+func shortImage(image string) string {
+	// Strip registry (anything before the last '/')
+	if i := len(image) - 1; i > 0 {
+		for j := len(image) - 1; j >= 0; j-- {
+			if image[j] == '/' {
+				image = image[j+1:]
+				break
+			}
+		}
+	}
+	// Strip tag
+	if i := len(image) - 1; i > 0 {
+		for j := 0; j < len(image); j++ {
+			if image[j] == ':' {
+				image = image[:j]
+				break
+			}
+		}
+	}
+	return image
 }
 
 // iconSlugForProfile returns the CDN icon slug override for a profileID by

--- a/internal/api/apps_test.go
+++ b/internal/api/apps_test.go
@@ -38,7 +38,7 @@ func newTestRouter(t *testing.T) http.Handler {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	snapshotRepo := repo.NewAppMetricSnapshotRepo(db)
-	h := api.NewAppsHandler(appRepo, nil, nil, nil, snapshotRepo)
+	h := api.NewAppsHandler(appRepo, nil, nil, nil, snapshotRepo, nil)
 	r := chi.NewRouter()
 	h.Routes(r)
 	return r
@@ -304,7 +304,7 @@ func TestGetMetrics_ReturnsSnapshots(t *testing.T) {
 	db := newTestDB(t)
 	appRepo := repo.NewAppRepo(db)
 	snapshotRepo := repo.NewAppMetricSnapshotRepo(db)
-	h := api.NewAppsHandler(appRepo, nil, nil, nil, snapshotRepo)
+	h := api.NewAppsHandler(appRepo, nil, nil, nil, snapshotRepo, nil)
 	r := chi.NewRouter()
 	h.Routes(r)
 

--- a/internal/api/apptemplates.go
+++ b/internal/api/apptemplates.go
@@ -68,7 +68,7 @@ func (h *AppTemplatesHandler) List(w http.ResponseWriter, r *http.Request) {
 			Category:    t.Meta.Category,
 			Icon:        t.Meta.Icon,
 			Description: t.Meta.Description,
-			Capability:  t.Meta.Capability,
+			Capability:  apptemplate.InferCapability(t),
 			Homepage:    t.Meta.Homepage,
 		})
 	}
@@ -96,7 +96,7 @@ func (h *AppTemplatesHandler) Get(w http.ResponseWriter, r *http.Request) {
 			Category:    t.Meta.Category,
 			Icon:        t.Meta.Icon,
 			Description: t.Meta.Description,
-			Capability:  t.Meta.Capability,
+			Capability:  apptemplate.InferCapability(t),
 			Homepage:    t.Meta.Homepage,
 		},
 	}
@@ -181,10 +181,6 @@ func validateAppTemplateYAML(content string) []string {
 	if t.Meta.Description == "" {
 		errs = append(errs, "meta.description is required")
 	}
-	if t.Meta.Capability == "" {
-		errs = append(errs, "meta.capability is required")
-	}
-
 	return errs
 }
 

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -368,7 +368,7 @@ func (h *DashboardHandler) Summary(w http.ResponseWriter, r *http.Request) {
 		if a.ProfileID != "" {
 			sum.IconURL = "/api/v1/icons/" + a.ProfileID
 			if p, err := h.profiler.Get(a.ProfileID); err == nil && p != nil {
-				sum.Capability = p.Meta.Capability
+				sum.Capability = apptemplate.InferCapability(p)
 			}
 		}
 		appSummaries = append(appSummaries, sum)

--- a/internal/api/docker_discovery.go
+++ b/internal/api/docker_discovery.go
@@ -32,6 +32,7 @@ func (h *DockerDiscoveryHandler) Routes(r chi.Router) {
 	r.Get("/infrastructure/{id}/routes", h.ListRoutes)
 	r.Get("/discovery/all", h.ListAll)
 	r.Get("/containers", h.ListAllContainers)
+	r.Get("/routes", h.ListAllRoutes)
 	r.Delete("/discovered-containers/{id}", h.DeleteContainer)
 	r.Post("/discovered-containers/{id}/link-app", h.LinkContainerApp)
 	r.Delete("/discovered-containers/{id}/link-app", h.UnlinkContainerApp)
@@ -151,6 +152,7 @@ func (h *DockerDiscoveryHandler) ListContainers(w http.ResponseWriter, r *http.R
 type discoveredRouteResponse struct {
 	ID             string     `json:"id"`
 	RouterName     string     `json:"router_name"`
+	Rule           string     `json:"rule"`
 	Domain         *string    `json:"domain"`
 	BackendService *string    `json:"backend_service"`
 	ContainerID    *string    `json:"container_id"`
@@ -174,6 +176,7 @@ func buildRouteResponses(routes []*models.DiscoveredRoute, containersByID map[st
 		item := discoveredRouteResponse{
 			ID:             ro.ID,
 			RouterName:     ro.RouterName,
+			Rule:           ro.Rule,
 			Domain:         ro.Domain,
 			BackendService: ro.BackendService,
 			ContainerID:    ro.ContainerID,
@@ -497,12 +500,6 @@ func (h *DockerDiscoveryHandler) LinkRouteApp(w http.ResponseWriter, r *http.Req
 		}
 		linkedAppID = req.AppID
 		route.AppID = &linkedAppID
-		// Wire the app into the topology: app → its Traefik component.
-		if comp, err := h.store.InfraComponents.Get(r.Context(), route.InfrastructureID); err == nil {
-			if err := h.store.ComponentLinks.SetParent(r.Context(), comp.Type, comp.ID, "app", linkedAppID); err != nil {
-				log.Printf("LinkRouteApp: set component_link for app %s: %v", linkedAppID, err)
-			}
-		}
 		_ = infra.EnrichAppOnLink(r.Context(), h.store, h.profiles, linkedAppID, nil, &id)
 		writeJSON(w, http.StatusOK, route)
 
@@ -551,12 +548,6 @@ func (h *DockerDiscoveryHandler) LinkRouteApp(w http.ResponseWriter, r *http.Req
 		}
 		linkedAppID = app.ID
 		route.AppID = &linkedAppID
-		// Wire the new app into the topology: app → its Traefik component.
-		if comp, err := h.store.InfraComponents.Get(r.Context(), route.InfrastructureID); err == nil {
-			if err := h.store.ComponentLinks.SetParent(r.Context(), comp.Type, comp.ID, "app", linkedAppID); err != nil {
-				log.Printf("LinkRouteApp: set component_link for app %s: %v", linkedAppID, err)
-			}
-		}
 		_ = infra.EnrichAppOnLink(r.Context(), h.store, h.profiles, linkedAppID, nil, &id)
 		writeJSON(w, http.StatusCreated, app)
 
@@ -569,23 +560,13 @@ func (h *DockerDiscoveryHandler) LinkRouteApp(w http.ResponseWriter, r *http.Req
 // DELETE /api/v1/discovered-routes/{id}/link-app
 func (h *DockerDiscoveryHandler) UnlinkRouteApp(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	dr, err := h.store.DiscoveredRoutes.GetDiscoveredRoute(r.Context(), id)
-	if errors.Is(err, repo.ErrNotFound) {
-		writeError(w, http.StatusNotFound, "discovered route not found")
-		return
-	} else if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
 	if err := h.store.DiscoveredRoutes.ClearDiscoveredRouteApp(r.Context(), id); err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "discovered route not found")
+			return
+		}
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
-	}
-	// Remove the topology link for the app that was just unlinked.
-	if dr.AppID != nil {
-		if err := h.store.ComponentLinks.RemoveParent(r.Context(), "app", *dr.AppID); err != nil {
-			log.Printf("UnlinkRouteApp: remove component_link for app %s: %v", *dr.AppID, err)
-		}
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -618,6 +599,22 @@ func (h *DockerDiscoveryHandler) ListAllContainers(w http.ResponseWriter, r *htt
 		}
 	}
 
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data":  out,
+		"total": len(out),
+	})
+}
+
+// ListAllRoutes returns a flat list of every discovered route across all Traefik components.
+// GET /api/v1/routes
+func (h *DockerDiscoveryHandler) ListAllRoutes(w http.ResponseWriter, r *http.Request) {
+	routes, err := h.store.DiscoveredRoutes.ListAllDiscoveredRoutes(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	allContainers, _ := h.store.DiscoveredContainers.ListAllDiscoveredContainers(r.Context())
+	out := buildRouteResponses(routes, containerNameIndex(allContainers))
 	writeJSON(w, http.StatusOK, map[string]any{
 		"data":  out,
 		"total": len(out),

--- a/internal/api/events_test.go
+++ b/internal/api/events_test.go
@@ -24,7 +24,7 @@ func newEventsTestSetup(t *testing.T) (http.Handler, *sqlx.DB) {
 	appRepo := repo.NewAppRepo(db)
 	eventRepo := repo.NewEventRepo(db)
 	r := chi.NewRouter()
-	api.NewAppsHandler(appRepo, nil, nil, nil, nil).Routes(r)
+	api.NewAppsHandler(appRepo, nil, nil, nil, nil, nil).Routes(r)
 	api.NewEventsHandler(eventRepo).Routes(r)
 	return r, db
 }

--- a/internal/api/ingest_test.go
+++ b/internal/api/ingest_test.go
@@ -51,7 +51,7 @@ func TestHandleIngest_HappyPath(t *testing.T) {
 	r.Post("/api/v1/ingest/{token}", api.HandleIngest(s, &apptemplate.NoopLoader{}, limiter))
 
 	appsR := chi.NewRouter()
-	api.NewAppsHandler(appRepo, nil, nil, nil, nil).Routes(appsR)
+	api.NewAppsHandler(appRepo, nil, nil, nil, nil, nil).Routes(appsR)
 
 	// Create an app
 	appBody, _ := json.Marshal(map[string]any{"name": "my-app", "rate_limit": 100})
@@ -139,7 +139,7 @@ func TestHandleIngest_RateLimit(t *testing.T) {
 
 	// Create app with limit of 1
 	appsR := chi.NewRouter()
-	api.NewAppsHandler(appRepo, nil, nil, nil, nil).Routes(appsR)
+	api.NewAppsHandler(appRepo, nil, nil, nil, nil, nil).Routes(appsR)
 	appBody, _ := json.Marshal(map[string]any{"name": "rate-app", "rate_limit": 1})
 	req := httptest.NewRequest(http.MethodPost, "/apps", bytes.NewReader(appBody))
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -99,7 +99,7 @@ func TestGetAppMetrics_EmptyTrend(t *testing.T) {
 	eventRepo := repo.NewEventRepo(db)
 	metricsRepo := repo.NewMetricsRepo(db)
 
-	appsHandler := api.NewAppsHandler(appRepo, nil, nil, nil, nil)
+	appsHandler := api.NewAppsHandler(appRepo, nil, nil, nil, nil, nil)
 	metricsHandler := api.NewMetricsHandler(eventRepo, appRepo, metricsRepo, db, ":memory:", time.Now(), "test")
 
 	r := chi.NewRouter()

--- a/internal/apptemplate/apptemplate.go
+++ b/internal/apptemplate/apptemplate.go
@@ -28,8 +28,28 @@ type AppTemplateMeta struct {
 	Category    string `yaml:"category"`
 	Icon        string `yaml:"icon"`         // dashboard-icons CDN slug — used to fetch the app icon
 	Description string `yaml:"description"`
-	Capability  string `yaml:"capability"`
 	Homepage    string `yaml:"homepage"`
+}
+
+// InferCapability derives the capability string from the template's actual content
+// rather than a static field. Rules:
+//   - webhook + api_polling → "full"
+//   - webhook only          → "webhook_only"
+//   - api_polling only      → "api_only"
+//   - neither               → "monitor_only"
+func InferCapability(t *AppTemplate) string {
+	hasWebhook := len(t.Webhook.FieldMappings) > 0 || len(t.Webhook.RecommendedEvents) > 0
+	hasAPI := len(t.APIPolling) > 0
+	switch {
+	case hasWebhook && hasAPI:
+		return "full"
+	case hasWebhook:
+		return "webhook_only"
+	case hasAPI:
+		return "api_only"
+	default:
+		return "monitor_only"
+	}
 }
 
 // EventTypeKeyRule synthesizes an event_type field from payload structure.

--- a/internal/infra/traefik_discovery.go
+++ b/internal/infra/traefik_discovery.go
@@ -94,13 +94,18 @@ func (t *TraefikDiscovery) Run(ctx context.Context, component *models.Infrastruc
 	// ── Build lookup maps ─────────────────────────────────────────────────────
 
 	// container_name → discovered_containers.id (UUID PK)
+	// container_name → discovered_containers.app_id (if linked)
 	containerByName := make(map[string]string)
+	containerAppByName := make(map[string]string) // container_name → app_id
 	containers, err := t.store.DiscoveredContainers.ListAllDiscoveredContainers(ctx)
 	if err != nil {
 		log.Printf("traefik discovery: list containers for cross-ref: %v", err)
 	} else {
 		for _, c := range containers {
 			containerByName[c.ContainerName] = c.ID
+			if c.AppID != nil && *c.AppID != "" {
+				containerAppByName[c.ContainerName] = *c.AppID
+			}
 		}
 	}
 
@@ -118,8 +123,12 @@ func (t *TraefikDiscovery) Run(ctx context.Context, component *models.Infrastruc
 		}
 
 		var containerIDPtr *string
+		var appIDPtr *string
 		if cid, ok := containerByName[backendService]; ok {
 			containerIDPtr = &cid
+		}
+		if aid, ok := containerAppByName[backendService]; ok {
+			appIDPtr = &aid
 		}
 
 		var domainPtr *string
@@ -158,6 +167,7 @@ func (t *TraefikDiscovery) Run(ctx context.Context, component *models.Infrastruc
 			Domain:           domainPtr,
 			BackendService:   backendPtr,
 			ContainerID:      containerIDPtr,
+			AppID:            appIDPtr,
 			LastSeenAt:       now,
 			CreatedAt:        now,
 			// Enriched fields (Infra-10).
@@ -171,6 +181,14 @@ func (t *TraefikDiscovery) Run(ctx context.Context, component *models.Infrastruc
 
 		if err := t.store.DiscoveredRoutes.UpsertDiscoveredRoute(ctx, route); err != nil {
 			log.Printf("traefik discovery: upsert route %s: %v", rr.Name, err)
+			continue
+		}
+		// If this route resolved to an app (via container cross-ref), sync
+		// the traefik_route → app link into component_links so all relationships
+		// live in the same place. INSERT OR IGNORE preserves any existing
+		// container → app parent link.
+		if appIDPtr != nil {
+			t.store.DiscoveredRoutes.SyncRouteAppLink(ctx, component.ID, rr.Name, *appIDPtr)
 		}
 	}
 

--- a/internal/jobs/digest.go
+++ b/internal/jobs/digest.go
@@ -356,10 +356,10 @@ func (d *DigestJob) buildDigestData(ctx context.Context, period string) (*Digest
 	}
 
 	// ── 3. App activity — per-app category breakdown ───────────────────────
-	// monitor_only / docker_only apps have no webhook/digest categories — route
+	// monitor_only apps have no webhook/digest categories — route
 	// them to ServiceSections so the email can render a separate Services block.
 	isServiceCapability := func(cap string) bool {
-		return cap == "monitor_only" || cap == "docker_only"
+		return cap == "monitor_only"
 	}
 
 	if d.profiler != nil {
@@ -373,7 +373,7 @@ func (d *DigestJob) buildDigestData(ctx context.Context, period string) (*Digest
 			}
 
 			// Service apps: no digest categories — list them in ServiceSections.
-			if isServiceCapability(profile.Meta.Capability) {
+			if isServiceCapability(apptemplate.InferCapability(profile)) {
 				data.ServiceSections = append(data.ServiceSections, DigestAppSection{
 					AppName:     app.Name,
 					ProfileName: profile.Meta.Name,

--- a/internal/jobs/discover.go
+++ b/internal/jobs/discover.go
@@ -3,11 +3,13 @@ package jobs
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/digitalcheffe/nora/internal/models"
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/digitalcheffe/nora/internal/scanner"
 	"github.com/digitalcheffe/nora/internal/scanner/discovery"
+	"github.com/digitalcheffe/nora/internal/scanner/snapshot"
 )
 
 // DiscoverOneComponent immediately runs the discovery scanner for a single
@@ -26,7 +28,17 @@ func DiscoverOneComponent(ctx context.Context, store *repo.Store, c *models.Infr
 		return nil, fmt.Errorf("no discovery scanner for type=%q method=%q", c.Type, c.CollectionMethod)
 	}
 
-	return sc.Discover(ctx, c.ID, c.Type)
+	result, err := sc.Discover(ctx, c.ID, c.Type)
+
+	// For Traefik components also run the snapshot scanner so the services table
+	// is populated alongside the routes — both use the same API connection.
+	if c.Type == "traefik" {
+		if _, snapErr := snapshot.NewTraefikSnapshotScanner(store).TakeSnapshot(ctx, c.ID, c.Type); snapErr != nil {
+			log.Printf("discover: traefik snapshot for %s (%s): %v", c.Name, c.ID, snapErr)
+		}
+	}
+
+	return result, err
 }
 
 // discoveryScanner returns the correct DiscoveryScanner for c, or nil if none
@@ -43,6 +55,8 @@ func discoveryScanner(store *repo.Store, c *models.InfrastructureComponent) scan
 		return discovery.NewOPNsenseDiscoveryScanner(store)
 	case "portainer":
 		return discovery.NewPortainerDiscoveryScanner(store)
+	case "traefik":
+		return discovery.NewTraefikDiscoveryScanner(store)
 	}
 	// Fallback: collection_method-based dispatch.
 	if c.CollectionMethod == "snmp" {

--- a/internal/repo/checks.go
+++ b/internal/repo/checks.go
@@ -86,6 +86,13 @@ func (r *sqliteCheckRepo) Create(ctx context.Context, check *models.MonitorCheck
 	if err != nil {
 		return fmt.Errorf("create check: %w", err)
 	}
+	// Keep component_links in sync: monitor → app.
+	if check.AppID != "" {
+		r.db.ExecContext(ctx, `
+			INSERT OR IGNORE INTO component_links (parent_type, parent_id, child_type, child_id, created_at)
+			VALUES ('monitor', ?, 'app', ?, datetime('now'))`,
+			check.ID, check.AppID)
+	}
 	return nil
 }
 
@@ -128,6 +135,16 @@ func (r *sqliteCheckRepo) Update(ctx context.Context, check *models.MonitorCheck
 	n, _ := res.RowsAffected()
 	if n == 0 {
 		return ErrNotFound
+	}
+	// Keep component_links in sync: monitor → app.
+	// Always remove the old link first, then re-insert if app_id is still set.
+	r.db.ExecContext(ctx, `
+		DELETE FROM component_links WHERE parent_type = 'monitor' AND parent_id = ?`, check.ID)
+	if check.AppID != "" {
+		r.db.ExecContext(ctx, `
+			INSERT OR IGNORE INTO component_links (parent_type, parent_id, child_type, child_id, created_at)
+			VALUES ('monitor', ?, 'app', ?, datetime('now'))`,
+			check.ID, check.AppID)
 	}
 	return nil
 }
@@ -226,6 +243,13 @@ func (r *sqliteCheckRepo) UpsertForComponent(ctx context.Context, check *models.
 		check.Enabled)
 	if err != nil {
 		return fmt.Errorf("upsert check for component: %w", err)
+	}
+	// Keep component_links in sync: monitor → app.
+	if check.AppID != "" {
+		r.db.ExecContext(ctx, `
+			INSERT OR IGNORE INTO component_links (parent_type, parent_id, child_type, child_id, created_at)
+			VALUES ('monitor', ?, 'app', ?, datetime('now'))`,
+			check.ID, check.AppID)
 	}
 	return nil
 }

--- a/internal/repo/discovery.go
+++ b/internal/repo/discovery.go
@@ -48,8 +48,14 @@ type DiscoveredRouteRepo interface {
 	ListDiscoveredRoutesByStatus(ctx context.Context, infrastructureID string, statusFilter string) ([]*models.DiscoveredRoute, error)
 	ListAllDiscoveredRoutes(ctx context.Context) ([]*models.DiscoveredRoute, error)
 	GetDiscoveredRoute(ctx context.Context, id string) (*models.DiscoveredRoute, error)
+	// ListByAppID returns all discovered routes linked to appID, ordered by router_name.
+	ListByAppID(ctx context.Context, appID string) ([]*models.DiscoveredRoute, error)
 	SetDiscoveredRouteApp(ctx context.Context, id string, appID string) error
 	ClearDiscoveredRouteApp(ctx context.Context, id string) error
+	// SyncRouteAppLink ensures a traefik_route → app entry exists in component_links
+	// for the route identified by (infrastructureID, routerName). Called by the
+	// Traefik discovery scanner after auto-resolving an app via container cross-ref.
+	SyncRouteAppLink(ctx context.Context, infrastructureID, routerName, appID string)
 }
 
 // ── DiscoveredContainerRepo implementation ────────────────────────────────────
@@ -101,6 +107,17 @@ func (r *sqliteDiscoveredContainerRepo) UpsertDiscoveredContainer(ctx context.Co
 	).Scan(&c.ID)
 	if err != nil {
 		return fmt.Errorf("upsert discovered container %s: %w", c.ContainerName, err)
+	}
+	// Keep component_links in sync: container → parent infra_component.
+	var parentType string
+	if err2 := r.db.QueryRowContext(ctx,
+		`SELECT type FROM infrastructure_components WHERE id = ?`, c.InfraComponentID,
+	).Scan(&parentType); err2 == nil {
+		r.db.ExecContext(ctx, `
+			INSERT INTO component_links (parent_type, parent_id, child_type, child_id, created_at)
+			VALUES (?, ?, 'container', ?, datetime('now'))
+			ON CONFLICT(child_type, child_id) DO UPDATE SET parent_type=excluded.parent_type, parent_id=excluded.parent_id`,
+			parentType, c.InfraComponentID, c.ID)
 	}
 	return nil
 }
@@ -161,10 +178,20 @@ func (r *sqliteDiscoveredContainerRepo) SetDiscoveredContainerApp(ctx context.Co
 	if n == 0 {
 		return fmt.Errorf("discovered container %s: %w", id, ErrNotFound)
 	}
+	// Keep component_links in sync: app → container.
+	r.db.ExecContext(ctx, `
+		INSERT INTO component_links (parent_type, parent_id, child_type, child_id, created_at)
+		VALUES ('container', ?, 'app', ?, datetime('now'))
+		ON CONFLICT(child_type, child_id) DO UPDATE SET parent_type='container', parent_id=excluded.parent_id`,
+		id, appID)
 	return nil
 }
 
 func (r *sqliteDiscoveredContainerRepo) ClearDiscoveredContainerApp(ctx context.Context, id string) error {
+	// Resolve app_id before clearing so we can remove it from component_links.
+	var appID string
+	r.db.QueryRowContext(ctx, `SELECT app_id FROM discovered_containers WHERE id = ?`, id).Scan(&appID)
+
 	res, err := r.db.ExecContext(ctx,
 		`UPDATE discovered_containers SET app_id = NULL WHERE id = ?`, id)
 	if err != nil {
@@ -173,6 +200,10 @@ func (r *sqliteDiscoveredContainerRepo) ClearDiscoveredContainerApp(ctx context.
 	n, _ := res.RowsAffected()
 	if n == 0 {
 		return fmt.Errorf("discovered container %s: %w", id, ErrNotFound)
+	}
+	// Remove the app → container link from component_links.
+	if appID != "" {
+		r.db.ExecContext(ctx, `DELETE FROM component_links WHERE child_type = 'app' AND child_id = ?`, appID)
 	}
 	return nil
 }
@@ -331,7 +362,25 @@ func (r *sqliteDiscoveredRouteRepo) UpsertDiscoveredRoute(ctx context.Context, r
 	if err != nil {
 		return fmt.Errorf("upsert discovered route %s: %w", ro.RouterName, err)
 	}
+	// Keep component_links in sync: traefik infra_component → traefik_route.
+	// Use a subquery to get the actual row ID (which may differ from ro.ID on conflict).
+	r.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO component_links (parent_type, parent_id, child_type, child_id, created_at)
+		SELECT 'traefik', ?, 'traefik_route', id, datetime('now')
+		FROM discovered_routes
+		WHERE infrastructure_id = ? AND router_name = ?`,
+		ro.InfrastructureID, ro.InfrastructureID, ro.RouterName)
 	return nil
+}
+
+func (r *sqliteDiscoveredRouteRepo) SyncRouteAppLink(ctx context.Context, infrastructureID, routerName, appID string) {
+	// INSERT OR IGNORE so we don't override an existing container → app parent.
+	r.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO component_links (parent_type, parent_id, child_type, child_id, created_at)
+		SELECT 'traefik_route', id, 'app', ?, datetime('now')
+		FROM discovered_routes
+		WHERE infrastructure_id = ? AND router_name = ?`,
+		appID, infrastructureID, routerName)
 }
 
 func (r *sqliteDiscoveredRouteRepo) ListDiscoveredRoutes(ctx context.Context, infrastructureID string) ([]*models.DiscoveredRoute, error) {
@@ -405,6 +454,24 @@ func (r *sqliteDiscoveredRouteRepo) GetDiscoveredRoute(ctx context.Context, id s
 	return &ro, nil
 }
 
+func (r *sqliteDiscoveredRouteRepo) ListByAppID(ctx context.Context, appID string) ([]*models.DiscoveredRoute, error) {
+	var routes []*models.DiscoveredRoute
+	// Match directly by app_id OR via container_id → discovered_containers.app_id
+	// (the latter handles routes discovered before app_id propagation was added).
+	err := r.db.SelectContext(ctx, &routes, `
+		SELECT `+routeSelectCols+`
+		FROM discovered_routes
+		WHERE app_id = ?
+		   OR container_id IN (
+		        SELECT id FROM discovered_containers WHERE app_id = ?
+		   )
+		ORDER BY router_name`, appID, appID)
+	if err != nil {
+		return nil, fmt.Errorf("list discovered routes for app %s: %w", appID, err)
+	}
+	return routes, nil
+}
+
 func (r *sqliteDiscoveredRouteRepo) SetDiscoveredRouteApp(ctx context.Context, id string, appID string) error {
 	res, err := r.db.ExecContext(ctx,
 		`UPDATE discovered_routes SET app_id = ? WHERE id = ?`, appID, id)
@@ -415,10 +482,20 @@ func (r *sqliteDiscoveredRouteRepo) SetDiscoveredRouteApp(ctx context.Context, i
 	if n == 0 {
 		return fmt.Errorf("discovered route %s: %w", id, ErrNotFound)
 	}
+	// Keep component_links in sync: traefik_route → app.
+	// INSERT OR IGNORE so we don't override an existing container → app parent link.
+	r.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO component_links (parent_type, parent_id, child_type, child_id, created_at)
+		VALUES ('traefik_route', ?, 'app', ?, datetime('now'))`,
+		id, appID)
 	return nil
 }
 
 func (r *sqliteDiscoveredRouteRepo) ClearDiscoveredRouteApp(ctx context.Context, id string) error {
+	// Resolve app_id before clearing so we can remove the specific link from component_links.
+	var appID string
+	r.db.QueryRowContext(ctx, `SELECT COALESCE(app_id,'') FROM discovered_routes WHERE id = ?`, id).Scan(&appID)
+
 	res, err := r.db.ExecContext(ctx,
 		`UPDATE discovered_routes SET app_id = NULL WHERE id = ?`, id)
 	if err != nil {
@@ -427,6 +504,14 @@ func (r *sqliteDiscoveredRouteRepo) ClearDiscoveredRouteApp(ctx context.Context,
 	n, _ := res.RowsAffected()
 	if n == 0 {
 		return fmt.Errorf("discovered route %s: %w", id, ErrNotFound)
+	}
+	// Remove the traefik_route → app link from component_links.
+	// Only remove if this specific route was the parent (don't touch a container → app link).
+	if appID != "" {
+		r.db.ExecContext(ctx, `
+			DELETE FROM component_links
+			WHERE child_type = 'app' AND child_id = ? AND parent_type = 'traefik_route' AND parent_id = ?`,
+			appID, id)
 	}
 	return nil
 }

--- a/internal/scanner/discovery/api_poll.go
+++ b/internal/scanner/discovery/api_poll.go
@@ -19,6 +19,27 @@ import (
 	"github.com/google/uuid"
 )
 
+// PollOneApp runs API polling for a single app identified by appID.
+// Returns an error if the app has no profile, no api_polling entries, or if polling fails.
+func PollOneApp(ctx context.Context, store *repo.Store, registry apptemplate.Loader, appID string) error {
+	app, err := store.Apps.Get(ctx, appID)
+	if err != nil {
+		return fmt.Errorf("get app: %w", err)
+	}
+	if app.ProfileID == "" {
+		return fmt.Errorf("app has no profile — API polling requires a template")
+	}
+	tmpl, err := registry.Get(app.ProfileID)
+	if err != nil || tmpl == nil {
+		return fmt.Errorf("template not found for profile %q", app.ProfileID)
+	}
+	if len(tmpl.APIPolling) == 0 {
+		return fmt.Errorf("profile %q has no api_polling entries", app.ProfileID)
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	return pollApp(ctx, store, client, *app, tmpl.APIPolling)
+}
+
 // RunAPIPolling iterates all apps, finds those with a non-empty api_polling block
 // in their profile, and calls pollApp for each. It is registered as a
 // GlobalDiscoveryJob and runs on the hourly Discovery cadence.
@@ -108,13 +129,15 @@ func pollEntry(
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Printf("api polling: app %s: GET %s: %v", app.Name, entry.Path, err)
-		return nil // log and skip; do not fire an event
+		emitPollFailureEvent(ctx, store, app, entry, fmt.Sprintf("connection error: %v", err))
+		return nil
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		log.Printf("api polling: app %s: GET %s: non-200 status %d", app.Name, entry.Path, resp.StatusCode)
-		return nil // log and skip; do not fire an event
+		emitPollFailureEvent(ctx, store, app, entry, fmt.Sprintf("HTTP %d from %s", resp.StatusCode, entry.Path))
+		return nil
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -266,3 +289,21 @@ func pollJsonPathToString(v interface{}) string {
 }
 
 var pollArrayIndexRe = regexp.MustCompile(`^([^\[]+)\[(\d+)\]$`)
+
+// emitPollFailureEvent writes a warn-level event for a failed API poll entry.
+func emitPollFailureEvent(ctx context.Context, store *repo.Store, app models.App, entry apptemplate.APIPollingEntry, reason string) {
+	now := time.Now().UTC()
+	ev := &models.Event{
+		ID:         uuid.NewString(),
+		Level:      "warn",
+		SourceName: app.Name,
+		SourceType: "app",
+		SourceID:   app.ID,
+		Title:      fmt.Sprintf("API poll failed — %s: %s", entry.Label, reason),
+		Payload:    fmt.Sprintf(`{"metric":%q,"path":%q,"reason":%q}`, entry.Name, entry.Path, reason),
+		CreatedAt:  now,
+	}
+	if err := store.Events.Create(ctx, ev); err != nil {
+		log.Printf("api polling: app %s: emit failure event: %v", app.Name, err)
+	}
+}

--- a/internal/scanner/snapshot/traefik.go
+++ b/internal/scanner/snapshot/traefik.go
@@ -96,6 +96,7 @@ func (s *TraefikSnapshotScanner) TakeSnapshot(ctx context.Context, entityID, ent
 	if err != nil {
 		log.Printf("traefik snapshot: fetch services for %s: %v", c.Name, err)
 	} else {
+		log.Printf("traefik snapshot: %s: %d services from API", c.Name, len(svcs))
 		presentNames := make([]string, 0, len(svcs))
 		for _, svc := range svcs {
 			if strings.HasSuffix(svc.Name, "@internal") {

--- a/migrations/040_container_component_links.sql
+++ b/migrations/040_container_component_links.sql
@@ -1,0 +1,39 @@
+-- 040_container_component_links.sql
+-- Normalises container and app→container relationships into component_links.
+--
+-- Prior to this migration:
+--   discovered_containers.infra_component_id  — container's parent (portainer/docker_engine/etc)
+--   discovered_containers.app_id              — which app this container belongs to
+-- Neither of these were reflected in component_links, so the topology chain
+-- (app → container → portainer → vm → proxmox) was only partially in the table.
+--
+-- After this migration component_links is the single source of truth:
+--   container  → infra_component  (portainer, docker_engine, etc.)
+--   app        → container        (replaces old app → docker_engine direct link)
+
+-- 1. Backfill container → parent infra_component links.
+INSERT OR IGNORE INTO component_links (parent_type, parent_id, child_type, child_id, created_at)
+SELECT ic.type, ic.id, 'container', dc.id, COALESCE(dc.created_at, datetime('now'))
+FROM discovered_containers dc
+JOIN infrastructure_components ic ON dc.infra_component_id = ic.id;
+
+-- 2. For apps already in component_links via old docker_engine_id / host_component_id
+--    backfill: switch their parent to the container when one exists.
+UPDATE component_links
+SET parent_type = 'container',
+    parent_id   = (
+        SELECT dc.id
+        FROM discovered_containers dc
+        WHERE dc.app_id = component_links.child_id
+        LIMIT 1
+    )
+WHERE child_type = 'app'
+  AND EXISTS (
+    SELECT 1 FROM discovered_containers dc WHERE dc.app_id = component_links.child_id
+  );
+
+-- 3. Insert app → container links for apps not yet in component_links.
+INSERT OR IGNORE INTO component_links (parent_type, parent_id, child_type, child_id, created_at)
+SELECT 'container', dc.id, 'app', dc.app_id, COALESCE(dc.created_at, datetime('now'))
+FROM discovered_containers dc
+WHERE dc.app_id IS NOT NULL;

--- a/migrations/041_relationship_backfill.sql
+++ b/migrations/041_relationship_backfill.sql
@@ -1,0 +1,27 @@
+-- 041_relationship_backfill.sql
+-- Backfills component_links for relationship types that were previously stored
+-- only as inline FK columns on their respective tables:
+--
+--   discovered_routes.app_id   → traefik_route → app
+--   discovered_routes.*        → traefik → traefik_route  (route's parent component)
+--   monitor_checks.app_id      → monitor → app
+--
+-- All inserts use INSERT OR IGNORE so existing links (e.g. container → app) are
+-- never overwritten.
+
+-- 1. traefik infra component → traefik_route (parent link for every route)
+INSERT OR IGNORE INTO component_links (parent_type, parent_id, child_type, child_id, created_at)
+SELECT 'traefik', infrastructure_id, 'traefik_route', id, COALESCE(created_at, datetime('now'))
+FROM discovered_routes;
+
+-- 2. traefik_route → app  (for routes that already have app_id set)
+INSERT OR IGNORE INTO component_links (parent_type, parent_id, child_type, child_id, created_at)
+SELECT 'traefik_route', id, 'app', app_id, COALESCE(created_at, datetime('now'))
+FROM discovered_routes
+WHERE app_id IS NOT NULL AND app_id != '';
+
+-- 3. monitor → app  (for monitor checks already linked to an app)
+INSERT OR IGNORE INTO component_links (parent_type, parent_id, child_type, child_id, created_at)
+SELECT 'monitor', id, 'app', app_id, COALESCE(created_at, datetime('now'))
+FROM monitor_checks
+WHERE app_id IS NOT NULL AND app_id != '';


### PR DESCRIPTION
## Summary

- **Traefik route → app linking UI** on the Relationships page Apps tab — gear panel now has a Traefik Routes section with a dropdown to link any discovered route to an app, a table showing currently linked routes with Unlink buttons, and a unified Save button
- **Route column** added to the Apps table showing which Traefik route is linked per app
- **`GET /routes`** endpoint returning all discovered routes across all Traefik components (with `rule` field fix — was missing from response, causing blank dropdown options)
- **Traefik services fix** — `DiscoverOneComponent` now also runs the snapshot scanner so services populate correctly
- **`component_links` consolidation** — all relationship writes now go through the repo layer consistently:
  - `SetDiscoveredRouteApp` / `ClearDiscoveredRouteApp` sync `traefik_route → app` in `component_links`
  - `UpsertDiscoveredRoute` syncs `traefik → traefik_route` link
  - `SyncRouteAppLink` (new) handles auto-resolved routes during Traefik discovery
  - `checks.go` `Create` / `Update` / `UpsertForComponent` sync `monitor → app` link
  - API handlers no longer do manual `component_links` writes (repo owns it)
- **Migration 040** — normalises container/app relationships into `component_links`
- **Migration 041** — backfills `traefik → traefik_route`, `traefik_route → app`, and `monitor → app` into `component_links` for existing data

## Test plan

- [ ] Rebuild Go server and restart — confirm `GET /api/v1/routes` returns routes with `rule` field populated
- [ ] Open Relationships → Apps tab — confirm Route column shows linked routes in accent colour
- [ ] Click gear on an app — confirm Traefik Routes section shows dropdown with all unlinked routes grouped
- [ ] Link a route to an app via dropdown + Save — confirm it appears in the linked routes table in the panel and in the Route column on the main table
- [ ] Unlink a route via the Unlink button — confirm it returns to the dropdown
- [ ] Run Discover Now on a Traefik component — confirm services tab populates
- [ ] Verify `component_links` table contains `traefik_route` and `monitor` parent entries after migration 041 runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)