### PR TITLE
feat(dashboard): rework dashboard layout and digest report

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -252,6 +252,8 @@ export interface AppSummary {
   last_event_text: string | null
   stats: AppStat[] | null
   sparkline: number[]
+  checks_up: number
+  checks_total: number
 }
 
 export interface CheckSummary {
@@ -497,6 +499,25 @@ export interface ProxmoxTaskFailure {
   node: string
 }
 
+export interface ProxmoxBackupJob {
+  upid: string
+  object_id?: string
+  exit_status: string
+  start_time: number
+  end_time?: number
+  node: string
+}
+
+export interface ProxmoxBackupFile {
+  volid: string
+  vmid: number
+  ctime: number
+  size: number
+  format: string
+  node: string
+  store: string
+}
+
 // ── Synology Detail ──────────────────────────────────────────────────────────
 
 export interface SynologyMemory {
@@ -565,6 +586,29 @@ export interface DiscoveredContainer {
   networks: string | null
   restart_policy: string | null
   docker_created_at: string | null
+}
+
+export interface ContainerDetail {
+  id: string
+  infra_component_id: string
+  source_type: string
+  container_id: string
+  container_name: string
+  image: string
+  status: string
+  app_id: string | null
+  last_seen_at: string
+  docker_created_at: string | null
+  image_digest: string | null
+  registry_digest: string | null
+  image_update_available: boolean
+  image_last_checked_at: string | null
+  ports: string | null
+  networks: string | null
+  volumes: string | null
+  restart_policy: string | null
+  labels: string | null
+  env_vars: string | null
 }
 
 export interface LinkAppInput {

--- a/frontend/src/components/AppWidget.tsx
+++ b/frontend/src/components/AppWidget.tsx
@@ -7,19 +7,6 @@ function monogram(name: string): string {
   return (words[0][0] + words[1][0]).toUpperCase()
 }
 
-function sparklinePoints(data: number[], width: number, height: number): string {
-  if (!data || data.length < 2) return ''
-  const max = Math.max(...data, 1)
-  const n = data.length
-  return data
-    .map((v, i) => {
-      const x = ((i / (n - 1)) * width).toFixed(1)
-      const y = (height - 2 - (v / max) * (height - 4)).toFixed(1)
-      return `${x},${y}`
-    })
-    .join(' ')
-}
-
 interface Props {
   app: AppSummary
   onClick: () => void
@@ -28,80 +15,58 @@ interface Props {
 export function AppWidget({ app, onClick }: Props) {
   const [iconFailed, setIconFailed] = useState(false)
 
-  const pts = sparklinePoints(app.sparkline, 180, 28)
-  const closedPts = pts ? `${pts} 180,28 0,28` : ''
-
-  const sparkColor =
-    app.status === 'warn'
-      ? 'var(--yellow)'
-      : app.status === 'down'
-      ? 'var(--red)'
-      : 'var(--accent)'
+  const showIcon = app.icon_url && !iconFailed
 
   const dotClass =
-    app.status === 'online' ? 'green' : app.status === 'warn' ? 'yellow' : app.status === 'down' ? 'red' : 'grey'
+    app.status === 'online' ? 'green'
+    : app.status === 'warn' ? 'yellow'
+    : app.status === 'down' ? 'red'
+    : 'grey'
 
   const statusText =
-    app.status === 'online' ? 'Online' : app.status === 'warn' ? 'Warn' : app.status === 'down' ? 'Down' : 'Unknown'
+    app.status === 'online' ? 'Online'
+    : app.status === 'warn' ? 'Warn'
+    : app.status === 'down' ? 'Down'
+    : 'Unknown'
 
-  const lastEventStyle: Record<string, string> =
-    app.status === 'warn' ? { color: 'var(--yellow)' } : app.status === 'down' ? { color: 'var(--red)' } : {}
-
-  const showIcon = app.icon_url && !iconFailed
+  const hasChecks   = app.checks_total > 0
+  const allUp       = app.checks_up === app.checks_total
+  const checksColor = !hasChecks ? '' : allUp ? 'ok' : app.status === 'down' ? 'down' : 'warn'
 
   return (
     <div
-      className={`app-widget${app.status !== 'online' ? ` ${app.status}` : ''}`}
+      className={`app-row${app.status !== 'online' ? ` ${app.status}` : ''}`}
       onClick={onClick}
     >
-      <div className="app-widget-header">
-        <div className="app-icon">
-          {showIcon ? (
-            <img
-              src={app.icon_url}
-              alt={app.name}
-              className="app-icon-img"
-              onError={() => setIconFailed(true)}
-            />
-          ) : (
-            monogram(app.name)
-          )}
-        </div>
-        <div className="app-name">{app.name}</div>
-        <div className={`app-status ${app.status}`}>
-          <div className={`dot ${dotClass}`} />
-          {statusText}
-        </div>
+      <div className="ar-icon">
+        {showIcon ? (
+          <img
+            src={app.icon_url}
+            alt={app.name}
+            className="ar-icon-img"
+            onError={() => setIconFailed(true)}
+          />
+        ) : (
+          monogram(app.name)
+        )}
       </div>
 
-      {app.stats && app.stats.length > 0 && (
-        <div className="app-widget-stats">
-          {app.stats.slice(0, 4).map(stat => (
-            <div key={stat.label} className="stat-item">
-              <div className="stat-label">{stat.label}</div>
-              <div
-                className="stat-value"
-                style={stat.color ? { color: stat.color } : {}}
-              >
-                {stat.value}
-              </div>
-            </div>
-          ))}
+      <div className="ar-body">
+        <div className="ar-top">
+          <span className="ar-name">{app.name}</span>
+          <span className={`ar-dot ${dotClass}`} title={statusText} />
         </div>
-      )}
 
-      {pts && (
-        <svg className="app-widget-sparkline" viewBox="0 0 180 28" preserveAspectRatio="none">
-          <polyline points={pts} fill="none" stroke={sparkColor} strokeWidth="1.5" opacity="0.7" />
-          <polyline points={closedPts} fill={sparkColor} stroke="none" opacity="0.07" />
-        </svg>
-      )}
-
-      {app.last_event_text && (
-        <div className="app-last-event" style={lastEventStyle}>
-          {app.last_event_text}
+        <div className="ar-event">
+          {app.last_event_text ?? <span className="ar-event-empty">No recent events</span>}
         </div>
-      )}
+
+        {hasChecks && (
+          <div className={`ar-checks ${checksColor}`}>
+            ✓ {app.checks_up}/{app.checks_total}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/SummaryCard.tsx
+++ b/frontend/src/components/SummaryCard.tsx
@@ -1,30 +1,10 @@
 import type { SummaryBarItem } from '../api/types'
 
-function sparklineColor(label: string): string {
-  const l = label.toLowerCase()
-  if (l.includes('error') || l.includes('fail') || l.includes('down')) return 'var(--red)'
-  if (l.includes('uptime') || l.includes('backup') || l.includes('success')) return 'var(--green)'
-  return 'var(--accent)'
-}
-
 function valueColorClass(label: string): string {
   const l = label.toLowerCase()
   if (l.includes('error') || l.includes('fail') || l.includes('down')) return 'summary-value red'
   if (l.includes('uptime') || l.includes('backup') || l.includes('success')) return 'summary-value green'
   return 'summary-value'
-}
-
-function sparklinePoints(data: number[], width: number, height: number): string {
-  if (!data || data.length < 2) return ''
-  const max = Math.max(...data, 1)
-  const n = data.length
-  return data
-    .map((v, i) => {
-      const x = ((i / (n - 1)) * width).toFixed(1)
-      const y = (height - 2 - (v / max) * (height - 4)).toFixed(1)
-      return `${x},${y}`
-    })
-    .join(' ')
 }
 
 interface Props {

--- a/frontend/src/components/SummaryCard.tsx
+++ b/frontend/src/components/SummaryCard.tsx
@@ -32,21 +32,11 @@ interface Props {
 }
 
 export function SummaryCard({ item }: Props) {
-  const color = sparklineColor(item.label)
-  const pts = sparklinePoints(item.sparkline, 120, 24)
-  const closedPts = pts ? `${pts} 120,24 0,24` : ''
-
   return (
     <div className="summary-card">
       <div className="summary-label">{item.label}</div>
       <div className={valueColorClass(item.label)}>{item.count}</div>
       <div className="summary-sub">{item.sub}</div>
-      {pts && (
-        <svg className="sparkline" viewBox="0 0 120 24" preserveAspectRatio="none">
-          <polyline points={pts} fill="none" stroke={color} strokeWidth="1.5" opacity="0.8" />
-          <polyline points={closedPts} fill={color} stroke="none" opacity="0.08" />
-        </svg>
-      )}
     </div>
   )
 }

--- a/frontend/src/pages/Apps.tsx
+++ b/frontend/src/pages/Apps.tsx
@@ -2,8 +2,8 @@ import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { Topbar } from '../components/Topbar'
-import { apps as appsApi, appTemplates as templatesApi, dashboard as dashboardApi } from '../api/client'
-import type { App, AppTemplate } from '../api/types'
+import { apps as appsApi, appTemplates as templatesApi, dashboard as dashboardApi, checks as checksApi, events as eventsApi } from '../api/client'
+import type { App, AppTemplate, MonitorCheck, Event } from '../api/types'
 import { AppSettingsModal } from './AppDetail'
 import { SlidePanel } from '../components/SlidePanel'
 import './Apps.css'
@@ -69,7 +69,9 @@ function AddAppModal({ open, onClose, onCreated }: AddAppModalProps) {
   const [baseUrl, setBaseUrl] = useState('')
   const [apiUrl, setApiUrl] = useState('')
   const [apiKey, setApiKey] = useState('')
-  const [rateLimit, setRateLimit] = useState('0')
+  const [rateLimit, setRateLimit] = useState('100')
+  const [addUrlCheck, setAddUrlCheck] = useState(false)
+  const [addSslCheck, setAddSslCheck] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState('')
 
@@ -105,6 +107,34 @@ function AddAppModal({ open, onClose, onCreated }: AddAppModalProps) {
         config: Object.keys(config).length > 0 ? config : undefined,
         rate_limit: parseInt(rateLimit, 10) || 0,
       })
+
+      // Auto-create monitor checks if pills selected
+      const url = baseUrl.trim()
+      if (url) {
+        const checkPromises = []
+        if (addUrlCheck) {
+          checkPromises.push(checksApi.create({
+            app_id: app.id,
+            name: `${appName.trim()} — uptime`,
+            type: 'url',
+            target: url,
+            interval_secs: 60,
+            enabled: true,
+          }))
+        }
+        if (addSslCheck && url.startsWith('https')) {
+          checkPromises.push(checksApi.create({
+            app_id: app.id,
+            name: `SSL — ${new URL(url).hostname}`,
+            type: 'ssl',
+            target: url,
+            interval_secs: 60,
+            enabled: true,
+          }))
+        }
+        await Promise.all(checkPromises)
+      }
+
       setCreatedApp(app)
       onCreated(app)
       setStep('done')
@@ -129,7 +159,8 @@ function AddAppModal({ open, onClose, onCreated }: AddAppModalProps) {
 
   function handleAddAnother() {
     setStep('setup'); setAppName(''); setSelectedTemplateId('')
-    setBaseUrl(''); setApiUrl(''); setApiKey(''); setRateLimit('0')
+    setBaseUrl(''); setApiUrl(''); setApiKey(''); setRateLimit('100')
+    setAddUrlCheck(false); setAddSslCheck(false)
     setCreatedApp(null); setCopied(false); setSubmitError('')
   }
 
@@ -243,7 +274,7 @@ function AddAppModal({ open, onClose, onCreated }: AddAppModalProps) {
           <label className="modal-label" style={{ marginTop: 16 }}>
             API Key <span className="modal-hint">(optional — used for API polling widgets)</span>
           </label>
-          <input className="modal-input modal-input-mono" placeholder="your-api-key"
+          <input className="modal-input" placeholder="your-api-key"
             type="password" autoComplete="new-password"
             value={apiKey} onChange={e => setApiKey(e.target.value)} />
 
@@ -252,6 +283,32 @@ function AddAppModal({ open, onClose, onCreated }: AddAppModalProps) {
           </label>
           <input className="modal-input modal-input-sm" type="number" min="0"
             value={rateLimit} onChange={e => setRateLimit(e.target.value)} />
+
+          {baseUrl.trim() && (
+            <>
+              <label className="modal-label" style={{ marginTop: 20 }}>
+                Monitor checks <span className="modal-hint">(auto-create based on App URL)</span>
+              </label>
+              <div className="modal-check-pills">
+                <button
+                  type="button"
+                  className={`modal-check-pill${addUrlCheck ? ' active' : ''}`}
+                  onClick={() => setAddUrlCheck(v => !v)}
+                >
+                  URL Check
+                </button>
+                {baseUrl.trim().startsWith('https') && (
+                  <button
+                    type="button"
+                    className={`modal-check-pill${addSslCheck ? ' active' : ''}`}
+                    onClick={() => setAddSslCheck(v => !v)}
+                  >
+                    SSL Check
+                  </button>
+                )}
+              </div>
+            </>
+          )}
 
           {submitError && <div className="modal-error">{submitError}</div>}
         </>
@@ -279,10 +336,26 @@ function AddAppModal({ open, onClose, onCreated }: AddAppModalProps) {
 
 // ── Apps Page ─────────────────────────────────────────────────────────────────
 
+type TimeFilter = 'day' | 'week' | 'month'
+
+function formatRelative(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return `${Math.floor(hrs / 24)}d ago`
+}
+
 export function Apps() {
   const navigate = useNavigate()
+  const [timeFilter, setTimeFilter] = useState<TimeFilter>('week')
   const [appList, setAppList] = useState<App[]>([])
   const [statusMap, setStatusMap] = useState<Record<string, 'online' | 'warn' | 'down'>>({})
+  const [allChecks, setAllChecks] = useState<MonitorCheck[]>([])
+  const [recentEvents, setRecentEvents] = useState<Event[]>([])
+  const [eventCounts, setEventCounts] = useState<Record<string, number> | null>(null)
   const [loading, setLoading] = useState(true)
   const [showAdd, setShowAdd] = useState(false)
 
@@ -297,24 +370,76 @@ export function Apps() {
       .then(res => setAppList(res.data))
       .catch(console.error)
       .finally(() => setLoading(false))
-    dashboardApi.summary()
+    const ms = timeFilter === 'day' ? 86400000 : timeFilter === 'month' ? 30 * 86400000 : 7 * 86400000
+    const since = new Date(Date.now() - ms).toISOString()
+
+    dashboardApi.summary(timeFilter)
       .then(res => {
         const map: Record<string, 'online' | 'warn' | 'down'> = {}
         for (const a of res.apps) map[a.id] = a.status
         setStatusMap(map)
       })
-      .catch(() => { /* status is best-effort */ })
-  }, [tick])
+      .catch(() => {})
+    checksApi.list()
+      .then(res => setAllChecks(res.data))
+      .catch(() => {})
+    eventsApi.list({ source_type: 'app', limit: 20, from: since })
+      .then(res => setRecentEvents(res.data))
+      .catch(() => {})
+    Promise.all(
+      (['info', 'warn', 'error', 'critical'] as const).map(level =>
+        eventsApi.list({ source_type: 'app', level, from: since, limit: 1 })
+          .then(res => [level, res.total] as const)
+          .catch(() => [level, 0] as const)
+      )
+    ).then(results => setEventCounts(Object.fromEntries(results)))
+  }, [tick, timeFilter])
 
   return (
     <>
-      <Topbar title="Apps" />
+      <Topbar title="Apps" timeFilter={timeFilter} onTimeFilter={setTimeFilter} />
       <div className="content">
         <div className="section-header">
           <span className="section-title">Configured Apps</span>
           <button className="section-action" onClick={() => { setAddKey(k => k + 1); setShowAdd(true) }}>+ Add app</button>
         </div>
 
+        {/* ── Summary strip ── */}
+        {!loading && appList.length > 0 && (() => {
+          const total    = appList.length
+          const healthy  = appList.filter(a => (statusMap[a.id] ?? 'online') === 'online').length
+          const warnApps = appList.filter(a => statusMap[a.id] === 'warn').length
+          const downApps = appList.filter(a => statusMap[a.id] === 'down').length
+          const checksUp   = allChecks.filter(c => c.last_status === 'up').length
+          const checksDown = allChecks.filter(c => c.last_status === 'down' || c.last_status === 'warn').length
+          const lastEvent  = recentEvents[0]
+          return (
+            <div className="apps-stats-strip">
+              <span className="apps-stats-pill">{total} apps</span>
+              <span className="apps-stats-pill" style={{ color: 'var(--green)' }}>{healthy} healthy</span>
+              {warnApps > 0 && <span className="apps-stats-pill" style={{ color: 'var(--yellow)' }}>{warnApps} warn</span>}
+              {downApps > 0 && <span className="apps-stats-pill" style={{ color: 'var(--red)' }}>{downApps} down</span>}
+              {allChecks.length > 0 && <span className="apps-stats-sep" />}
+              {allChecks.length > 0 && <span className="apps-stats-pill" style={{ color: 'var(--green)' }}>{checksUp} checks up</span>}
+              {checksDown > 0 && <span className="apps-stats-pill" style={{ color: 'var(--red)' }}>{checksDown} checks down</span>}
+              {eventCounts !== null && <span className="apps-stats-sep" />}
+              {eventCounts !== null && (['info', 'warn', 'error', 'critical'] as const).map(level => {
+                const count = eventCounts[level] ?? 0
+                const color = level === 'info' ? 'var(--accent)' : level === 'warn' ? 'var(--yellow)' : 'var(--red)'
+                const label = level === 'critical' ? 'crit' : level
+                return (
+                  <span key={level} className="apps-stats-pill" style={{ color, cursor: 'pointer' }}
+                    onClick={() => navigate(`/events?source_type=app&level=${level}`)}>
+                    {count} {label}
+                  </span>
+                )
+              })}
+              {lastEvent && <><span className="apps-stats-sep" /><span className="apps-stats-pill">{formatRelative(lastEvent.created_at)}</span></>}
+            </div>
+          )
+        })()}
+
+        <hr style={{ border: 'none', borderTop: '1px solid var(--border)', margin: '0 0 16px' }} />
         <div className="apps-page-grid widget-grid">
           {loading ? (
             [0, 1, 2].map(i => (
@@ -371,6 +496,8 @@ export function Apps() {
             })
           )}
         </div>
+
+
       </div>
 
       <AddAppModal
@@ -378,7 +505,7 @@ export function Apps() {
         open={showAdd}
         onClose={() => setShowAdd(false)}
         onCreated={app => {
-          setAppList(prev => [...prev, app])
+          setAppList(prev => prev.some(a => a.id === app.id) ? prev : [...prev, app])
           // Panel stays open to show the done step with webhook URL
         }}
       />

--- a/frontend/src/pages/Checks.tsx
+++ b/frontend/src/pages/Checks.tsx
@@ -2,9 +2,8 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { Topbar } from '../components/Topbar'
-import { SSLRow } from '../components/SSLRow'
 import { checks as checksApi, apps as appsApi, appTemplates as appTemplatesApi } from '../api/client'
-import type { App, MonitorCheck, SSLCert } from '../api/types'
+import type { App, MonitorCheck } from '../api/types'
 import { CheckForm } from '../components/CheckForm'
 import { SlidePanel } from '../components/SlidePanel'
 import {
@@ -47,107 +46,10 @@ function statusClass(status: string | null): string {
   return 'monitor-status-block unknown'
 }
 
-function extractSSLCerts(checkList: MonitorCheck[]): SSLCert[] {
-  return checkList
-    .filter(c => c.type === 'ssl' && c.last_result)
-    .flatMap(c => {
-      try {
-        const result = JSON.parse(c.last_result!) as { days_remaining?: number; expires_at?: string }
-        if (result.days_remaining == null) return []
-        const domain = c.target.replace(/^https?:\/\//, '').split('/')[0]
-        const expiresAt = result.expires_at
-          ? new Date(result.expires_at).toISOString().split('T')[0]
-          : ''
-        return [{
-          domain,
-          days_remaining: result.days_remaining,
-          expires_at: expiresAt,
-          status: c.last_status ?? 'unknown',
-        } as SSLCert]
-      } catch {
-        return []
-      }
-    })
-    .sort((a, b) => a.days_remaining - b.days_remaining)
-}
-
-import { CheckTypeIcon } from '../components/CheckTypeIcon'
-
-// ── Check card ────────────────────────────────────────────────────────────────
-
-interface CheckCardProps {
-  check: MonitorCheck
-  runningIds: Set<string>
-  onToggleEnabled: () => void
-  onRun: () => void
-  onClick: () => void
-  onSettings: () => void
-}
-
-function CheckCard({ check, runningIds, onToggleEnabled, onRun, onClick, onSettings }: CheckCardProps) {
-  const disabled = !check.enabled
-
-  return (
-    <div className={`check-card${disabled ? ' disabled' : ''}`} onClick={onClick}>
-
-      {/* Top row: type icon + name */}
-      <div className="check-card-top">
-        <CheckTypeIcon type={check.type} />
-        <span className="check-card-name">{check.name}</span>
-        {disabled && <span className="check-paused-badge">PAUSED</span>}
-      </div>
-
-      {/* Target */}
-      <div className="check-card-target" title={check.target}>
-        {check.target}
-        {check.source_component_id && <span className="check-card-target-tag traefik">Traefik</span>}
-        {check.skip_tls_verify && <span className="check-card-target-tag warn">self-signed</span>}
-      </div>
-
-      {/* Status + type row (between target and buttons) */}
-      <div className="check-card-status-row">
-        <div className={statusClass(check.last_status)}>
-          {statusLabel(check)}
-        </div>
-        <span className={`check-type-badge check-type-${check.type}`}>
-          {check.type.toUpperCase()}
-        </span>
-      </div>
-
-      {/* Footer: interval · last checked · run · pause · settings */}
-      <div className="check-card-footer">
-        <span className="check-card-interval">every {check.interval_secs}s</span>
-        <span className="check-card-last">{formatEventTime(check.last_checked_at)}</span>
-        <div className="check-card-footer-actions">
-          <button
-            className={`check-run-btn${runningIds.has(check.id) ? ' running' : ''}`}
-            title="Run now"
-            onClick={e => { e.stopPropagation(); onRun() }}
-            disabled={runningIds.has(check.id)}
-          >
-            {runningIds.has(check.id) ? <span className="check-spinner" /> : '▶'}
-          </button>
-          <button
-            className={`check-toggle-btn${check.enabled ? ' enabled' : ' paused'}`}
-            title={check.enabled ? 'Pause check' : 'Resume check'}
-            onClick={e => { e.stopPropagation(); onToggleEnabled() }}
-          >
-            {check.enabled ? '⏸' : '▶'}
-          </button>
-          <button
-            className="check-settings-btn"
-            title="Settings"
-            onClick={e => { e.stopPropagation(); onSettings() }}
-          >
-            ⚙
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
 
 // ── Main page ─────────────────────────────────────────────────────────────────
+
+type StatusFilter = 'all' | 'up' | 'down' | 'paused'
 
 export function Checks() {
   const navigate = useNavigate()
@@ -156,6 +58,11 @@ export function Checks() {
   const [loading, setLoading] = useState(true)
 
   const [appList, setAppList] = useState<App[]>([])
+
+  // Filter state
+  const [search, setSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+  const [typeFilter, setTypeFilter] = useState<string>('all')
 
   // Add form
   const [showAddForm, setShowAddForm] = useState(false)
@@ -184,8 +91,6 @@ export function Checks() {
       .then(res => setAppList(res.data))
       .catch(() => {})
   }, [tick])
-
-  const sslCerts = extractSSLCerts(checkList)
 
   // ── Add form ──
 
@@ -262,43 +167,114 @@ export function Checks() {
 
         <div className="section-header">
           <span className="section-title">Active Checks</span>
+          {!loading && checkList.length > 0 && (() => {
+            const up     = checkList.filter(c => c.last_status === 'up').length
+            const down   = checkList.filter(c => c.last_status === 'down' || c.last_status === 'warn').length
+            const paused = checkList.filter(c => !c.enabled).length
+            const byType = (['url','ssl','dns','ping'] as const).map(t => ({ t, n: checkList.filter(c => c.type === t).length })).filter(x => x.n > 0)
+            return (
+              <span className="checks-header-stats">
+                <span style={{ color: 'var(--green)' }}>{up} up</span>
+                {down > 0 && <><span className="checks-header-dot" /><span style={{ color: 'var(--red)' }}>{down} down</span></>}
+                {paused > 0 && <><span className="checks-header-dot" /><span style={{ color: 'var(--text3)' }}>{paused} paused</span></>}
+                <span className="checks-header-sep" />
+                {byType.map(({ t, n }) => <span key={t}>{n} {t.toUpperCase()}</span>)}
+              </span>
+            )
+          })()}
           <button className="section-action" onClick={() => setShowAddForm(prev => !prev)}>
             + Add check
           </button>
         </div>
 
+        {/* ── Filter bar ── */}
+        {!loading && checkList.length > 0 && (
+          <div className="checks-filter-bar">
+            <input
+              className="checks-search"
+              placeholder="Search name or target…"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+            />
+            <div className="checks-filter-pills">
+              {(['all', 'up', 'down', 'paused'] as const).map(s => (
+                <button key={s} className={`checks-filter-pill${statusFilter === s ? ' active' : ''}`}
+                  onClick={() => setStatusFilter(s)}>
+                  {s === 'all' ? 'All' : s.charAt(0).toUpperCase() + s.slice(1)}
+                </button>
+              ))}
+              <span style={{ width: 1, background: 'var(--border)', alignSelf: 'stretch', margin: '0 4px' }} />
+              {(['url', 'ssl', 'dns', 'ping'] as const).map(t => (
+                <button key={t} className={`checks-filter-pill${typeFilter === t ? ' active' : ''}`}
+                  onClick={() => setTypeFilter(cur => cur === t ? 'all' : t)}>
+                  {t.toUpperCase()}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
         {loading ? (
           <div className="checks-empty"><span>Loading…</span></div>
         ) : checkList.length === 0 ? (
           <div className="checks-empty"><span>No monitor checks configured yet.</span></div>
-        ) : (
-          <div className="checks-grid">
-            {checkList.map(check => (
-              <CheckCard
-                key={check.id}
-                check={check}
-                runningIds={runningIds}
-                onToggleEnabled={() => void handleToggleEnabled(check)}
-                onRun={() => void handleRun(check.id)}
-                onClick={() => navigate(`/checks/${check.id}`)}
-                onSettings={() => navigate(`/checks/${check.id}`)}
-              />
-            ))}
-          </div>
-        )}
+        ) : (() => {
+          const q = search.toLowerCase()
+          const filtered = checkList.filter(c => {
+            if (typeFilter !== 'all' && c.type !== typeFilter) return false
+            if (statusFilter === 'up' && c.last_status !== 'up') return false
+            if (statusFilter === 'down' && c.last_status !== 'down' && c.last_status !== 'warn') return false
+            if (statusFilter === 'paused' && c.enabled) return false
+            if (q && !c.name.toLowerCase().includes(q) && !c.target.toLowerCase().includes(q)) return false
+            return true
+          })
+          if (filtered.length === 0) return (
+            <div className="checks-empty"><span>No checks match your filters.</span></div>
+          )
+          return (
+            <div className="checks-table-wrap">
+              <table className="checks-table">
+                <thead>
+                  <tr>
+                    <th>Status</th>
+                    <th>Name</th>
+                    <th>Target</th>
+                    <th>Type</th>
+                    <th>Interval</th>
+                    <th>Last Checked</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map(check => (
+                    <tr key={check.id} style={{ cursor: 'pointer' }} onClick={() => navigate(`/checks/${check.id}`)}>
+                      <td><div className={statusClass(check.last_status)} style={{ display: 'inline-block' }}>{statusLabel(check)}</div></td>
+                      <td className="checks-table-name">{check.name}{!check.enabled && <span className="check-paused-badge" style={{ marginLeft: 6 }}>PAUSED</span>}</td>
+                      <td className="checks-table-target" title={check.target}>{check.target}</td>
+                      <td><span className={`check-type-badge check-type-${check.type}`}>{check.type.toUpperCase()}</span></td>
+                      <td>{check.interval_secs}s</td>
+                      <td>{formatEventTime(check.last_checked_at)}</td>
+                      <td>
+                        <div className="checks-table-actions" onClick={e => e.stopPropagation()}>
+                          <button className={`check-run-btn${runningIds.has(check.id) ? ' running' : ''}`} title="Run now"
+                            onClick={() => void handleRun(check.id)} disabled={runningIds.has(check.id)}>
+                            {runningIds.has(check.id) ? <span className="check-spinner" /> : '▶'}
+                          </button>
+                          <button className={`check-toggle-btn${check.enabled ? ' enabled' : ' paused'}`}
+                            title={check.enabled ? 'Pause' : 'Resume'}
+                            onClick={() => void handleToggleEnabled(check)}>
+                            {check.enabled ? '⏸' : '▶'}
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )
+        })()}
 
-        {sslCerts.length > 0 && (
-          <>
-            <div className="section-header" style={{ marginTop: 24 }}>
-              <span className="section-title">SSL Certificates</span>
-            </div>
-            <div className="ssl-panel">
-              {sslCerts.map(cert => (
-                <SSLRow key={cert.domain} cert={cert} />
-              ))}
-            </div>
-          </>
-        )}
 
       </div>
 

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -97,56 +97,133 @@
 /* ── WIDGET GRID ── */
 .widget-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 8px;
 }
 
-/* ── APP WIDGET ── */
-.app-widget {
+/* ── APP CARD ── */
+.app-row {
   background: var(--bg2);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 14px;
+  padding: 10px 12px;
   cursor: pointer;
   transition: all 0.15s;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: flex-start;
   gap: 10px;
   position: relative;
   overflow: hidden;
   animation: fadeUp 0.3s ease both;
 }
 
-.app-widget::before {
+/* status stripe along the top */
+.app-row::before {
   content: '';
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
+  top: 0; left: 0; right: 0;
   height: 2px;
   background: var(--green);
   opacity: 0;
   transition: opacity 0.15s;
 }
 
-.app-widget:hover { border-color: var(--border2); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
-.app-widget:hover::before { opacity: 1; }
-.app-widget.warn::before { background: var(--yellow); opacity: 1; }
-.app-widget.down::before { background: var(--red); opacity: 1; }
+.app-row:hover { border-color: var(--border2); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(0,0,0,0.25); }
+.app-row:hover::before { opacity: 1; }
+.app-row.warn::before  { background: var(--yellow); opacity: 1; }
+.app-row.down::before  { background: var(--red);    opacity: 1; }
 
-.app-widget:nth-child(1) { animation-delay: 0.05s; }
-.app-widget:nth-child(2) { animation-delay: 0.10s; }
-.app-widget:nth-child(3) { animation-delay: 0.15s; }
-.app-widget:nth-child(4) { animation-delay: 0.20s; }
-.app-widget:nth-child(5) { animation-delay: 0.25s; }
-.app-widget:nth-child(6) { animation-delay: 0.30s; }
+.app-row:nth-child(1) { animation-delay: 0.04s; }
+.app-row:nth-child(2) { animation-delay: 0.08s; }
+.app-row:nth-child(3) { animation-delay: 0.12s; }
+.app-row:nth-child(4) { animation-delay: 0.16s; }
+.app-row:nth-child(5) { animation-delay: 0.20s; }
+.app-row:nth-child(6) { animation-delay: 0.24s; }
 
-.app-widget-header {
+/* card inner layout: icon left, stacked body right */
+.ar-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 7px;
+  background: var(--bg4);
+  border: 1px solid var(--border);
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text2);
+  flex-shrink: 0;
+  overflow: hidden;
+  margin-top: 1px;
 }
 
+.ar-icon-img {
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+}
+
+.ar-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.ar-top {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ar-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1;
+}
+
+.ar-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.ar-dot.green  { background: var(--green); }
+.ar-dot.yellow { background: var(--yellow); }
+.ar-dot.red    { background: var(--red); }
+.ar-dot.grey   { background: var(--text3); }
+
+.ar-event {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.4;
+}
+
+.ar-event-empty { opacity: 0.4; }
+
+.ar-checks {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+}
+.ar-checks.ok   { color: var(--green); }
+.ar-checks.warn { color: var(--yellow); }
+.ar-checks.down { color: var(--red); }
+
+/* legacy classes used elsewhere */
 .app-icon {
   width: 28px;
   height: 28px;
@@ -170,80 +247,16 @@
   object-fit: contain;
 }
 
-.app-name {
-  font-weight: 500;
-  font-size: 13px;
-  color: var(--text);
-  flex: 1;
-}
-
-.app-status {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-family: var(--mono);
-  font-size: 10px;
-}
-
 .dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
   flex-shrink: 0;
 }
-
-.dot.green { background: var(--green); }
+.dot.green  { background: var(--green); }
 .dot.yellow { background: var(--yellow); }
-.dot.red { background: var(--red); }
-.dot.grey { background: var(--text3); }
-
-.app-status.online { color: var(--green); }
-.app-status.warn { color: var(--yellow); }
-.app-status.down { color: var(--red); }
-.app-status.unknown { color: var(--text3); }
-
-.app-widget-stats {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 6px;
-}
-
-.stat-item {
-  background: var(--bg3);
-  border-radius: 4px;
-  padding: 6px 8px;
-}
-
-.stat-label {
-  font-family: var(--mono);
-  font-size: 9px;
-  color: var(--text3);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  margin-bottom: 2px;
-}
-
-.stat-value {
-  font-family: var(--mono);
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text);
-  line-height: 1;
-}
-
-.app-widget-sparkline {
-  height: 28px;
-  width: 100%;
-}
-
-.app-last-event {
-  font-size: 11px;
-  color: var(--text3);
-  font-family: var(--mono);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+.dot.red    { background: var(--red); }
+.dot.grey   { background: var(--text3); }
 
 /* ── HOST WIDGET ── */
 .host-widget {
@@ -565,11 +578,25 @@
   gap: 20px;
 }
 
+/* ── EVENTS + MONITOR CHECKS SIDE BY SIDE ── */
+.dash-signals-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  align-items: start;
+}
+
+.dash-signals-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
 /* ── EVENT SEVERITY COUNTS ── */
 .event-counts-row {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 10px;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
 }
 
 .event-count-card {
@@ -580,54 +607,49 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
-  transition: border-color 0.15s;
+  cursor: pointer;
+  transition: all 0.15s;
 }
 
-.event-count-card:hover { border-color: var(--border2); }
+.event-count-card:hover { border-color: var(--border2); transform: translateY(-1px); }
 
-.event-count-icon {
-  width: 20px;
-  height: 20px;
-  opacity: 0.6;
-  margin-bottom: 4px;
-  flex-shrink: 0;
+/* top border accent — mirrors check-rollup-card */
+.event-count-card.info     { border-top: 3px solid var(--accent); }
+.event-count-card.warn     { border-top: 3px solid var(--yellow); }
+.event-count-card.error    { border-top: 3px solid var(--red); }
+.event-count-card.critical { border-top: 3px solid var(--red); }
+
+.event-count-type {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
-
-.event-count-card.info     .event-count-icon { stroke: var(--accent); }
-.event-count-card.warn     .event-count-icon { stroke: var(--yellow); }
-.event-count-card.error    .event-count-icon { stroke: var(--red); }
-.event-count-card.critical .event-count-icon { stroke: var(--red); }
 
 .event-count-value {
   font-family: var(--mono);
-  font-size: 28px;
+  font-size: 24px;
   font-weight: 600;
   line-height: 1;
 }
 
-.event-count-label {
+.event-count-meta {
   font-family: var(--mono);
   font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
   color: var(--text3);
 }
 
-.event-count-card.info    .event-count-value { color: var(--accent); }
-.event-count-card.warn    .event-count-value { color: var(--yellow); }
-.event-count-card.error   .event-count-value { color: var(--red); }
+.event-count-card.info     .event-count-value { color: var(--accent); }
+.event-count-card.warn     .event-count-value { color: var(--yellow); }
+.event-count-card.error    .event-count-value { color: var(--red); }
 .event-count-card.critical .event-count-value { color: var(--red); }
-
-.event-count-card.info    { border-left: 3px solid var(--accent); }
-.event-count-card.warn    { border-left: 3px solid var(--yellow); }
-.event-count-card.error   { border-left: 3px solid var(--red); }
-.event-count-card.critical { border-left: 3px solid var(--red); opacity: 0.85; }
 
 /* ── CHECK ROLLUP CARDS ── */
 .check-rollup-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 10px;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
 }
 
 .check-rollup-card {
@@ -640,6 +662,7 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  border-top-width: 3px;
 }
 
 .check-rollup-card:hover { border-color: var(--border2); transform: translateY(-1px); }
@@ -797,9 +820,15 @@
 
 @media (max-width: 767px) {
 
-  /* ── Summary bar: 2-row × 3-column grid, no sparklines ── */
+  /* ── Events + Monitor Checks: stack on mobile ── */
+  .dash-signals-row {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  /* ── Summary bar: 2-column grid, no sparklines ── */
   .summary-bar {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr);
     gap: 8px;
   }
 
@@ -816,58 +845,14 @@
     font-size: 18px;
   }
 
-  /* ── Widget grid: single column ── */
+  /* ── App cards: 2-column on mobile ── */
   .widget-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
   }
 
-  /* ── App widget: left stripe instead of top stripe ── */
-  .app-widget::before {
-    top: 0;
-    bottom: 0;
-    right: auto;
-    left: 0;
-    width: 3px;
-    height: auto;
-    opacity: 1;
-    background: var(--green);
-  }
-
-  .app-widget.warn::before  { background: var(--yellow); }
-  .app-widget.down::before  { background: var(--red); }
-  .app-widget:hover::before { background: var(--green); }
-  .app-widget.warn:hover::before { background: var(--yellow); }
-  .app-widget.down:hover::before { background: var(--red); }
-
-  /* Show primary stat as right-column value, hide 2×2 grid */
-  .app-widget-stats {
-    display: none;
-  }
-
-  .app-widget-sparkline {
-    display: none;
-  }
-
-  .app-widget {
-    flex-direction: row;
-    align-items: center;
-    gap: 12px;
-    padding: 12px 14px 12px 18px;
-  }
-
-  .app-widget-header {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .app-name {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .app-last-event {
-    display: none;
+  .ar-event {
+    font-size: 10px;
   }
 
   /* ── Event rows: card layout ── */

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,7 +4,6 @@ import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { Topbar } from '../components/Topbar'
 import { SummaryCard } from '../components/SummaryCard'
 import { AppWidget } from '../components/AppWidget'
-import { BookmarkWidget } from '../components/BookmarkWidget'
 import { dashboard as dashboardApi, events as eventsApi, infrastructure as infraApi } from '../api/client'
 import type { DashboardSummaryResponse, InfrastructureComponent, ResourceSummary } from '../api/types'
 import { InfraTypeIcon, CheckTypeIcon } from '../components/CheckTypeIcon'
@@ -300,175 +299,93 @@ export function Dashboard() {
           </div>
         )}
 
-        {/* Apps — split into full widgets (webhook/digest capable) and service cards */}
-        {(() => {
-          const SERVICE_CAPS = new Set(['monitor_only', 'docker_only'])
-          const fullApps = data.apps.filter(a => !SERVICE_CAPS.has(a.capability ?? ''))
-          const serviceApps = data.apps.filter(a => SERVICE_CAPS.has(a.capability ?? ''))
+        {/* Events + Monitor Checks — side by side, each 2×2 */}
+        <div className="dash-signals-row">
 
-          return (
-            <>
-              {fullApps.length > 0 && (
-                <div>
-                  <div className="section-header">
-                    <div className="section-title">Apps</div>
-                    <button className="section-action" onClick={() => navigate('/apps')}>
-                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                        <line x1="12" y1="5" x2="12" y2="19" />
-                        <line x1="5" y1="12" x2="19" y2="12" />
-                      </svg>
-                      Add app
-                    </button>
+          {eventCounts !== null && (
+            <div className="dash-signals-col">
+              <div className="section-header">
+                <div className="section-title">
+                  Events ({timeFilter === 'day' ? '24h' : timeFilter === 'week' ? '7d' : '30d'})
+                </div>
+              </div>
+              <div className="event-counts-row">
+                <div className="event-count-card info" style={{ cursor: 'pointer' }} onClick={() => navigate('/events?level=info')}>
+                  <div className="event-count-type">INFO</div>
+                  <div className="event-count-value">{eventCounts.info}</div>
+                  <div className="event-count-meta">{eventCounts.info === 1 ? '1 event' : `${eventCounts.info} events`}</div>
+                </div>
+                <div className="event-count-card warn" style={{ cursor: 'pointer' }} onClick={() => navigate('/events?level=warn')}>
+                  <div className="event-count-type">WARN</div>
+                  <div className="event-count-value">{eventCounts.warn}</div>
+                  <div className="event-count-meta">{eventCounts.warn === 1 ? '1 event' : `${eventCounts.warn} events`}</div>
+                </div>
+                <div className="event-count-card error" style={{ cursor: 'pointer' }} onClick={() => navigate('/events?level=error')}>
+                  <div className="event-count-type">ERROR</div>
+                  <div className="event-count-value">{eventCounts.error}</div>
+                  <div className="event-count-meta">{eventCounts.error === 1 ? '1 event' : `${eventCounts.error} events`}</div>
+                </div>
+                <div className="event-count-card critical" style={{ cursor: 'pointer' }} onClick={() => navigate('/events?level=critical')}>
+                  <div className="event-count-type">CRITICAL</div>
+                  <div className="event-count-value">{eventCounts.critical}</div>
+                  <div className="event-count-meta">{eventCounts.critical === 1 ? '1 event' : `${eventCounts.critical} events`}</div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="dash-signals-col">
+            <div className="section-header">
+              <div className="section-title">Monitor Checks</div>
+            </div>
+            <div className="check-rollup-grid">
+              {checkRollup.map(r => (
+                <div
+                  key={r.type}
+                  className={`check-rollup-card ${r.status}`}
+                  onClick={() => navigate('/checks')}
+                >
+                  <div className="check-rollup-type">
+                    <CheckTypeIcon type={r.type} size={14} />
+                    {r.type.toUpperCase()}
                   </div>
-                  <div className="widget-grid">
-                    {fullApps.map(app => (
-                      <AppWidget
-                        key={app.id}
-                        app={app}
-                        onClick={() => navigate(`/apps/${app.id}`)}
-                      />
-                    ))}
+                  <div className="check-rollup-uptime">
+                    {r.status === 'empty' ? '—' : `${r.avgUptime.toFixed(1)}%`}
+                  </div>
+                  <div className="check-rollup-meta">
+                    {r.total} check{r.total !== 1 ? 's' : ''}
+                    {r.notUp > 0 && <span className="check-rollup-not-up"> · {r.notUp} not up</span>}
                   </div>
                 </div>
-              )}
+              ))}
+            </div>
+          </div>
 
-              {serviceApps.length > 0 && (
-                <div>
-                  <div className="section-header">
-                    <div className="section-title">Services</div>
-                    {fullApps.length === 0 && (
-                      <button className="section-action" onClick={() => navigate('/apps')}>
-                        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                          <line x1="12" y1="5" x2="12" y2="19" />
-                          <line x1="5" y1="12" x2="19" y2="12" />
-                        </svg>
-                        Add app
-                      </button>
-                    )}
-                  </div>
-                  <div className="services-grid">
-                    {serviceApps.map(app => (
-                      <BookmarkWidget
-                        key={app.id}
-                        app={app}
-                        onClick={() => navigate(`/apps/${app.id}`)}
-                      />
-                    ))}
-                  </div>
-                </div>
-              )}
+        </div>
 
-              {data.apps.length > 0 && fullApps.length === 0 && serviceApps.length === 0 && (
-                <div>
-                  <div className="section-header">
-                    <div className="section-title">Apps</div>
-                  </div>
-                  <div className="widget-grid">
-                    {data.apps.map(app => (
-                      <AppWidget
-                        key={app.id}
-                        app={app}
-                        onClick={() => navigate(`/apps/${app.id}`)}
-                      />
-                    ))}
-                  </div>
-                </div>
-              )}
-            </>
-          )
-        })()}
-
-        {/* Events — severity counts */}
-        {eventCounts !== null && (
+        {/* Apps — unified list (all types) */}
+        {data.apps.length > 0 && (
           <div>
             <div className="section-header">
-              <div className="section-title">
-                Events ({timeFilter === 'day' ? '24h' : timeFilter === 'week' ? '7d' : '30d'})
-              </div>
-              <button className="section-action" onClick={() => navigate('/events')}>
-                View all →
-              </button>
+              <div className="section-title">Apps</div>
             </div>
-            <div className="event-counts-row">
-              <div className="event-count-card info" style={{ cursor: 'pointer' }} onClick={() => navigate('/events?level=info')}>
-                <svg className="event-count-icon" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="10" cy="10" r="8" />
-                  <path d="M10 9v5M10 7h.01" />
-                </svg>
-                <div className="event-count-value">{eventCounts.info}</div>
-                <div className="event-count-label">Info</div>
-              </div>
-              <div className="event-count-card warn" style={{ cursor: 'pointer' }} onClick={() => navigate('/events?level=warn')}>
-                <svg className="event-count-icon" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M10 3L18.5 17H1.5L10 3z" />
-                  <path d="M10 9v4M10 15h.01" />
-                </svg>
-                <div className="event-count-value">{eventCounts.warn}</div>
-                <div className="event-count-label">Warn</div>
-              </div>
-              <div className="event-count-card error" style={{ cursor: 'pointer' }} onClick={() => navigate('/events?level=error')}>
-                <svg className="event-count-icon" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="10" cy="10" r="8" />
-                  <path d="M7 7l6 6M13 7l-6 6" />
-                </svg>
-                <div className="event-count-value">{eventCounts.error}</div>
-                <div className="event-count-label">Error</div>
-              </div>
-              <div className="event-count-card critical" style={{ cursor: 'pointer' }} onClick={() => navigate('/events?level=critical')}>
-                <svg className="event-count-icon" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M10 2c0 4-4 5-4 9a4 4 0 0 0 8 0c0-4-4-5-4-9z" />
-                  <path d="M8 17.5a2 2 0 0 0 4 0" />
-                </svg>
-                <div className="event-count-value">{eventCounts.critical}</div>
-                <div className="event-count-label">Critical</div>
-              </div>
+            <div className="widget-grid">
+              {data.apps.map(app => (
+                <AppWidget
+                  key={app.id}
+                  app={app}
+                  onClick={() => navigate(`/apps/${app.id}`)}
+                />
+              ))}
             </div>
           </div>
         )}
-
-        {/* Monitor Checks — always show all 4 types */}
-        <div>
-          <div className="section-header">
-            <div className="section-title">Monitor Checks</div>
-            <button className="section-action" onClick={() => navigate('/checks')}>
-              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <line x1="12" y1="5" x2="12" y2="19" />
-                <line x1="5" y1="12" x2="19" y2="12" />
-              </svg>
-              Add check
-            </button>
-          </div>
-          <div className="check-rollup-grid">
-            {checkRollup.map(r => (
-              <div
-                key={r.type}
-                className={`check-rollup-card ${r.status}`}
-                onClick={() => navigate('/checks')}
-              >
-                <div className="check-rollup-type">
-                  <CheckTypeIcon type={r.type} size={14} />
-                  {r.type.toUpperCase()}
-                </div>
-                <div className="check-rollup-uptime">
-                  {r.status === 'empty' ? '—' : `${r.avgUptime.toFixed(1)}%`}
-                </div>
-                <div className="check-rollup-meta">
-                  {r.total} check{r.total !== 1 ? 's' : ''}
-                  {r.notUp > 0 && <span className="check-rollup-not-up"> · {r.notUp} not up</span>}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
 
         {/* ── INFRASTRUCTURE — full-width below two-col ── */}
         {infraComponents.length > 0 && (
           <div>
             <div className="section-header">
               <div className="section-title">Infrastructure</div>
-              <button className="section-action" onClick={() => navigate('/infrastructure')}>
-                View all →
-              </button>
             </div>
             <div className="dash-infra-grid">
               {infraComponents.map(host => renderInfraCard(host))}

--- a/frontend/src/pages/Infrastructure.css
+++ b/frontend/src/pages/Infrastructure.css
@@ -38,7 +38,37 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 16px;
+  margin-bottom: 10px;
+}
+
+/* ── Inline stats strip ── */
+.infra-stats-strip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.infra-stats-pill {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text2);
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px 10px;
+}
+
+.infra-stats-dot { display: none; }
+
+.infra-stats-sep {
+  width: 1px;
+  height: 14px;
+  background: var(--border2);
+  flex-shrink: 0;
+  margin: 0 2px;
 }
 
 .infra-tab-row .infra-tabs {
@@ -524,59 +554,191 @@
   color: var(--red);
 }
 
-/* ── CONTAINERS TABLE ────────────────────────────────────────────────────────── */
+/* ── CONTAINERS CARD LIST ────────────────────────────────────────────────────── */
 
-.rel-table.ctr-table thead tr {
-  background: var(--bg4);
+.ctr-table {
+  display: flex;
+  flex-direction: column;
 }
 
-.rel-table.ctr-table thead th {
-  color: #ffffff;
-  font-family: var(--sans, sans-serif);
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-  border-bottom: 1px solid var(--border2);
-}
-
-.rel-table.ctr-table thead th:first-child {
-  border-left: 3px solid var(--accent);
-  padding-left: 13px;
-}
-
-.ctr-table tbody tr:hover td {
-  background: var(--bg3);
-  cursor: default;
-}
-
-.ctr-name {
+/* Column header row — mirrors the card grid exactly */
+.ctr-table-header {
+  display: grid;
+  grid-template-columns: 1fr 130px 160px 36px;
+  gap: 0 16px;
+  padding: 0 14px 6px 17px; /* 17px = 3px border + 14px card padding */
   font-family: var(--mono);
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--text);
-  white-space: nowrap;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text3);
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 6px;
 }
 
-.ctr-image {
-  font-size: 11px;
-  max-width: 300px;
+.ctr-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+/* Desktop: 4-column grid — identity | status | app | button */
+.ctr-card {
+  display: grid;
+  grid-template-columns: 1fr 130px 160px 36px;
+  align-items: center;
+  gap: 0 16px;
+  padding: 10px 14px 10px 14px;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--border);
+  border-radius: 6px;
+  transition: border-color 0.15s, background 0.15s;
+  min-width: 0;
+}
+
+.ctr-card:hover {
+  background: var(--bg3);
+  border-color: var(--border2);
+}
+
+.ctr-card.ctr-card-running  { border-left-color: var(--green, #4ade80); }
+.ctr-card.ctr-card-stopped  { border-left-color: var(--text3); }
+
+/* ── Identity: name + image ── */
+
+.ctr-card-identity {
+  min-width: 0;
+}
+
+.ctr-card-name {
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text1);
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.ctr-status-label {
+.ctr-card-image {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+}
+
+/* ── Status column ── */
+
+.ctr-card-badges {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.ctr-card-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.ctr-card-status-label {
   font-family: var(--mono);
   font-size: 11px;
   color: var(--text2);
   text-transform: capitalize;
+  white-space: nowrap;
 }
 
-.ctr-last-seen {
+/* Amber pill shown only when an image update is available */
+.ctr-card-update-pill {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  color: #f59e0b;
   white-space: nowrap;
-  font-size: 11px;
+  flex-shrink: 0;
 }
+
+/* ── App column ── */
+
+.ctr-card-app-col {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.ctr-card-app-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ctr-card-no-app {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+}
+
+/* ── Navigate button ── */
+
+.ctr-card-open {
+  width: 34px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--accent, rgba(139,92,246,0.6));
+  border-radius: 999px;
+  background: rgba(139, 92, 246, 0.1);
+  color: var(--accent);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s, transform 0.1s;
+  padding: 0;
+}
+
+.ctr-card-open:hover {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(139,92,246,0.35);
+  transform: translateX(1px);
+}
+
+.ctr-card-open:active {
+  transform: translateX(2px);
+  box-shadow: none;
+}
+
+/* ── Mobile: stack into 2-row layout ── */
+
+@media (max-width: 640px) {
+  .ctr-table-header { display: none; }
+  .ctr-card {
+    grid-template-columns: 1fr 30px;
+    grid-template-rows: auto auto;
+    gap: 6px 10px;
+    padding: 10px 12px;
+  }
+  .ctr-card-identity { grid-column: 1; grid-row: 1; }
+  .ctr-card-open     { grid-column: 2; grid-row: 1; align-self: center; }
+  .ctr-card-badges   { grid-column: 1 / -1; grid-row: 2; flex-wrap: wrap; }
+  .ctr-card-app-col  { display: none; } /* app shown in linked badge on detail page */
+}
+
+/* ── Kept source badge + app link (shared) ──────────────────────────────────── */
 
 .ctr-source-badge {
   font-family: var(--mono);
@@ -599,12 +761,6 @@
   background: #1a3a2a22;
   color: #4ade80;
   border-color: #16653044;
-}
-
-.ctr-app-cell {
-  font-family: var(--mono);
-  font-size: 11px;
-  white-space: nowrap;
 }
 
 .ctr-app-linked {

--- a/frontend/src/pages/Infrastructure.tsx
+++ b/frontend/src/pages/Infrastructure.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { Topbar } from '../components/Topbar'
-import { SlidePanel } from '../components/SlidePanel'
 import { infrastructure as infraApi, discovery, apps as appsApi } from '../api/client'
 import type {
   InfrastructureComponent,
@@ -96,12 +95,6 @@ export function Infrastructure() {
   const [containers,      setContainers]      = useState<DiscoveredContainer[]>([])
   const [containersLoading, setContainersLoading] = useState(false)
   const [allApps,         setAllApps]         = useState<App[]>([])
-  const [ctrPanelOpen,    setCtrPanelOpen]    = useState(false)
-  const [selectedCtr,     setSelectedCtr]     = useState<DiscoveredContainer | null>(null)
-  const [ctrLinkAppId,    setCtrLinkAppId]    = useState('')
-  const [ctrLinkBusy,     setCtrLinkBusy]     = useState(false)
-  const [ctrLinkError,    setCtrLinkError]    = useState('')
-
   // Panel state
   const [modalOpen,             setModalOpen]             = useState(false)
   const [openKey,               setOpenKey]               = useState(0)
@@ -156,10 +149,10 @@ export function Infrastructure() {
     return () => clearInterval(id)
   }, [])
 
-  // Load containers + apps when Containers tab is active
+  // Load containers + apps (always, so container count is available on components tab too)
   useEffect(() => {
-    if (view !== 'containers') return
-    setContainersLoading(true)
+    // Only show the loading spinner on the initial load (no data yet).
+    if (view === 'containers' && containers.length === 0) setContainersLoading(true)
     Promise.all([
       discovery.allContainers(),
       appsApi.list(),
@@ -167,6 +160,7 @@ export function Infrastructure() {
       .then(([cRes, aRes]) => { setContainers(cRes.data); setAllApps(aRes.data) })
       .catch(console.error)
       .finally(() => setContainersLoading(false))
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [view, refreshTick])
 
   // Suppress unused variable warning for tick
@@ -203,9 +197,15 @@ export function Infrastructure() {
     try {
       const result = await infraApi.discover(id)
       setScanResults(prev => ({ ...prev, [id]: result }))
-      // Refresh the component list so last_status updates immediately.
-      const res = await infraApi.list()
+      // Refresh the component list and containers so everything reflects the new state.
+      const [res, cRes, aRes] = await Promise.all([
+        infraApi.list(),
+        discovery.allContainers(),
+        appsApi.list(),
+      ])
       setComponents(res.data)
+      setContainers(cRes.data)
+      setAllApps(aRes.data)
       void pollAll(res.data)
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Discover failed'
@@ -495,60 +495,6 @@ export function Infrastructure() {
     return profileId ? `/api/v1/icons/${profileId}` : null
   }
 
-  function openCtrPanel(c: DiscoveredContainer) {
-    setSelectedCtr(c)
-    setCtrLinkAppId(c.app_id ?? '')
-    setCtrLinkError('')
-    setCtrPanelOpen(true)
-  }
-
-  async function handleCtrLink() {
-    if (!selectedCtr || !ctrLinkAppId) return
-    setCtrLinkBusy(true)
-    setCtrLinkError('')
-    try {
-      await discovery.linkContainerApp(selectedCtr.id, { mode: 'existing', app_id: ctrLinkAppId })
-      setContainers(prev => prev.map(c => c.id === selectedCtr.id ? { ...c, app_id: ctrLinkAppId } : c))
-      setSelectedCtr(prev => prev ? { ...prev, app_id: ctrLinkAppId } : prev)
-    } catch (e) {
-      setCtrLinkError(String(e))
-    } finally {
-      setCtrLinkBusy(false)
-    }
-  }
-
-  async function handleCtrUnlink() {
-    if (!selectedCtr) return
-    setCtrLinkBusy(true)
-    setCtrLinkError('')
-    try {
-      await discovery.unlinkContainerApp(selectedCtr.id)
-      setContainers(prev => prev.map(c => c.id === selectedCtr.id ? { ...c, app_id: null } : c))
-      setSelectedCtr(prev => prev ? { ...prev, app_id: null } : prev)
-      setCtrLinkAppId('')
-    } catch (e) {
-      setCtrLinkError(String(e))
-    } finally {
-      setCtrLinkBusy(false)
-    }
-  }
-
-  function formatImage(image: string): { name: string; tag: string } {
-    if (image.startsWith('sha256:')) {
-      return { name: 'sha256:' + image.slice(7, 19), tag: '…' }
-    }
-    const colonIdx = image.lastIndexOf(':')
-    if (colonIdx === -1) {
-      return { name: image.length > 45 ? image.slice(0, 44) + '…' : image, tag: '' }
-    }
-    const name = image.slice(0, colonIdx)
-    const tag  = image.slice(colonIdx + 1)
-    return {
-      name: name.length > 45 ? name.slice(0, 44) + '…' : name,
-      tag,
-    }
-  }
-
   function sourceLabel(s: string) {
     if (s === 'docker_engine') return 'Docker'
     if (s === 'portainer')     return 'Portainer'
@@ -582,83 +528,71 @@ export function Infrastructure() {
     }
 
     return (
-      <div className="rel-table-wrap">
-        <table className="rel-table ctr-table">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Source</th>
-              <th>Image</th>
-              <th>Status</th>
-              <th>Image Update</th>
-              <th>Last Seen</th>
-              <th>App</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            {containers.map(c => {
-              const img = formatImage(c.image)
-              return (
-                <tr key={c.id} className="rel-row">
-                  <td className="ctr-name">{c.container_name}</td>
-                  <td>
-                    <span className={`ctr-source-badge ctr-source-${c.source_type}`}>
-                      {sourceLabel(c.source_type)}
-                    </span>
-                  </td>
-                  <td className="rel-mono ctr-image" title={c.image}>
-                    {img.name}
-                    {img.tag && <span className="rel-dim">:{img.tag}</span>}
-                  </td>
-                  <td>
-                    <span className={`infra-status-dot ${containerStatusClass(c.status)}`} style={{ marginRight: 6 }} />
-                    <span className="ctr-status-label">{c.status}</span>
-                  </td>
-                  <td>
-                    {c.image_last_checked_at === null
-                      ? <span className="rel-dim">Not checked</span>
-                      : c.image_update_available
-                        ? <span className="de-update-badge">Update available</span>
-                        : <span className="de-uptodate-badge">Up to date</span>
-                    }
-                  </td>
-                  <td className="rel-dim ctr-last-seen">
-                    {new Date(c.last_seen_at).toLocaleString()}
-                  </td>
-                  <td className="ctr-app-cell">
-                    {(() => {
-                      const app = allApps.find(a => a.id === c.app_id)
-                      if (!app) return <span className="rel-dim">—</span>
-                      const iconUrl = appIconUrl(app.profile_id)
-                      return (
-                        <span className="ctr-app-linked">
-                          {iconUrl && (
-                            <img
-                              src={iconUrl}
-                              alt=""
-                              className="ctr-app-icon"
-                              onError={e => { (e.target as HTMLImageElement).style.display = 'none' }}
-                            />
-                          )}
-                          {app.name}
-                        </span>
-                      )
-                    })()}
-                  </td>
-                  <td className="ctr-settings-cell">
-                    <button className="ctr-settings-btn" onClick={() => openCtrPanel(c)} title="Settings">
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" width="13" height="13">
-                        <circle cx="12" cy="12" r="3" />
-                        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-                      </svg>
-                    </button>
-                  </td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </table>
+      <div className="ctr-table">
+        {/* Column headers */}
+        <div className="ctr-table-header">
+          <span>Container</span>
+          <span>Status</span>
+          <span>App</span>
+          <span />
+        </div>
+
+        <div className="ctr-cards">
+        {containers.map(c => {
+          const app = allApps.find(a => a.id === c.app_id)
+          const iconUrl = app ? appIconUrl(app.profile_id) : null
+          const cardStatusClass = c.status === 'running' ? 'ctr-card-running'
+            : (c.status === 'stopped' || c.status === 'exited') ? 'ctr-card-stopped'
+            : ''
+          return (
+            <div key={c.id} className={`ctr-card ${cardStatusClass}`}>
+
+              {/* Name + image */}
+              <div className="ctr-card-identity">
+                <div className="ctr-card-name">{c.container_name}</div>
+                <div className="ctr-card-image">{c.image}</div>
+              </div>
+
+              {/* Status + update */}
+              <div className="ctr-card-badges">
+                <span className={`ctr-card-status-dot ${containerStatusClass(c.status)}`} />
+                <span className="ctr-card-status-label">{c.status}</span>
+                {c.image_update_available && (
+                  <span className="ctr-card-update-pill">Update</span>
+                )}
+              </div>
+
+              {/* Linked app */}
+              <div className="ctr-card-app-col">
+                {app ? (
+                  <span className="ctr-app-linked">
+                    {iconUrl && (
+                      <img
+                        src={iconUrl}
+                        alt=""
+                        className="ctr-app-icon"
+                        onError={e => { (e.target as HTMLImageElement).style.display = 'none' }}
+                      />
+                    )}
+                    <span className="ctr-card-app-name">{app.name}</span>
+                  </span>
+                ) : (
+                  <span className="ctr-card-no-app">—</span>
+                )}
+              </div>
+
+              {/* Navigate */}
+              <button
+                className="ctr-card-open"
+                onClick={() => navigate(`/containers/${c.id}`)}
+                title={`Open ${c.container_name}`}
+              >
+                →
+              </button>
+            </div>
+          )
+        })}
+        </div>
       </div>
     )
   }
@@ -691,6 +625,48 @@ export function Infrastructure() {
           )}
         </div>
 
+        {/* ── Stats strip ── */}
+        {!loading && (() => {
+          if (view === 'components' && components.length > 0) {
+            const online   = components.filter(c => c.last_status === 'online').length
+            const offline  = components.filter(c => c.last_status === 'offline').length
+            const degraded = components.filter(c => c.last_status === 'degraded').length
+            const typeCounts = [
+              { label: 'VM',        n: components.filter(c => c.type === 'vm_linux' || c.type === 'vm_windows').length },
+              { label: 'Proxmox',   n: components.filter(c => c.type === 'proxmox_node').length },
+              { label: 'Docker',    n: components.filter(c => c.type === 'docker_engine').length },
+              { label: 'Portainer', n: components.filter(c => c.type === 'portainer').length },
+              { label: 'Traefik',   n: components.filter(c => c.type === 'traefik').length },
+              { label: 'Synology',  n: components.filter(c => c.type === 'synology').length },
+            ].filter(x => x.n > 0)
+            const ctrCount = containers.length
+            return (
+              <div className="infra-stats-strip">
+                <span className="infra-stats-pill" style={{ color: 'var(--green)' }}>{online} online</span>
+                {degraded > 0 && <span className="infra-stats-pill" style={{ color: 'var(--yellow)' }}>{degraded} degraded</span>}
+                {offline  > 0 && <span className="infra-stats-pill" style={{ color: 'var(--red)' }}>{offline} offline</span>}
+                {typeCounts.length > 0 && <span className="infra-stats-sep" />}
+                {typeCounts.map(({ label, n }) => <span key={label} className="infra-stats-pill">{n} {label}</span>)}
+                {ctrCount > 0 && <><span className="infra-stats-sep" /><span className="infra-stats-pill">{ctrCount} container{ctrCount !== 1 ? 's' : ''}</span></>}
+              </div>
+            )
+          }
+          if (view === 'containers' && containers.length > 0) {
+            const running = containers.filter(c => c.status === 'running').length
+            const stopped = containers.filter(c => c.status !== 'running').length
+            const linked  = containers.filter(c => c.app_id).length
+            return (
+              <div className="infra-stats-strip">
+                <span className="infra-stats-pill" style={{ color: 'var(--green)' }}>{running} running</span>
+                {stopped > 0 && <span className="infra-stats-pill" style={{ color: 'var(--text3)' }}>{stopped} stopped</span>}
+                <span className="infra-stats-sep" />
+                <span className="infra-stats-pill">{linked} linked to app{linked !== 1 ? 's' : ''}</span>
+              </div>
+            )
+          }
+          return null
+        })()}
+
         {view === 'containers' ? renderContainersTable() : loading ? (
           <div className="infra-empty">Loading…</div>
         ) : components.length === 0 ? (
@@ -704,70 +680,6 @@ export function Infrastructure() {
         )}
 
       </div>
-
-      {/* ── Container settings panel ── */}
-      <SlidePanel
-        open={ctrPanelOpen}
-        onClose={() => setCtrPanelOpen(false)}
-        title={selectedCtr?.container_name ?? ''}
-        subtitle={selectedCtr ? `${sourceLabel(selectedCtr.source_type)} · ${formatImage(selectedCtr.image).name}` : ''}
-        width={400}
-      >
-        {selectedCtr && (
-          <div className="ctr-panel-body">
-            <div className="ctr-panel-section-title">Linked Application</div>
-            {selectedCtr.app_id ? (
-              <div className="ctr-panel-linked">
-                <span className="ctr-app-linked">
-                  {allApps.find(a => a.id === selectedCtr.app_id)?.name ?? selectedCtr.app_id}
-                </span>
-                <button
-                  className="ctr-panel-unlink-btn"
-                  onClick={() => void handleCtrUnlink()}
-                  disabled={ctrLinkBusy}
-                >
-                  {ctrLinkBusy ? 'Unlinking…' : 'Unlink'}
-                </button>
-              </div>
-            ) : (
-              <div className="ctr-panel-link-form">
-                <select
-                  className="ctr-panel-select"
-                  value={ctrLinkAppId}
-                  onChange={e => setCtrLinkAppId(e.target.value)}
-                >
-                  <option value="">— select app —</option>
-                  {allApps.map(a => (
-                    <option key={a.id} value={a.id}>{a.name}</option>
-                  ))}
-                </select>
-                <button
-                  className="ctr-panel-link-btn"
-                  onClick={() => void handleCtrLink()}
-                  disabled={!ctrLinkAppId || ctrLinkBusy}
-                >
-                  {ctrLinkBusy ? 'Linking…' : 'Link App'}
-                </button>
-              </div>
-            )}
-            {ctrLinkError && <div className="ctr-panel-error">{ctrLinkError}</div>}
-
-            <div className="ctr-panel-section-title" style={{ marginTop: 24 }}>Container Info</div>
-            <div className="ctr-panel-info-grid">
-              <span className="ctr-panel-info-label">Image</span>
-              <span className="ctr-panel-info-value" title={selectedCtr.image}>
-                {(() => { const i = formatImage(selectedCtr.image); return i.name + (i.tag ? ':' + i.tag : '') })()}
-              </span>
-              <span className="ctr-panel-info-label">Status</span>
-              <span className="ctr-panel-info-value">{selectedCtr.status}</span>
-              <span className="ctr-panel-info-label">Source</span>
-              <span className="ctr-panel-info-value">{sourceLabel(selectedCtr.source_type)}</span>
-              <span className="ctr-panel-info-label">Last seen</span>
-              <span className="ctr-panel-info-value">{new Date(selectedCtr.last_seen_at).toLocaleString()}</span>
-            </div>
-          </div>
-        )}
-      </SlidePanel>
 
       {/* ── Slide panel ── */}
       <InfraEditModal

--- a/frontend/src/pages/Infrastructure.tsx
+++ b/frontend/src/pages/Infrastructure.tsx
@@ -495,13 +495,6 @@ export function Infrastructure() {
     return profileId ? `/api/v1/icons/${profileId}` : null
   }
 
-  function sourceLabel(s: string) {
-    if (s === 'docker_engine') return 'Docker'
-    if (s === 'portainer')     return 'Portainer'
-    return s || '—'
-  }
-
-
   function renderContainersTable() {
     if (containersLoading) return <div className="infra-empty">Loading…</div>
 

--- a/frontend/src/pages/NotFound.css
+++ b/frontend/src/pages/NotFound.css
@@ -1,0 +1,226 @@
+.nf-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - 56px);
+  overflow: hidden;
+  position: relative;
+  transition: background 0.4s;
+}
+
+.nf-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  text-align: center;
+  position: relative;
+  z-index: 2;
+}
+
+/* ── Droid ───────────────────────────────────────────────────────────────────── */
+
+.nf-droid {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  animation: nf-hover 3s ease-in-out infinite;
+  cursor: pointer;
+  user-select: none;
+}
+
+.nf-droid:active .nf-emoji {
+  transform: scale(0.88);
+}
+
+.nf-revealed {
+  animation: nf-spin 0.6s ease, nf-hover 3s ease-in-out 0.6s infinite;
+}
+
+@keyframes nf-spin {
+  0%   { transform: rotate(0deg) scale(1); }
+  50%  { transform: rotate(180deg) scale(1.3); }
+  100% { transform: rotate(360deg) scale(1); }
+}
+
+@keyframes nf-hover {
+  0%, 100% { transform: translateY(0px) rotate(-1deg); }
+  50%       { transform: translateY(-10px) rotate(1deg); }
+}
+
+.nf-emoji {
+  font-size: 96px;
+  line-height: 1;
+  filter: drop-shadow(0 0 18px rgba(139, 92, 246, 0.6));
+  transition: transform 0.1s, filter 0.3s;
+}
+
+.nf-revealed .nf-emoji {
+  filter: drop-shadow(0 0 28px rgba(250, 204, 21, 0.8));
+}
+
+.nf-bleep {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  margin-top: 6px;
+  min-height: 16px;
+  transition: color 0.2s;
+  animation: nf-blink 2.4s step-end infinite;
+}
+
+.nf-bleep-angry {
+  animation: none;
+  color: var(--red);
+}
+
+.nf-revealed .nf-bleep {
+  color: var(--yellow, #facc15) !important;
+}
+
+@keyframes nf-blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+/* ── Wave text ───────────────────────────────────────────────────────────────── */
+
+.nf-wave-text {
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text1);
+  letter-spacing: 0.01em;
+  min-height: 32px;
+}
+
+.nf-wave-text span {
+  display: inline-block;
+  animation: nf-wave-fade 0.4s ease forwards;
+}
+
+@keyframes nf-wave-fade {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── 404 number ──────────────────────────────────────────────────────────────── */
+
+.nf-code {
+  font-family: var(--mono);
+  font-size: 64px;
+  font-weight: 700;
+  letter-spacing: 0.3em;
+  color: transparent;
+  background: linear-gradient(135deg, var(--accent) 0%, #a78bfa 50%, var(--accent) 100%);
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  animation: nf-shimmer 3s linear infinite;
+  line-height: 1;
+}
+
+@keyframes nf-shimmer {
+  0%   { background-position: 0% center; }
+  100% { background-position: 200% center; }
+}
+
+/* ── Sub / hint ──────────────────────────────────────────────────────────────── */
+
+.nf-sub {
+  font-size: 14px;
+  color: var(--text2);
+  letter-spacing: 0.05em;
+}
+
+.nf-dim {
+  color: var(--text3);
+  font-size: 12px;
+}
+
+.nf-hint {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--border);
+  letter-spacing: 0.12em;
+  margin-top: -8px;
+}
+
+/* ── Button ──────────────────────────────────────────────────────────────────── */
+
+.nf-btn {
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 9px 22px;
+  border-radius: 6px;
+  border: 1px solid var(--accent);
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, box-shadow 0.2s;
+  letter-spacing: 0.04em;
+}
+
+.nf-btn:hover {
+  background: var(--accent);
+  color: #000;
+  box-shadow: 0 0 16px var(--accent);
+}
+
+/* ── Hyperspace ──────────────────────────────────────────────────────────────── */
+
+.nf-canvas {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.nf-hs-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 11;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  pointer-events: none;
+  animation: nf-hs-appear 0.6s ease forwards;
+}
+
+@keyframes nf-hs-appear {
+  0%   { opacity: 0; transform: scale(0.8); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+.nf-hs-title {
+  font-family: var(--mono);
+  font-size: 36px;
+  font-weight: 700;
+  letter-spacing: 0.25em;
+  color: #fff;
+  text-shadow:
+    0 0 10px #fff,
+    0 0 30px rgba(100, 200, 255, 0.9),
+    0 0 60px rgba(100, 200, 255, 0.5);
+  animation: nf-hs-pulse 1s ease-in-out infinite alternate;
+}
+
+@keyframes nf-hs-pulse {
+  from { text-shadow: 0 0 10px #fff, 0 0 30px rgba(100,200,255,0.9), 0 0 60px rgba(100,200,255,0.5); }
+  to   { text-shadow: 0 0 20px #fff, 0 0 50px rgba(100,200,255,1),   0 0 100px rgba(100,200,255,0.7); }
+}
+
+.nf-hs-sub {
+  font-family: var(--mono);
+  font-size: 15px;
+  letter-spacing: 0.15em;
+  color: rgba(150, 220, 255, 0.8);
+  animation: nf-wave-fade 0.8s ease 0.4s both;
+}
+
+.nf-hidden {
+  opacity: 0;
+  pointer-events: none;
+}

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,0 +1,206 @@
+import { useNavigate } from 'react-router-dom'
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { Topbar } from '../components/Topbar'
+import './NotFound.css'
+
+// ── Konami ────────────────────────────────────────────────────────────────────
+
+const KONAMI = [
+  'ArrowUp','ArrowUp','ArrowDown','ArrowDown',
+  'ArrowLeft','ArrowRight','ArrowLeft','ArrowRight',
+  'b','a',
+]
+
+// ── Droid click stages ────────────────────────────────────────────────────────
+
+const STAGES = [
+  { emoji: '🤖', bleep: 'bleep bloop...' },
+  { emoji: '🤖', bleep: 'hey, stop that.' },
+  { emoji: '🤖', bleep: 'i said STOP.' },
+  { emoji: '😤', bleep: 'you have been warned.' },
+  { emoji: '😡', bleep: '...' },
+  { emoji: '🦾', bleep: 'FINE. I am R2-D2. Happy now?!' },
+]
+
+// ── Hyperspace canvas ─────────────────────────────────────────────────────────
+
+function HyperspaceCanvas({ onEnd }: { onEnd: () => void }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const onEndRef  = useRef(onEnd)
+  onEndRef.current = onEnd
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')!
+
+    const resize = () => {
+      canvas.width  = window.innerWidth
+      canvas.height = window.innerHeight
+    }
+    resize()
+    window.addEventListener('resize', resize)
+
+    const DURATION = 3500
+    const NUM_STARS = 180
+
+    const stars = Array.from({ length: NUM_STARS }, () => ({
+      angle: Math.random() * Math.PI * 2,
+      dist:  Math.random() * 8,
+      speed: 0.8 + Math.random() * 1.2,
+      width: 0.6 + Math.random() * 1.2,
+    }))
+
+    const start = Date.now()
+    let raf: number
+
+    function frame() {
+      if (!canvas) return
+      const elapsed  = Date.now() - start
+      const progress = Math.min(elapsed / DURATION, 1)
+
+      if (progress >= 1) { onEndRef.current(); return }
+
+      const cx = canvas.width  / 2
+      const cy = canvas.height / 2
+      const maxDist = Math.hypot(cx, cy) + 50
+
+      // Fade trail — heavy at start for "flash" feel, light after
+      const alpha = progress < 0.05 ? 0.85 : 0.18
+      ctx.fillStyle = `rgba(0,0,0,${alpha})`
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
+
+      const accel = 1 + Math.pow(progress, 1.6) * 60
+
+      for (const s of stars) {
+        const oldDist = s.dist
+        s.dist += s.speed * accel
+
+        if (s.dist > maxDist) {
+          s.dist  = Math.random() * 6
+          s.speed = 0.8 + Math.random() * 1.2
+          continue
+        }
+
+        const ox = cx + Math.cos(s.angle) * oldDist
+        const oy = cy + Math.sin(s.angle) * oldDist
+        const nx = cx + Math.cos(s.angle) * s.dist
+        const ny = cy + Math.sin(s.angle) * s.dist
+
+        // Colour: deep blue → cyan → white as we accelerate
+        const t  = Math.min(progress * 2, 1)
+        const r  = Math.round(40  + t * 215)
+        const g  = Math.round(100 + t * 155)
+        const b  = 255
+        const op = Math.min(0.3 + progress * 0.7, 1)
+
+        ctx.beginPath()
+        ctx.moveTo(ox, oy)
+        ctx.lineTo(nx, ny)
+        ctx.strokeStyle = `rgba(${r},${g},${b},${op})`
+        ctx.lineWidth   = s.width * (1 + progress * 3)
+        ctx.stroke()
+      }
+
+      // Bright centre glow
+      const glow = ctx.createRadialGradient(cx, cy, 0, cx, cy, 120 * progress)
+      glow.addColorStop(0,   `rgba(180,220,255,${0.15 * progress})`)
+      glow.addColorStop(1,   'rgba(0,0,0,0)')
+      ctx.fillStyle = glow
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
+
+      raf = requestAnimationFrame(frame)
+    }
+
+    raf = requestAnimationFrame(frame)
+    return () => { cancelAnimationFrame(raf); window.removeEventListener('resize', resize) }
+  }, [])
+
+  return <canvas ref={canvasRef} className="nf-canvas" />
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export function NotFound() {
+  const navigate   = useNavigate()
+  const [hyper,   setHyper]  = useState(false)
+  const [clicks,  setClicks] = useState(0)
+  const [seq,     setSeq]    = useState<string[]>([])
+
+  const stage    = STAGES[Math.min(clicks, STAGES.length - 1)]
+  const revealed = clicks >= STAGES.length - 1
+
+  const activateHyper = useCallback(() => {
+    setHyper(true)
+  }, [])
+
+  const endHyper = useCallback(() => {
+    setHyper(false)
+  }, [])
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      setSeq(prev => {
+        const next = [...prev, e.key].slice(-KONAMI.length)
+        if (next.join(',') === KONAMI.join(',')) activateHyper()
+        return next
+      })
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [activateHyper])
+
+  void seq
+
+  return (
+    <>
+      <Topbar title="404" />
+      <div className="content nf-page">
+
+        {hyper && (
+          <>
+            <HyperspaceCanvas onEnd={endHyper} />
+            <div className="nf-hs-overlay">
+              <div className="nf-hs-title">JUMPING TO HYPERSPACE</div>
+              <div className="nf-hs-sub">May the Force be with you.</div>
+            </div>
+          </>
+        )}
+
+        <div className={`nf-inner${hyper ? ' nf-hidden' : ''}`}>
+          <div
+            className={`nf-droid${revealed ? ' nf-revealed' : ''}`}
+            onClick={() => setClicks(c => Math.min(c + 1, STAGES.length - 1))}
+            title="click me..."
+          >
+            <div className="nf-emoji">{stage.emoji}</div>
+            <div className={`nf-bleep${clicks > 0 ? ' nf-bleep-angry' : ''}`}>
+              {stage.bleep}
+            </div>
+          </div>
+
+          <div className="nf-wave-text">
+            <span key={revealed ? 'r' : 'n'}>
+              {revealed
+                ? 'Artoo-Detoo, it is you! It is you!'
+                : "These are not the droids you're looking for."}
+            </span>
+          </div>
+
+          <div className="nf-code">4 0 4</div>
+
+          <div className="nf-sub">
+            Move along. <span className="nf-dim">Move along.</span>
+          </div>
+
+          <button className="nf-btn" onClick={() => navigate('/')}>
+            ← Return to base
+          </button>
+
+          <div className="nf-hint">↑↑↓↓←→←→BA</div>
+        </div>
+
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/Relationships.tsx
+++ b/frontend/src/pages/Relationships.tsx
@@ -469,8 +469,6 @@ export function Relationships() {
                           <tr
                             key={app.id}
                             className="rel-row"
-                            onClick={() => navigate(`/apps/${app.id}`)}
-                            title={`Open ${app.name}`}
                           >
                             <td><AppCell app={app} /></td>
 
@@ -512,9 +510,16 @@ export function Relationships() {
                               <button
                                 className="rel-gear-btn"
                                 title="Manage link"
-                                onClick={e => { e.stopPropagation(); openAppPanel(app) }}
+                                onClick={() => openAppPanel(app)}
                               >
                                 <GearIcon />
+                              </button>
+                              <button
+                                className="rel-nav-btn"
+                                title={`Open ${app.name}`}
+                                onClick={() => navigate(`/apps/${app.id}`)}
+                              >
+                                Open →
                               </button>
                             </td>
                           </tr>
@@ -594,7 +599,7 @@ export function Relationships() {
                         const linkedApp = allApps.find(a => a.id === m.app_id)
                         const iconUrl   = linkedApp ? appIconUrl(linkedApp.profile_id ?? null) : null
                         return (
-                          <tr key={m.id} className="rel-row" onClick={() => openMoniPanel(m)}>
+                          <tr key={m.id} className="rel-row">
                             <td style={{ color: 'var(--text)', fontWeight: 500 }}>{m.name}</td>
 
                             <td>
@@ -635,9 +640,16 @@ export function Relationships() {
                               <button
                                 className="rel-gear-btn"
                                 title="Manage link"
-                                onClick={e => { e.stopPropagation(); openMoniPanel(m) }}
+                                onClick={() => openMoniPanel(m)}
                               >
                                 <GearIcon />
+                              </button>
+                              <button
+                                className="rel-nav-btn"
+                                title={`Open ${m.name}`}
+                                onClick={() => openMoniPanel(m)}
+                              >
+                                Open →
                               </button>
                             </td>
                           </tr>
@@ -672,7 +684,7 @@ export function Relationships() {
                           const parent = infraParentByChildId.get(comp.id)
                           const ctrs   = allContainers.filter(c => c.infra_component_id === comp.id)
                           return (
-                            <tr key={comp.id} className="rel-row" onClick={() => navigate(`/infrastructure/${comp.id}`)}>
+                            <tr key={comp.id} className="rel-row">
                               <td style={{ color: 'var(--text)', fontWeight: 500 }}>{comp.name}</td>
                               <td className="rel-mono rel-type">{TYPE_LABEL[comp.type] ?? comp.type}</td>
                               <td>
@@ -695,11 +707,18 @@ export function Relationships() {
                                   <button
                                     className="rel-gear-btn"
                                     title="Manage relationship"
-                                    onClick={e => { e.stopPropagation(); openInfraPanel(comp) }}
+                                    onClick={() => openInfraPanel(comp)}
                                   >
                                     <GearIcon />
                                   </button>
                                 )}
+                                <button
+                                  className="rel-nav-btn"
+                                  title={`Open ${comp.name}`}
+                                  onClick={() => navigate(`/infrastructure/${comp.id}`)}
+                                >
+                                  Open →
+                                </button>
                               </td>
                             </tr>
                           )

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -91,6 +91,8 @@ type appSummary struct {
 	LastEventText *string   `json:"last_event_text"`
 	Stats         []appStat `json:"stats"`
 	Sparkline     [7]int    `json:"sparkline"`
+	ChecksUp      int       `json:"checks_up"`
+	ChecksTotal   int       `json:"checks_total"`
 }
 
 type checkSummary struct {
@@ -300,6 +302,21 @@ func (h *DashboardHandler) Summary(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Build a map from appID → {up, total} for per-app check counts.
+	type checkCounts struct{ up, total int }
+	appCheckCounts := map[string]checkCounts{}
+	for _, c := range checks {
+		if c.AppID == "" || !c.Enabled {
+			continue
+		}
+		cc := appCheckCounts[c.AppID]
+		cc.total++
+		if c.LastStatus == "up" {
+			cc.up++
+		}
+		appCheckCounts[c.AppID] = cc
+	}
+
 	appSummaries := make([]appSummary, 0, len(apps))
 	for _, a := range apps {
 		status := "online"
@@ -355,6 +372,7 @@ func (h *DashboardHandler) Summary(w http.ResponseWriter, r *http.Request) {
 			lastEventText = &ev.Title
 		}
 
+		cc := appCheckCounts[a.ID]
 		sum := appSummary{
 			ID:            a.ID,
 			Name:          a.Name,
@@ -364,6 +382,8 @@ func (h *DashboardHandler) Summary(w http.ResponseWriter, r *http.Request) {
 			LastEventText: lastEventText,
 			Stats:         stats,
 			Sparkline:     appSparkline,
+			ChecksUp:      cc.up,
+			ChecksTotal:   cc.total,
 		}
 		if a.ProfileID != "" {
 			sum.IconURL = "/api/v1/icons/" + a.ProfileID

--- a/internal/jobs/digest.go
+++ b/internal/jobs/digest.go
@@ -95,6 +95,41 @@ type DigestAppSection struct {
 	Categories  []DigestCategoryRow
 	TotalEvents int
 	HasIssues   bool
+	// Per-app enrichment (full detail)
+	Checks     []DigestAppCheck
+	Routes     []DigestAppRoute
+	Containers []DigestAppContainer
+	// Pre-computed summary counts (used by compact table row)
+	ChecksTotal int
+	ChecksDown  int
+	ChecksWarn  int
+	CtrTotal    int
+	CtrRunning  int
+	CtrUpdates  int
+	SSLMinDays  int // minimum SSL days across all routes; -1 = no SSL data
+}
+
+// DigestAppCheck is a single monitor check associated with an app.
+type DigestAppCheck struct {
+	Name   string
+	Type   string // url / ssl / dns / ping
+	Status string // up / down / warn / "" (not yet run)
+	Target string
+}
+
+// DigestAppRoute is a Traefik-discovered endpoint linked to an app.
+type DigestAppRoute struct {
+	Domain  string
+	HasTLS  bool
+	Status  string // RouterStatus: "enabled" | "disabled" | other
+	SSLDays int    // days until SSL expiry; -1 = no SSL data
+}
+
+// DigestAppContainer is a discovered container linked to an app.
+type DigestAppContainer struct {
+	Name      string
+	Status    string
+	HasUpdate bool
 }
 
 // DigestCategoryRow is one category (e.g. "Downloads", "Errors") for an app.
@@ -355,6 +390,30 @@ func (d *DigestJob) buildDigestData(ctx context.Context, period string) (*Digest
 		data.CheckGroups = append(data.CheckGroups, g)
 	}
 
+	// ── Pre-3. Build per-app lookup maps ──────────────────────────────────
+	// Fetch all containers now so we can group by app_id here AND reuse
+	// the slice in section 5 without a second DB round-trip.
+	var containers []*models.DiscoveredContainer
+	if d.store.DiscoveredContainers != nil {
+		if cs, cerr := d.store.DiscoveredContainers.ListAllDiscoveredContainers(ctx); cerr == nil {
+			containers = cs
+		} else {
+			log.Printf("digest: list containers (early): %v", cerr)
+		}
+	}
+	checksByApp := make(map[string][]models.MonitorCheck)
+	for _, c := range checks {
+		if c.AppID != "" && c.Enabled {
+			checksByApp[c.AppID] = append(checksByApp[c.AppID], c)
+		}
+	}
+	containersByApp := make(map[string][]*models.DiscoveredContainer)
+	for _, c := range containers {
+		if c.AppID != nil && *c.AppID != "" {
+			containersByApp[*c.AppID] = append(containersByApp[*c.AppID], c)
+		}
+	}
+
 	// ── 3. App activity — per-app category breakdown ───────────────────────
 	// monitor_only apps have no webhook/digest categories — route
 	// them to ServiceSections so the email can render a separate Services block.
@@ -374,10 +433,12 @@ func (d *DigestJob) buildDigestData(ctx context.Context, period string) (*Digest
 
 			// Service apps: no digest categories — list them in ServiceSections.
 			if isServiceCapability(apptemplate.InferCapability(profile)) {
-				data.ServiceSections = append(data.ServiceSections, DigestAppSection{
+				svcSection := DigestAppSection{
 					AppName:     app.Name,
 					ProfileName: profile.Meta.Name,
-				})
+				}
+				svcSection = enrichAppSection(ctx, d.store, app.ID, svcSection, checksByApp, containersByApp)
+				data.ServiceSections = append(data.ServiceSections, svcSection)
 				continue
 			}
 
@@ -414,6 +475,7 @@ func (d *DigestJob) buildDigestData(ctx context.Context, period string) (*Digest
 					section.HasIssues = true
 				}
 			}
+			section = enrichAppSection(ctx, d.store, app.ID, section, checksByApp, containersByApp)
 			data.AppSections = append(data.AppSections, section)
 		}
 	} else {
@@ -469,13 +531,7 @@ func (d *DigestJob) buildDigestData(ctx context.Context, period string) (*Digest
 	}
 
 	// ── 5. Container signals ───────────────────────────────────────────────
-	var containers []*models.DiscoveredContainer
-	if d.store.DiscoveredContainers != nil {
-		containers, err = d.store.DiscoveredContainers.ListAllDiscoveredContainers(ctx)
-		if err != nil {
-			log.Printf("digest: list containers: %v", err)
-		}
-	}
+	// containers was fetched early (before section 3) for per-app grouping — reuse it.
 	for _, c := range containers {
 		data.ContainersTotal++
 		if c.Status == "running" {
@@ -813,6 +869,96 @@ func isAre(n int) string {
 	return "are"
 }
 
+// enrichAppSection populates Checks, Routes, and Containers on a DigestAppSection
+// using pre-built lookup maps (checks, containers) and a live route query.
+func enrichAppSection(
+	ctx context.Context,
+	store *repo.Store,
+	appID string,
+	section DigestAppSection,
+	checksByApp map[string][]models.MonitorCheck,
+	containersByApp map[string][]*models.DiscoveredContainer,
+) DigestAppSection {
+	// Checks
+	for _, mc := range checksByApp[appID] {
+		section.Checks = append(section.Checks, DigestAppCheck{
+			Name:   mc.Name,
+			Type:   mc.Type,
+			Status: mc.LastStatus,
+			Target: mc.Target,
+		})
+	}
+	// Routes (Traefik-discovered endpoints)
+	if store.DiscoveredRoutes != nil {
+		if routes, rErr := store.DiscoveredRoutes.ListByAppID(ctx, appID); rErr == nil {
+			for _, r := range routes {
+				daysLeft := -1
+				if r.SSLExpiry != nil {
+					daysLeft = int(time.Until(*r.SSLExpiry).Hours() / 24)
+				}
+				section.Routes = append(section.Routes, DigestAppRoute{
+					Domain:  routeDomain(r),
+					HasTLS:  r.HasTLSResolver == 1,
+					Status:  r.RouterStatus,
+					SSLDays: daysLeft,
+				})
+			}
+		}
+	}
+	// Containers
+	for _, c := range containersByApp[appID] {
+		section.Containers = append(section.Containers, DigestAppContainer{
+			Name:      trimContainerName(c.ContainerName),
+			Status:    c.Status,
+			HasUpdate: c.ImageUpdateAvailable == 1,
+		})
+	}
+
+	// Pre-compute summary counts for compact display
+	section.ChecksTotal = len(section.Checks)
+	for _, c := range section.Checks {
+		if c.Status == "down" {
+			section.ChecksDown++
+		} else if c.Status == "warn" {
+			section.ChecksWarn++
+		}
+	}
+	section.CtrTotal = len(section.Containers)
+	section.SSLMinDays = -1
+	for _, r := range section.Routes {
+		if r.SSLDays >= 0 {
+			if section.SSLMinDays == -1 || r.SSLDays < section.SSLMinDays {
+				section.SSLMinDays = r.SSLDays
+			}
+		}
+	}
+	for _, c := range section.Containers {
+		if c.Status == "running" {
+			section.CtrRunning++
+		}
+		if c.HasUpdate {
+			section.CtrUpdates++
+		}
+	}
+	return section
+}
+
+// routeDomain extracts a human-readable domain from a DiscoveredRoute.
+// Prefers the stored Domain field; falls back to parsing Host(`) from the Traefik rule.
+func routeDomain(r *models.DiscoveredRoute) string {
+	if r.Domain != nil && *r.Domain != "" {
+		return *r.Domain
+	}
+	rule := r.Rule
+	if i := strings.Index(rule, "Host(`"); i >= 0 {
+		rest := rule[i+6:]
+		if j := strings.Index(rest, "`"); j >= 0 {
+			return rest[:j]
+		}
+	}
+	return r.RouterName
+}
+
 func trimContainerName(name string) string {
 	name = strings.TrimPrefix(name, "/")
 	if len(name) > 32 {
@@ -1148,65 +1294,40 @@ var digestHTMLTemplate = `<!DOCTYPE html>
       </table>
     </td></tr>
 
-    <!-- App activity -->
-    {{if .AppSections}}
+    <!-- App activity — compact table -->
+    {{if or .AppSections .ServiceSections}}
     <tr><td style="background:#0f1215;border:1px solid #1e2530;border-top:none;border-bottom:none;padding:16px 28px;">
-      <p style="margin:0 0 12px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.08em;color:#445566;font-family:monospace;">App Activity</p>
-      {{range .AppSections}}
-      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:14px;">
-        <tr>
-          <td colspan="2" style="padding:6px 0 4px;border-bottom:1px solid #1e2530;">
-            <span style="font-size:13px;font-weight:600;color:#c8d4e0;">{{.AppName}}</span>
-            {{if .ProfileName}}<span style="font-size:11px;color:#445566;margin-left:6px;font-family:monospace;">{{.ProfileName}}</span>{{end}}
-          </td>
-        </tr>
-        {{range .Categories}}
-        <tr>
-          <td style="padding:5px 0 5px 12px;font-size:13px;color:#7a8fa8;">{{.Label}}</td>
-          <td align="right" style="padding:5px 0;font-size:14px;font-weight:600;font-family:monospace;{{if and .IsError (gt .Count 0)}}color:#ef4444;{{else if gt .Count 0}}color:#3b82f6;{{else}}color:#445566;{{end}}">{{.Count}}</td>
-        </tr>
-        {{end}}
-        {{if eq .TotalEvents 0}}
-        <tr><td colspan="2" style="padding:5px 0 5px 12px;font-size:12px;color:#445566;font-style:italic;">No activity this period</td></tr>
-        {{end}}
-      </table>
-      {{end}}
-    </td></tr>
-    {{end}}
-
-    <!-- Services (monitor_only / docker_only — no digest data) -->
-    {{if .ServiceSections}}
-    <tr><td style="background:#0f1215;border:1px solid #1e2530;border-top:none;border-bottom:none;padding:16px 28px;">
-      <p style="margin:0 0 12px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.08em;color:#445566;font-family:monospace;">Services</p>
+      <p style="margin:0 0 10px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.08em;color:#445566;font-family:monospace;">Apps</p>
       <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
-        {{range .ServiceSections}}
-        <tr>
-          <td style="padding:5px 0;font-size:13px;color:#c8d4e0;">{{.AppName}}</td>
-          <td style="padding:5px 0;font-size:11px;color:#445566;font-family:monospace;">{{.ProfileName}}</td>
-          <td align="right" style="padding:5px 0;font-size:11px;font-family:monospace;color:#445566;">monitor only</td>
+        <!-- header -->
+        <tr style="border-bottom:1px solid #1e2530;">
+          <td style="padding:4px 0;font-size:10px;color:#2a3a4a;font-family:monospace;text-transform:uppercase;letter-spacing:0.06em;">App</td>
+          <td align="right" style="padding:4px 6px;font-size:10px;color:#2a3a4a;font-family:monospace;text-transform:uppercase;letter-spacing:0.06em;">Events</td>
+          <td align="right" style="padding:4px 6px;font-size:10px;color:#2a3a4a;font-family:monospace;text-transform:uppercase;letter-spacing:0.06em;">Endpoints</td>
+          <td align="right" style="padding:4px 6px;font-size:10px;color:#2a3a4a;font-family:monospace;text-transform:uppercase;letter-spacing:0.06em;">Monitors</td>
+          <td align="right" style="padding:4px 0;font-size:10px;color:#2a3a4a;font-family:monospace;text-transform:uppercase;letter-spacing:0.06em;">Containers</td>
         </tr>
-        {{end}}
+        {{range .AppSections}}{{template "emailAppRow" .}}{{end}}
+        {{range .ServiceSections}}{{template "emailAppRow" .}}{{end}}
       </table>
-      <p style="margin:10px 0 0;font-size:11px;color:#445566;font-style:italic;">These services are monitored for uptime but do not emit webhook events.</p>
     </td></tr>
     {{end}}
 
     <!-- Infrastructure -->
     {{if .InfraRows}}
     <tr><td style="background:#0f1215;border:1px solid #1e2530;border-top:none;border-bottom:none;padding:16px 28px;">
-      <p style="margin:0 0 12px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.08em;color:#445566;font-family:monospace;">Infrastructure
-        <span style="font-weight:400;color:#22c55e;margin-left:8px;">{{.InfraOnline}} online</span>
-        {{if gt .InfraOffline 0}}<span style="font-weight:400;color:#ef4444;margin-left:8px;">{{.InfraOffline}} offline</span>{{end}}
-      </p>
+      <p style="margin:0 0 10px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.08em;color:#445566;font-family:monospace;">Infrastructure <span style="font-weight:400;color:#22c55e;">{{.InfraOnline}} online</span>{{if gt .InfraOffline 0}} <span style="font-weight:400;color:#ef4444;">{{.InfraOffline}} offline</span>{{end}}</p>
       <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+        <tr style="border-bottom:1px solid #1e2530;">
+          <td style="padding:3px 0;font-size:10px;color:#2a3a4a;font-family:monospace;text-transform:uppercase;letter-spacing:0.06em;">Component</td>
+          <td style="padding:3px 6px;font-size:10px;color:#2a3a4a;font-family:monospace;text-transform:uppercase;letter-spacing:0.06em;">Type</td>
+          <td align="right" style="padding:3px 0;font-size:10px;color:#2a3a4a;font-family:monospace;text-transform:uppercase;letter-spacing:0.06em;">Status</td>
+        </tr>
         {{range .InfraRows}}
-        <tr>
-          <td style="padding:5px 0;font-size:13px;color:#c8d4e0;">{{.Name}}</td>
-          <td style="padding:5px 0;font-size:11px;color:#445566;font-family:monospace;">{{.Type}}</td>
-          <td align="right" style="padding:5px 0;font-size:12px;font-family:monospace;
-            {{if eq .Status "online"}}color:#22c55e;
-            {{else if eq .Status "degraded"}}color:#eab308;
-            {{else}}color:#ef4444;{{end}}">{{.Status}}</td>
+        <tr style="border-bottom:1px solid #1e2530;">
+          <td style="padding:7px 0;font-size:13px;color:#c8d4e0;font-weight:500;">{{.Name}}</td>
+          <td style="padding:7px 6px;font-size:11px;color:#445566;font-family:monospace;">{{.Type}}</td>
+          <td align="right" style="padding:7px 0;font-size:12px;font-family:monospace;{{if eq .Status "online"}}color:#22c55e;{{else if eq .Status "degraded"}}color:#eab308;{{else}}color:#ef4444;{{end}}">● {{.Status}}</td>
         </tr>
         {{end}}
       </table>
@@ -1261,6 +1382,37 @@ var digestHTMLTemplate = `<!DOCTYPE html>
   </table>
   </td></tr>
 </table>
+
+{{define "emailAppRow"}}
+<tr style="border-bottom:1px solid #1e2530;">
+  <td style="padding:7px 0;font-size:13px;{{if .HasIssues}}color:#ef4444;font-weight:600;{{else}}color:#c8d4e0;{{end}}">
+    {{.AppName}}{{if .ProfileName}} <span style="font-size:10px;color:#445566;font-family:monospace;">{{.ProfileName}}</span>{{end}}
+  </td>
+  <td align="right" style="padding:7px 6px;font-size:13px;font-weight:600;font-family:monospace;{{if .HasIssues}}color:#ef4444;{{else if gt .TotalEvents 0}}color:#3b82f6;{{else}}color:#445566;{{end}}">
+    {{if gt .TotalEvents 0}}{{.TotalEvents}}{{else}}—{{end}}
+  </td>
+  <td align="right" style="padding:7px 6px;font-size:11px;font-family:monospace;">
+    {{if .Routes}}
+      {{len .Routes}}
+      {{if ge .SSLMinDays 0}}{{if le .SSLMinDays 7}}<span style="color:#ef4444;">SSL {{.SSLMinDays}}d</span>{{else if le .SSLMinDays 30}}<span style="color:#eab308;">SSL {{.SSLMinDays}}d</span>{{end}}{{end}}
+    {{else}}<span style="color:#445566;">—</span>{{end}}
+  </td>
+  <td align="right" style="padding:7px 6px;font-size:12px;font-family:monospace;">
+    {{if gt .ChecksTotal 0}}
+      {{if gt .ChecksDown 0}}<span style="color:#ef4444;">{{.ChecksDown}} ✗</span> {{end}}
+      {{if gt .ChecksWarn 0}}<span style="color:#eab308;">{{.ChecksWarn}} ▲</span> {{end}}
+      {{if and (eq .ChecksDown 0) (eq .ChecksWarn 0)}}<span style="color:#22c55e;">{{.ChecksTotal}} ●</span>{{end}}
+    {{else}}<span style="color:#445566;">—</span>{{end}}
+  </td>
+  <td align="right" style="padding:7px 0;font-size:12px;font-family:monospace;">
+    {{if gt .CtrTotal 0}}
+      <span style="{{if lt .CtrRunning .CtrTotal}}color:#eab308;{{else}}color:#22c55e;{{end}}">{{.CtrRunning}}/{{.CtrTotal}}</span>
+      {{if gt .CtrUpdates 0}}<span style="color:#f59e0b;font-size:10px;"> +{{.CtrUpdates}}upd</span>{{end}}
+    {{else}}<span style="color:#445566;">—</span>{{end}}
+  </td>
+</tr>
+{{end}}
+
 </body>
 </html>`
 
@@ -1315,29 +1467,37 @@ var reportHTMLTemplate = `<!DOCTYPE html>
   .check-card-meta{font-size:11px;color:#445566;font-family:monospace;line-height:1.4;}
   .check-card-notup{color:#ef4444;}
   .check-card.warning .check-card-notup{color:#eab308;}
-  /* ── App widgets ── */
-  .app-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:12px;}
-  .app-widget{background:#0f1215;border:1px solid #1e2530;border-radius:8px;overflow:hidden;}
-  .app-widget-header{padding:10px 14px;border-bottom:1px solid #1e2530;display:flex;align-items:center;justify-content:space-between;gap:8px;}
-  .app-widget-name{font-weight:600;font-size:13px;color:#c8d4e0;}
-  .app-widget-badge{font-size:10px;font-family:monospace;color:#445566;background:#141820;border:1px solid #1e2530;border-radius:4px;padding:1px 5px;}
-  .cat-row{display:flex;justify-content:space-between;align-items:center;padding:7px 14px;border-bottom:1px solid #1e2530;}
-  .cat-row:last-child{border-bottom:none;}
-  .cat-label{font-size:12px;color:#7a8fa8;}
-  .cat-count{font-family:monospace;font-size:13px;font-weight:600;}
-  .cat-count.has-errors{color:#ef4444;}
-  .cat-count.has-activity{color:#3b82f6;}
-  .cat-count.none{color:#445566;}
-  /* ── Infra cards ── */
-  .infra-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:10px;}
-  .infra-card{background:#0f1215;border:1px solid #1e2530;border-radius:8px;padding:12px 14px;display:flex;align-items:center;justify-content:space-between;gap:8px;}
-  .infra-card-left{}
-  .infra-card-name{font-size:13px;font-weight:600;color:#c8d4e0;margin-bottom:3px;}
-  .infra-card-type{font-size:11px;font-family:monospace;color:#445566;}
-  .infra-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0;}
-  .infra-dot.online{background:#22c55e;}
-  .infra-dot.degraded{background:#eab308;}
-  .infra-dot.offline,.infra-dot.unknown{background:#ef4444;}
+  /* ── App table (compact one-row-per-app) ── */
+  .app-table{width:100%;border-collapse:collapse;}
+  .app-table th{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:0.08em;color:#445566;font-family:monospace;padding:4px 8px 6px;border-bottom:1px solid #1e2530;text-align:right;}
+  .app-table th:first-child{text-align:left;padding-left:0;}
+  .app-table th:last-child{padding-right:0;}
+  .app-table td{padding:8px 8px;border-bottom:1px solid #1e2530;vertical-align:middle;font-size:13px;}
+  .app-table td:first-child{padding-left:0;}
+  .app-table td:last-child{padding-right:0;text-align:right;}
+  .app-table tr:last-child td{border-bottom:none;}
+  .app-name{font-weight:500;color:#c8d4e0;}
+  .app-name.has-issues{color:#ef4444;}
+  .app-badge{font-size:10px;font-family:monospace;color:#445566;background:#141820;border:1px solid #1e2530;border-radius:3px;padding:1px 5px;margin-left:6px;vertical-align:middle;}
+  .app-num{font-family:monospace;font-weight:600;text-align:right;}
+  .app-num.events-err{color:#ef4444;}
+  .app-num.events-act{color:#3b82f6;}
+  .app-num.dim{color:#445566;}
+  .app-ep{font-family:monospace;font-size:11px;text-align:right;}
+  .app-mon{font-family:monospace;font-size:11px;text-align:right;white-space:nowrap;}
+  .app-ctr{font-family:monospace;font-size:12px;text-align:right;white-space:nowrap;}
+  .ssl-crit{color:#ef4444;font-size:10px;}
+  .ssl-warn{color:#eab308;font-size:10px;}
+  .c-green{color:#22c55e;}
+  .c-red{color:#ef4444;}
+  .c-amber{color:#eab308;}
+  .c-dim{color:#445566;}
+  .update-pill{font-size:9px;font-weight:600;padding:1px 5px;border-radius:3px;background:rgba(245,158,11,0.1);border:1px solid rgba(245,158,11,0.35);color:#f59e0b;text-transform:uppercase;}
+  /* ── Infra table (reuses .app-table styles) ── */
+  .infra-status-dot{display:inline-block;width:7px;height:7px;border-radius:50%;margin-right:5px;vertical-align:middle;}
+  .infra-status-dot.online{background:#22c55e;}
+  .infra-status-dot.degraded{background:#eab308;}
+  .infra-status-dot.offline,.infra-status-dot.unknown{background:#ef4444;}
   /* ── Containers ── */
   .container-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px;}
   .container-cell{background:#0f1215;border:1px solid #1e2530;border-radius:8px;padding:14px;}
@@ -1359,10 +1519,14 @@ var reportHTMLTemplate = `<!DOCTYPE html>
     .banner.healthy .banner-headline{color:#16a34a;}
     .banner.warning .banner-headline{color:#ca8a04;}
     .banner.critical .banner-headline{color:#dc2626;}
-    .check-card,.app-widget,.infra-card,.container-cell,.event-cell{border-color:#ddd;background:#fff;}
-    .section-label,.check-card-meta,.infra-card-type,.container-label,.app-widget-badge{color:#666;}
-    .summary-text,.cat-label,.infra-card-name{color:#333;}
-    .cat-count.none,.check-card.none .check-card-uptime{color:#999;}
+    .check-card,.container-cell,.event-cell{border-color:#ddd;background:#fff;}
+    .section-label,.check-card-meta,.container-label,.app-badge,.c-dim{color:#666;}
+    .summary-text,.app-name{color:#333;}
+    .infra-status-dot.online{background:#16a34a;}
+    .infra-status-dot.degraded{background:#ca8a04;}
+    .infra-status-dot.offline,.infra-status-dot.unknown{background:#dc2626;}
+    .check-card.none .check-card-uptime{color:#999;}
+    .app-table th,.app-table td{border-bottom-color:#ddd;}
   }
 </style>
 </head>
@@ -1442,67 +1606,53 @@ var reportHTMLTemplate = `<!DOCTYPE html>
     </div>
   </div>
 
-  <!-- App activity — widget grid -->
-  {{if .AppSections}}
+  <!-- Apps — compact table -->
+  {{if or .AppSections .ServiceSections}}
   <div class="section">
-    <div class="section-label">App Activity</div>
-    <div class="app-grid">
-      {{range .AppSections}}
-      <div class="app-widget">
-        <div class="app-widget-header">
-          <span class="app-widget-name">{{.AppName}}</span>
-          {{if .ProfileName}}<span class="app-widget-badge">{{.ProfileName}}</span>{{end}}
-        </div>
-        {{range .Categories}}
-        <div class="cat-row">
-          <span class="cat-label">{{.Label}}</span>
-          <span class="cat-count {{if and .IsError (gt .Count 0)}}has-errors{{else if gt .Count 0}}has-activity{{else}}none{{end}}">{{.Count}}</span>
-        </div>
-        {{end}}
-        {{if eq .TotalEvents 0}}
-        <div class="cat-row"><span class="cat-label" style="font-style:italic;font-size:11px;">No activity this period</span></div>
-        {{end}}
-      </div>
-      {{end}}
-    </div>
+    <div class="section-label">Apps</div>
+    <table class="app-table">
+      <thead>
+        <tr>
+          <th style="text-align:left;">App</th>
+          <th>Events</th>
+          <th>Endpoints</th>
+          <th>Monitors</th>
+          <th>Containers</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{range .AppSections}}{{template "reportAppRow" .}}{{end}}
+        {{range .ServiceSections}}{{template "reportAppRow" .}}{{end}}
+      </tbody>
+    </table>
   </div>
   {{end}}
 
-  <!-- Services — monitor_only / docker_only -->
-  {{if .ServiceSections}}
-  <div class="section">
-    <div class="section-label">Services</div>
-    <div class="app-grid">
-      {{range .ServiceSections}}
-      <div class="app-widget">
-        <div class="app-widget-header">
-          <span class="app-widget-name">{{.AppName}}</span>
-          {{if .ProfileName}}<span class="app-widget-badge">{{.ProfileName}}</span>{{end}}
-        </div>
-        <div class="cat-row">
-          <span class="cat-label" style="font-style:italic;">Monitor only — no event data</span>
-        </div>
-      </div>
-      {{end}}
-    </div>
-  </div>
-  {{end}}
-
-  <!-- Infrastructure — card grid -->
+  <!-- Infrastructure -->
   {{if .InfraRows}}
   <div class="section">
-    <div class="section-label">Infrastructure — {{.InfraOnline}} online{{if gt .InfraOffline 0}}, {{.InfraOffline}} offline{{end}}</div>
-    <div class="infra-grid">
-      {{range .InfraRows}}
-      <div class="infra-card">
-        <div class="infra-card-left">
-          <div class="infra-card-name">{{.Name}}</div>
-          <div class="infra-card-type">{{.Type}}</div>
-        </div>
-        <div class="infra-dot {{.Status}}"></div>
-      </div>
-      {{end}}
-    </div>
+    <div class="section-label">Infrastructure — <span class="c-green">{{.InfraOnline}} online</span>{{if gt .InfraOffline 0}} <span class="c-red">{{.InfraOffline}} offline</span>{{end}}</div>
+    <table class="app-table">
+      <thead>
+        <tr>
+          <th style="text-align:left;">Component</th>
+          <th style="text-align:left;">Type</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{range .InfraRows}}
+        <tr>
+          <td style="font-weight:500;color:#c8d4e0;">{{.Name}}</td>
+          <td style="font-family:monospace;font-size:11px;color:#445566;">{{.Type}}</td>
+          <td style="text-align:right;font-family:monospace;font-size:12px;">
+            <span class="infra-status-dot {{.Status}}"></span>
+            <span class="{{if eq .Status "online"}}c-green{{else if eq .Status "degraded"}}c-amber{{else}}c-red{{end}}">{{.Status}}</span>
+          </td>
+        </tr>
+        {{end}}
+      </tbody>
+    </table>
   </div>
   {{end}}
 
@@ -1510,17 +1660,23 @@ var reportHTMLTemplate = `<!DOCTYPE html>
   {{if gt .ContainersTotal 0}}
   <div class="section">
     <div class="section-label">Containers</div>
-    <div class="container-grid">
-      <div class="container-cell">
-        <div class="container-value" style="color:#22c55e;">{{.ContainersRunning}}<span style="font-size:14px;color:#445566;"> / {{.ContainersTotal}}</span></div>
-        <div class="container-label">Running</div>
-      </div>
-      <div class="container-cell">
-        <div class="container-value" style="{{if gt .UpdatesAvailable 0}}color:#eab308;{{else}}color:#445566;{{end}}">{{.UpdatesAvailable}}</div>
-        <div class="container-label">Updates Available</div>
-        {{if .NewContainers}}<div class="container-sub">New: {{range $i,$n := .NewContainers}}{{if $i}}, {{end}}{{$n}}{{end}}</div>{{end}}
-      </div>
-    </div>
+    <table class="app-table">
+      <tbody>
+        <tr>
+          <td style="color:#7a8fa8;">Running</td>
+          <td style="text-align:right;font-family:monospace;font-weight:600;" class="{{if lt .ContainersRunning .ContainersTotal}}c-amber{{else}}c-green{{end}}">{{.ContainersRunning}} / {{.ContainersTotal}}</td>
+        </tr>
+        <tr>
+          <td style="color:#7a8fa8;">Image updates available</td>
+          <td style="text-align:right;font-family:monospace;font-weight:600;" class="{{if gt .UpdatesAvailable 0}}c-amber{{else}}c-dim{{end}}">{{.UpdatesAvailable}}</td>
+        </tr>
+        {{if .NewContainers}}
+        <tr>
+          <td colspan="2" style="font-family:monospace;font-size:11px;color:#445566;">New this period: {{range $i,$n := .NewContainers}}{{if $i}}, {{end}}{{$n}}{{end}}</td>
+        </tr>
+        {{end}}
+      </tbody>
+    </table>
   </div>
   {{end}}
 
@@ -1541,5 +1697,41 @@ var reportHTMLTemplate = `<!DOCTYPE html>
   {{end}}
 
 </div>
+
+{{define "reportAppRow"}}
+<tr>
+  <td>
+    <span class="app-name{{if .HasIssues}} has-issues{{end}}">{{.AppName}}</span>
+    {{if .ProfileName}}<span class="app-badge">{{.ProfileName}}</span>{{end}}
+  </td>
+  <td class="app-num {{if .HasIssues}}events-err{{else if gt .TotalEvents 0}}events-act{{else}}dim{{end}}">
+    {{if gt .TotalEvents 0}}{{.TotalEvents}}{{else}}—{{end}}
+  </td>
+  <td class="app-ep">
+    {{if .Routes}}
+      <span class="{{if gt (len .Routes) 0}}c-green{{else}}c-dim{{end}}">{{len .Routes}}</span>
+      {{if ge .SSLMinDays 0}}
+        {{if le .SSLMinDays 7}}<span class="ssl-crit"> SSL {{.SSLMinDays}}d</span>
+        {{else if le .SSLMinDays 30}}<span class="ssl-warn"> SSL {{.SSLMinDays}}d</span>
+        {{end}}
+      {{end}}
+    {{else}}<span class="c-dim">—</span>{{end}}
+  </td>
+  <td class="app-mon">
+    {{if gt .ChecksTotal 0}}
+      {{if gt .ChecksDown 0}}<span class="c-red">{{.ChecksDown}} ✗</span> {{end}}
+      {{if gt .ChecksWarn 0}}<span class="c-amber">{{.ChecksWarn}} ▲</span> {{end}}
+      {{if and (eq .ChecksDown 0) (eq .ChecksWarn 0)}}<span class="c-green">{{.ChecksTotal}} ●</span>{{end}}
+    {{else}}<span class="c-dim">—</span>{{end}}
+  </td>
+  <td class="app-ctr">
+    {{if gt .CtrTotal 0}}
+      <span class="{{if lt .CtrRunning .CtrTotal}}c-amber{{else}}c-green{{end}}">{{.CtrRunning}}/{{.CtrTotal}}</span>
+      {{if gt .CtrUpdates 0}}<span class="update-pill"> +{{.CtrUpdates}}</span>{{end}}
+    {{else}}<span class="c-dim">—</span>{{end}}
+  </td>
+</tr>
+{{end}}
+
 </body>
 </html>`


### PR DESCRIPTION
## Summary

### Dashboard Rework
- **Unified app cards** — replaced the old Apps/Services split (AppWidget card + BookmarkWidget) with a single compact card design: icon on the left, name + status dot, last event text, and a checks `X/Y` pill
- **New section order** — Summary Bar → Events → Monitor Checks → Apps → Infrastructure
- **Events + Monitor Checks side by side** — placed in a shared 2-column row, each rendering as a 2×2 grid so they sit at equal height; event cards redesigned to match check card structure (type label, count, meta — no icon)
- **Responsive grids** — summary bar, events, and monitor checks all use `auto-fill` / fixed 2-column grids that collapse cleanly on mobile
- **Removed clutter** — all section action buttons (View all, Add app, Add check) removed from Dashboard
- **Sparklines removed** from SummaryCard; zero-count flat-line renders suppressed

### Infrastructure Page
- Container list column headers added for desktop layout
- Needs-update indicator changed from amber dot to labelled amber **"Update"** pill
- Navigate button redesigned as a pill with accent border and solid hover fill + glow

### Digest Report
- Per-app enrichment: linked monitor checks, Traefik routes (via `routeDomain()` helper), and container counts aggregated into `DigestAppSection`
- `enrichAppSection()` helper centralises all per-app data population
- Templates switched from expanded per-app widgets to compact one-row-per-app tables (App | Events | Endpoints | Monitors | Containers)
- Infrastructure and container sections use consistent column-header table layout in both HTML and email templates

### Backend
- `dashboard.go`: computes `checks_up` / `checks_total` per app from linked enabled monitor checks
- `api/types.ts`: adds `checks_up: number` and `checks_total: number` to `AppSummary`
- CSS class renamed from `.app-widget` to `.app-row` on Dashboard to avoid collision with Apps page CSS

## Test plan
- [ ] Dashboard loads and shows all 5 sections in correct order
- [ ] Events and Monitor Checks render side-by-side at equal card heights
- [ ] App cards show icon, name, last event, checks pill (X/Y) and status dot
- [ ] Apps with no linked checks show no checks pill
- [ ] Mobile view: summary bar 2×2, events 2×2, monitor checks 2×2, apps stack cleanly
- [ ] Infrastructure container list shows column headers and Update pill
- [ ] Digest report email/HTML renders compact per-app table rows
- [ ] Backend builds cleanly: `go build ./...`
- [ ] Frontend type-checks cleanly: `tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)