### PR TITLE
fix(test): add missing mock methods to enrichMockRouteRepo

### DIFF
--- a/internal/infra/docker_enrichment_test.go
+++ b/internal/infra/docker_enrichment_test.go
@@ -134,6 +134,10 @@ func (m *enrichMockRouteRepo) ListDiscoveredRoutesByStatus(_ context.Context, _ 
 }
 func (m *enrichMockRouteRepo) SetDiscoveredRouteApp(_ context.Context, _, _ string) error { return nil }
 func (m *enrichMockRouteRepo) ClearDiscoveredRouteApp(_ context.Context, _ string) error  { return nil }
+func (m *enrichMockRouteRepo) ListByAppID(_ context.Context, _ string) ([]*models.DiscoveredRoute, error) {
+	return nil, nil
+}
+func (m *enrichMockRouteRepo) SyncRouteAppLink(_ context.Context, _, _, _ string) {}
 
 type enrichMockResourceRepo struct {
 	backfilled int64


### PR DESCRIPTION
## Summary

- Adds `ListByAppID` and `SyncRouteAppLink` stub methods to `enrichMockRouteRepo` in the infra package tests
- These methods were added to the `DiscoveredRouteRepo` interface as part of the component_links consolidation in #263 but the test mock was not updated, causing `go test ./...` to fail with a build error

## Test plan

- [ ] `go test ./...` passes with no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)