### PR TITLE
feat: restore missed work from ui-enhancements-01

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/digitalcheffe/nora/internal/scanner"
 	"github.com/digitalcheffe/nora/internal/scanner/discovery"
 	noraMetrics "github.com/digitalcheffe/nora/internal/scanner/metrics"
+	noraDaily    "github.com/digitalcheffe/nora/internal/scanner/daily"
 	noraSnapshot "github.com/digitalcheffe/nora/internal/scanner/snapshot"
 	"github.com/digitalcheffe/nora/migrations"
 	"github.com/go-chi/chi/v5"
@@ -314,17 +315,16 @@ func main() {
 		go watcher.Start(dockerCtx)
 	}
 
-	// Image update poller — checks container registries for newer image versions.
-	// Runs as a GlobalSnapshotJob on the 30-minute snapshot interval.
-	// Skipped if the Docker socket is not available.
-	var imagePoller *noraSnapshot.ImageUpdatePoller
-	if p, err := noraSnapshot.NewImageUpdatePoller(store); err != nil {
+	// Image update poller — checks container registries once per day for newer
+	// image versions. Registered as a GlobalDailyJob so it runs on startup and
+	// every 24 hours. Rate-limited registries (Docker Hub etc.) are safe at this
+	// frequency. Skipped if the Docker socket is not available.
+	if p, err := noraDaily.NewImageUpdatePoller(store); err != nil {
 		log.Printf("image update poller: socket not available, skipping (%v)", err)
 	} else {
-		imagePoller = p
-		scanScheduler.RegisterGlobalSnapshot(scanner.GlobalSnapshotFunc(func(ctx context.Context) {
-			if err := imagePoller.Run(ctx); err != nil {
-				log.Printf("image update poller: snapshot run: %v", err)
+		scanScheduler.RegisterGlobalDaily(scanner.GlobalDailyFunc(func(ctx context.Context) {
+			if err := p.Run(ctx); err != nil {
+				log.Printf("image update poller: daily run: %v", err)
 			}
 		}))
 	}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,12 +14,14 @@ import { Apps } from './pages/Apps'
 import { AppDetail } from './pages/AppDetail'
 import { Infrastructure } from './pages/Infrastructure'
 import { InfraComponentDetail } from './pages/InfraComponentDetail'
+import { ContainerDetail } from './pages/ContainerDetail'
 import { TopologyPage } from './pages/Topology'
 import { Relationships } from './pages/Relationships'
 import { Settings } from './pages/Settings'
 import { AppTemplateEditor } from './pages/AppTemplateEditor'
 import { Profile } from './pages/Profile'
 import { SlidePanelDevPage } from './pages/SlidePanelDevPage'
+import { NotFound } from './pages/NotFound'
 
 export default function App() {
   return (
@@ -47,6 +49,7 @@ export default function App() {
               <Route path="apps/:id" element={<AppDetail />} />
               <Route path="infrastructure" element={<Infrastructure />} />
               <Route path="infrastructure/:id" element={<InfraComponentDetail />} />
+              <Route path="containers/:id" element={<ContainerDetail />} />
               <Route path="topology" element={<TopologyPage />} />
               <Route path="network-map" element={<Navigate to="/topology" replace />} />
               <Route path="relationships" element={<Relationships />} />
@@ -54,7 +57,7 @@ export default function App() {
               <Route path="profile" element={<Profile />} />
               <Route path="app-templates/new" element={<AppTemplateEditor />} />
               <Route path="app-templates/:id/edit" element={<AppTemplateEditor />} />
-              <Route path="*" element={<Navigate to="/" replace />} />
+              <Route path="*" element={<NotFound />} />
             </Route>
           </Routes>
         </AutoRefreshProvider>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -20,6 +20,7 @@ import type {
   DigestRegistryListResponse,
   DigestSchedule,
   DiscoverResult,
+  ContainerDetail,
   DiscoveredContainer,
   DiscoveredRoute,
   Event,
@@ -46,6 +47,8 @@ import type {
   ProxmoxNodeStatusDetail,
   ProxmoxStoragePool,
   ProxmoxTaskFailure,
+  ProxmoxBackupJob,
+  ProxmoxBackupFile,
   ResourceHistory,
   ResourceSummary,
   Rule,
@@ -86,8 +89,13 @@ async function request<T>(
     if (res.status === 401 && !path.startsWith('/auth/')) {
       window.dispatchEvent(new CustomEvent('nora:session-expired'))
     }
-    const payload = await res.json().catch(() => ({ error: 'Request failed' }))
-    throw new Error(payload.error ?? `HTTP ${res.status}`)
+    let errMsg = `HTTP ${res.status}`
+    const text = await res.text().catch(() => '')
+    if (text.trim()) {
+      try { errMsg = (JSON.parse(text) as { error?: string }).error ?? text.trim() }
+      catch { errMsg = text.trim() }
+    }
+    throw new Error(errMsg)
   }
 
   if (res.status === 204) return undefined as T
@@ -467,6 +475,12 @@ export const proxmox = {
 
   taskFailures: (id: string) =>
     request<ListResponse<ProxmoxTaskFailure>>('GET', `/infrastructure/proxmox/${id}/tasks`),
+
+  backupJobs: (id: string) =>
+    request<ListResponse<ProxmoxBackupJob>>('GET', `/infrastructure/proxmox/${id}/backups`),
+
+  backupFiles: (id: string) =>
+    request<ListResponse<ProxmoxBackupFile>>('GET', `/infrastructure/proxmox/${id}/backup-files`),
 }
 
 // ── Docker Discovery ──────────────────────────────────────────────────────────
@@ -477,6 +491,9 @@ export const discovery = {
 
   allContainers: () =>
     request<ListResponse<DiscoveredContainer>>('GET', `/containers`),
+
+  getContainer: (id: string) =>
+    request<ContainerDetail>('GET', `/discovered-containers/${id}`),
 
   deleteContainer: (containerId: string) =>
     request<void>('DELETE', `/discovered-containers/${containerId}`),

--- a/frontend/src/components/AppChain.css
+++ b/frontend/src/components/AppChain.css
@@ -227,6 +227,93 @@
   user-select: none;
 }
 
+/* ── Vertical layout ─────────────────────────────────────────────────────────── */
+
+.app-chain-row--vertical {
+  flex-direction: column;
+  overflow-x: visible;
+  align-items: stretch;
+}
+
+.app-chain-row--vertical .app-chain-step {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.app-chain-row--vertical .app-chain-node {
+  width: 100%;
+  max-width: 260px;
+  height: auto;
+}
+
+.chain-connector--vertical {
+  flex-direction: column;
+  align-items: center;
+  width: auto;
+  height: 24px;
+  padding: 0;
+}
+
+.chain-connector--vertical .chain-connector-line {
+  border-top: none;
+  border-left: 2px dashed var(--border2);
+  flex: 1;
+  margin-right: 0;
+  width: 0;
+}
+
+.chain-connector--vertical .chain-connector-arrow {
+  font-size: 13px;
+  line-height: 1;
+}
+
+/* ── Traefik route sub-lines ─────────────────────────────────────────────────── */
+
+.chain-traefik-rule-line {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  flex-shrink: 1;
+}
+
+.chain-traefik-svc-line {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  flex-shrink: 1;
+}
+
+.chain-traefik-arrow {
+  font-size: 14px;
+  color: var(--text3);
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+/* ── Traefik in vertical (narrow) mode ───────────────────────────────────────── */
+
+.app-chain-wrap--vertical .app-chain-traefik {
+  flex-direction: column;
+  gap: 6px;
+}
+
+.app-chain-wrap--vertical .chain-traefik-row {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+
+.app-chain-wrap--vertical .chain-traefik-rule {
+  max-width: 200px;
+}
+
+.app-chain-wrap--vertical .chain-traefik-backend {
+  margin-left: 0;
+  font-size: 10px;
+}
+
 /* ── Traefik section ─────────────────────────────────────────────────────────── */
 
 .app-chain-traefik {

--- a/frontend/src/components/AppChain.tsx
+++ b/frontend/src/components/AppChain.tsx
@@ -108,18 +108,19 @@ interface AppChainProps {
   chain: ChainNode[]
   appStatus?: string
   traefik: ChainTraefikRoute[]
+  vertical?: boolean
 }
 
-export function AppChain({ chain, appStatus, traefik }: AppChainProps) {
+export function AppChain({ chain, appStatus, traefik, vertical }: AppChainProps) {
   const navigate = useNavigate()
 
   if (chain.length === 0) return null
 
   return (
-    <div className="app-chain-wrap">
+    <div className={`app-chain-wrap${vertical ? ' app-chain-wrap--vertical' : ''}`}>
       <div className="app-chain-label">Infrastructure</div>
 
-      <div className="app-chain-row">
+      <div className={`app-chain-row${vertical ? ' app-chain-row--vertical' : ''}`}>
         {chain.map((node, i) => {
           const href = nodeHref(node)
           const status = node.type === 'app' ? (appStatus ?? '') : node.status
@@ -156,9 +157,9 @@ export function AppChain({ chain, appStatus, traefik }: AppChainProps) {
               </div>
 
               {i < chain.length - 1 && (
-                <div className="chain-connector" aria-hidden>
+                <div className={`chain-connector${vertical ? ' chain-connector--vertical' : ''}`} aria-hidden>
                   <span className="chain-connector-line" />
-                  <span className="chain-connector-arrow">›</span>
+                  <span className="chain-connector-arrow">{vertical ? '↓' : '›'}</span>
                 </div>
               )}
             </div>
@@ -189,20 +190,16 @@ export function AppChain({ chain, appStatus, traefik }: AppChainProps) {
                 </div>
               ) : (
                 <div key={i} className="chain-traefik-row">
-                  {/* Router status + rule */}
-                  <div className="chain-status-row">
+                  {/* Rule line: status dot + rule text */}
+                  <div className="chain-traefik-rule-line">
                     <span className={`chain-dot ${statusClass(r.status)}`} title={`Router: ${statusLabel(r.status)}`} />
+                    <span className="chain-traefik-rule" title={r.rule}>{r.rule}</span>
                   </div>
-                  <span className="chain-traefik-rule" title={r.rule}>{r.rule}</span>
 
-                  {/* Arrow to service */}
+                  {/* Service line: connector + service + health + backend */}
                   {(r.service || r.router) && (
-                    <>
-                      <div className="chain-connector chain-connector--sm" aria-hidden>
-                        <span className="chain-connector-line" />
-                        <span className="chain-connector-arrow">›</span>
-                      </div>
-                      {/* Service name + its own health */}
+                    <div className="chain-traefik-svc-line">
+                      <span className="chain-traefik-arrow">›</span>
                       <span className="chain-traefik-service">{r.service || r.router}</span>
                       {r.service_status && (
                         <div className="chain-status-row chain-traefik-svc-status">
@@ -214,7 +211,6 @@ export function AppChain({ chain, appStatus, traefik }: AppChainProps) {
                           )}
                         </div>
                       )}
-                      {/* First backend host from servers_json */}
                       {(() => {
                         if (!r.servers_json) return null
                         try {
@@ -229,7 +225,7 @@ export function AppChain({ chain, appStatus, traefik }: AppChainProps) {
                           )
                         } catch { return null }
                       })()}
-                    </>
+                    </div>
                   )}
                 </div>
               )

--- a/frontend/src/components/AppMetricCard.css
+++ b/frontend/src/components/AppMetricCard.css
@@ -20,17 +20,21 @@
 
 .amc-value {
   font-family: var(--mono);
-  font-size: 24px;
-  font-weight: 600;
-  color: var(--text);
+  font-size: 30px;
+  font-weight: 700;
+  color: var(--accent);
   line-height: 1;
   text-align: center;
+  letter-spacing: -0.02em;
 }
 
 .amc-label {
   font-family: var(--mono);
-  font-size: 11px;
-  color: var(--text2);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text);
   text-align: center;
   line-height: 1.3;
 }

--- a/frontend/src/components/DetailPageLayout.css
+++ b/frontend/src/components/DetailPageLayout.css
@@ -149,6 +149,48 @@
   margin: 8px 0;
 }
 
+/* ── Event summary section ───────────────────────────────────────────────── */
+
+.dpl-event-section {
+  margin-top: 8px;
+}
+
+.dpl-event-section-title {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text3);
+  margin-bottom: 8px;
+}
+
+.dpl-event-list {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.appdetail-event-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.appdetail-event-row:last-child { border-bottom: none; }
+.appdetail-event-row:hover { background: var(--bg3); }
+
+.appdetail-event-icon { width: 16px; height: 16px; flex-shrink: 0; display: flex; align-items: center; }
+.appdetail-event-icon svg { width: 14px; height: 14px; }
+.appdetail-event-level { font-family: var(--mono); font-size: 11px; font-weight: 600; width: 68px; flex-shrink: 0; }
+.appdetail-event-count { font-family: var(--mono); font-size: 11px; font-weight: 600; flex: 1; }
+.appdetail-event-link  { font-family: var(--mono); font-size: 10px; color: var(--text3); flex-shrink: 0; }
+.appdetail-event-row:hover .appdetail-event-link { color: var(--text2); }
+
 /* ── Content area ────────────────────────────────────────────────────────── */
 
 .dpl-content {

--- a/frontend/src/components/DetailPageLayout.tsx
+++ b/frontend/src/components/DetailPageLayout.tsx
@@ -1,6 +1,7 @@
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Topbar } from './Topbar'
-import { EventFeed } from './EventFeed'
+import { events as eventsApi } from '../api/client'
 import './DetailPageLayout.css'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -36,10 +37,14 @@ export interface DetailPageLayoutProps {
   headerExtra?: React.ReactNode
   /** Optional source_type filter for EventFeed at the bottom */
   sourceType?: string
-  /** Required for EventFeed at the bottom */
-  sourceId: string
+  /** Optional — when provided, renders an EventFeed at the bottom */
+  sourceId?: string
   /** Optional custom title for the EventFeed section (defaults to "RECENT EVENTS") */
   eventFeedTitle?: string
+  /** Time filter value passed to Topbar (day/week/month) */
+  timeFilter?: 'day' | 'week' | 'month'
+  /** When provided, shows Day/Week/Month tabs in the Topbar */
+  onTimeFilter?: (f: 'day' | 'week' | 'month') => void
   /** Unique content section — rendered between dividers */
   children: React.ReactNode
 }
@@ -55,6 +60,14 @@ const STATUS_DOT_CLASS: Record<StatusIndicator['status'], string> = {
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
+const EVENT_LEVELS = ['info', 'warn', 'error', 'critical'] as const
+const EVENT_META = {
+  info:     { label: 'Info',     color: 'var(--accent)',  icon: <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><circle cx="10" cy="10" r="8"/><path d="M10 9v5M10 7h.01"/></svg> },
+  warn:     { label: 'Warn',     color: 'var(--yellow)',  icon: <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><path d="M10 3L18.5 17H1.5L10 3z"/><path d="M10 9v4M10 15h.01"/></svg> },
+  error:    { label: 'Error',    color: 'var(--red)',     icon: <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><circle cx="10" cy="10" r="8"/><path d="M7 7l6 6M13 7l-6 6"/></svg> },
+  critical: { label: 'Critical', color: 'var(--red)',     icon: <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><path d="M10 2c0 4-4 5-4 9a4 4 0 0 0 8 0c0-4-4-5-4-9z"/><path d="M8 17.5a2 2 0 0 0 4 0"/></svg> },
+}
+
 export function DetailPageLayout({
   breadcrumb,
   breadcrumbPath,
@@ -68,13 +81,27 @@ export function DetailPageLayout({
   sourceType,
   sourceId,
   eventFeedTitle,
+  timeFilter,
+  onTimeFilter,
   children,
 }: DetailPageLayoutProps) {
   const navigate = useNavigate()
+  const [eventCounts, setEventCounts] = useState<Record<string, number> | null>(null)
+
+  useEffect(() => {
+    if (!sourceId) return
+    Promise.all(
+      EVENT_LEVELS.map(level =>
+        eventsApi.list({ source_type: sourceType, source_id: sourceId, level, limit: 1 })
+          .then(res => [level, res.total] as const)
+          .catch(() => [level, 0] as const)
+      )
+    ).then(results => setEventCounts(Object.fromEntries(results)))
+  }, [sourceId, sourceType])
 
   return (
     <>
-      <Topbar title={name} />
+      <Topbar title={name} timeFilter={timeFilter} onTimeFilter={onTimeFilter} />
       <div className="content dpl-page">
 
         {/* ── Header row ── */}
@@ -133,11 +160,33 @@ export function DetailPageLayout({
         {/* ── Unique content ── */}
         <div className="dpl-content">{children}</div>
 
-        {/* ── Divider ── */}
-        <div className="dpl-divider" />
-
-        {/* ── Event feed — always at the bottom, not configurable ── */}
-        <EventFeed sourceType={sourceType} sourceId={sourceId} title={eventFeedTitle} />
+        {/* ── Event summary — only rendered when a sourceId is provided ── */}
+        {sourceId && eventCounts !== null && (
+          <>
+            <div className="dpl-divider" />
+            <div className="dpl-event-section">
+              <div className="dpl-event-section-title">{eventFeedTitle ?? 'Events'}</div>
+              <div className="dpl-event-list">
+                {EVENT_LEVELS.map(level => {
+                  const { label, color, icon: lvlIcon } = EVENT_META[level]
+                  const count = eventCounts[level] ?? 0
+                  const params = new URLSearchParams({ level })
+                  if (sourceType) params.set('source_type', sourceType)
+                  if (sourceId)   params.set('source_id', sourceId)
+                  return (
+                    <div key={level} className="appdetail-event-row"
+                      onClick={() => navigate(`/events?${params.toString()}`)}>
+                      <span className="appdetail-event-icon" style={{ color }}>{lvlIcon}</span>
+                      <span className="appdetail-event-level" style={{ color }}>{label}</span>
+                      <span className="appdetail-event-count" style={{ color }}>{count}</span>
+                      <span className="appdetail-event-link">View →</span>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          </>
+        )}
 
       </div>
     </>

--- a/frontend/src/components/ProxmoxDetail.css
+++ b/frontend/src/components/ProxmoxDetail.css
@@ -460,6 +460,95 @@
   white-space: nowrap;
 }
 
+.px-backup-vm-date {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.px-backup-inline-badge {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+.px-backup-summary-card {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 20px;
+  width: fit-content;
+  flex-wrap: wrap;
+}
+
+.px-backup-summary-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 0 20px;
+}
+
+.px-backup-summary-divider {
+  width: 1px;
+  height: 36px;
+  background: var(--border);
+  flex-shrink: 0;
+}
+
+.px-backup-summary-value {
+  font-family: var(--mono);
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1;
+}
+
+.px-backup-summary-date {
+  font-size: 13px;
+}
+
+.px-backup-summary-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text3);
+}
+
+.px-skeleton-inline {
+  height: 68px;
+  border-radius: 8px;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  width: 320px;
+}
+
+.px-backup-counts {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.px-backup-ok-icon {
+  color: var(--green);
+  font-size: 12px;
+}
+
+.px-backup-status {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+}
+
 /* ── Skeleton loading ────────────────────────────────────────────────────────── */
 
 .px-skeleton-row td {

--- a/frontend/src/components/ProxmoxDetail.tsx
+++ b/frontend/src/components/ProxmoxDetail.tsx
@@ -10,6 +10,8 @@ import type {
   ProxmoxGuestInfo,
   ProxmoxNodeStatusDetail,
   ProxmoxTaskFailure,
+  ProxmoxBackupJob,
+  ProxmoxBackupFile,
 } from '../api/types'
 import './ProxmoxDetail.css'
 
@@ -256,11 +258,15 @@ function GuestsSection({
   loading,
   error,
   onRetry,
+  backupJobs,
+  backupFiles,
 }: {
   guests: ProxmoxGuestInfo[]
   loading: boolean
   error: string | null
   onRetry: () => void
+  backupJobs: ProxmoxBackupJob[]
+  backupFiles: ProxmoxBackupFile[]
 }) {
   const [typeFilter,   setTypeFilter]   = useState<GuestTypeFilter>('all')
   const [statusFilter, setStatusFilter] = useState<GuestStatusFilter>('all')
@@ -277,6 +283,23 @@ function GuestsSection({
   const headerCount = statusFilter !== 'all'
     ? `${filtered.length} of ${guests.length} guests`
     : `${guests.length} guest${guests.length !== 1 ? 's' : ''}`
+
+  // Build per-VMID latest backup ctime from storage files (most reliable)
+  const latestBackupByVMID = useMemo(() => {
+    const map = new Map<number, number>()
+    for (const f of backupFiles) {
+      const existing = map.get(f.vmid)
+      if (!existing || f.ctime > existing) {
+        map.set(f.vmid, f.ctime)
+      }
+    }
+    return map
+  }, [backupFiles])
+
+  const lastBackup = backupJobs.length > 0
+    ? [...backupJobs].sort((a, b) => b.start_time - a.start_time)[0]
+    : null
+  const lastBackupOk = lastBackup?.exit_status === 'OK'
 
   return (
     <div className="px-section">
@@ -304,6 +327,15 @@ function GuestsSection({
             <option value="stopped">Stopped</option>
           </select>
           <span className="px-guest-count">{headerCount}</span>
+          {lastBackup && (
+            <span
+              className="px-backup-inline-badge"
+              style={{ color: lastBackupOk ? 'var(--green)' : 'var(--red)' }}
+              title={`Last backup: ${new Date(lastBackup.start_time * 1000).toLocaleString()}`}
+            >
+              {lastBackupOk ? '✓' : '✕'} backup {formatTimestamp(lastBackup.start_time)}
+            </span>
+          )}
         </div>
       </div>
 
@@ -323,6 +355,7 @@ function GuestsSection({
               <th>Disk</th>
               <th>Bridge</th>
               <th>OS / Tags</th>
+              {latestBackupByVMID.size > 0 && <th>Last Backup</th>}
             </tr>
           </thead>
           <tbody>
@@ -381,6 +414,20 @@ function GuestsSection({
                         )}
                       </div>
                     </td>
+                    {latestBackupByVMID.size > 0 && (() => {
+                      const ctime = latestBackupByVMID.get(g.vmid)
+                      return (
+                        <td>
+                          {ctime ? (
+                            <span className="px-backup-vm-date" style={{ color: 'var(--green)' }}>
+                              ✓ {formatTimestamp(ctime)}
+                            </span>
+                          ) : (
+                            <span className="px-muted">—</span>
+                          )}
+                        </td>
+                      )
+                    })()}
                   </tr>
                 )
               })
@@ -466,6 +513,55 @@ function TaskFailuresSection({
   )
 }
 
+// ── Backup Jobs ───────────────────────────────────────────────────────────────
+
+function BackupSummarySection({
+  jobs,
+  loading,
+  error,
+  onRetry,
+}: {
+  jobs: ProxmoxBackupJob[]
+  loading: boolean
+  error: string | null
+  onRetry: () => void
+}) {
+  const sorted   = [...jobs].sort((a, b) => b.start_time - a.start_time).slice(0, 50)
+  const ok       = sorted.filter(j => j.exit_status === 'OK').length
+  const failed   = sorted.length - ok
+  const lastRun  = sorted[0]
+
+  return (
+    <div className="px-section">
+      <div className="px-section-title">Backup Jobs</div>
+      {error ? (
+        <SectionError msg={error} onRetry={onRetry} />
+      ) : loading ? (
+        <div className="px-backup-summary-card px-skeleton-inline" />
+      ) : sorted.length === 0 ? (
+        <div className="px-task-clean">No completed backup jobs found.</div>
+      ) : (
+        <div className="px-overview-meta">
+          <span className="px-meta-chip" style={{ color: 'var(--green)' }}>
+            {ok} successful
+          </span>
+          {failed > 0 && (
+            <span className="px-meta-chip" style={{ color: 'var(--red)' }}>
+              {failed} failed
+            </span>
+          )}
+          <span className="px-meta-chip">{sorted.length} total runs</span>
+          {lastRun && (
+            <span className="px-meta-chip">
+              Last run {formatTimestamp(lastRun.start_time)}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ── Updates Banner ────────────────────────────────────────────────────────────
 
 function UpdatesBanner({
@@ -528,6 +624,13 @@ export function ProxmoxContent({ component }: ProxmoxContentProps) {
   const [failuresLoading, setFailuresLoading] = useState(true)
   const [failuresError,   setFailuresError]   = useState<string | null>(null)
 
+  const [backupJobs,        setBackupJobs]        = useState<ProxmoxBackupJob[]>([])
+  const [backupJobsLoading, setBackupJobsLoading] = useState(true)
+  const [backupJobsError,   setBackupJobsError]   = useState<string | null>(null)
+
+  const [backupFiles,        setBackupFiles]        = useState<ProxmoxBackupFile[]>([])
+  const [backupFilesLoading, setBackupFilesLoading] = useState(true)
+
   const loadResources = useCallback(() => {
     infraApi.resources(componentId, 'hour')
       .then(r => setResources(r))
@@ -566,13 +669,31 @@ export function ProxmoxContent({ component }: ProxmoxContentProps) {
       .finally(() => setFailuresLoading(false))
   }, [componentId])
 
+  const loadBackupJobs = useCallback(() => {
+    setBackupJobsLoading(true)
+    proxmoxApi.backupJobs(componentId)
+      .then(r => { setBackupJobs(r.data); setBackupJobsError(null) })
+      .catch(err => setBackupJobsError(err instanceof Error ? err.message : 'Failed to load backup jobs'))
+      .finally(() => setBackupJobsLoading(false))
+  }, [componentId])
+
+  const loadBackupFiles = useCallback(() => {
+    setBackupFilesLoading(true)
+    proxmoxApi.backupFiles(componentId)
+      .then(r => { setBackupFiles(r.data) })
+      .catch(() => { /* best-effort — missing permission is expected */ })
+      .finally(() => setBackupFilesLoading(false))
+  }, [componentId])
+
   useEffect(() => {
     loadResources()
     loadPools()
     loadGuests()
     loadStatus()
     loadFailures()
-  }, [loadResources, loadPools, loadGuests, loadStatus, loadFailures, tick])
+    loadBackupJobs()
+    loadBackupFiles()
+  }, [loadResources, loadPools, loadGuests, loadStatus, loadFailures, loadBackupJobs, loadBackupFiles, tick])
 
   const updatesAvailable = nodeStatuses.reduce((sum, ns) => sum + ns.updates_available, 0)
 
@@ -603,6 +724,8 @@ export function ProxmoxContent({ component }: ProxmoxContentProps) {
         loading={guestsLoading}
         error={guestsError ? `Failed to load guests. ${guestsError}` : null}
         onRetry={loadGuests}
+        backupJobs={backupJobs}
+        backupFiles={backupFilesLoading ? [] : backupFiles}
       />
 
       <TaskFailuresSection
@@ -610,6 +733,13 @@ export function ProxmoxContent({ component }: ProxmoxContentProps) {
         loading={failuresLoading}
         error={failuresError ? `Failed to load task failures. ${failuresError}` : null}
         onRetry={loadFailures}
+      />
+
+      <BackupSummarySection
+        jobs={backupJobs}
+        loading={backupJobsLoading}
+        error={backupJobsError ? `Failed to load backup jobs. ${backupJobsError}` : null}
+        onRetry={loadBackupJobs}
       />
     </>
   )

--- a/frontend/src/pages/AppDetail.css
+++ b/frontend/src/pages/AppDetail.css
@@ -333,6 +333,111 @@
   flex-direction: column;
 }
 
+/* ── Event summary rows ── */
+.appdetail-event-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.appdetail-event-row:last-child { border-bottom: none; }
+.appdetail-event-row:hover { background: var(--bg3); }
+
+.appdetail-event-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.appdetail-event-icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.appdetail-event-level {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  width: 68px;
+  flex-shrink: 0;
+}
+
+.appdetail-event-count {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  flex: 1;
+}
+
+.appdetail-event-link {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  flex-shrink: 0;
+}
+
+.appdetail-event-row:hover .appdetail-event-link {
+  color: var(--text2);
+}
+
+/* ── Monitor check rows ── */
+.appdetail-check-list {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  margin-top: 8px;
+}
+
+.appdetail-check-row {
+  display: grid;
+  grid-template-columns: 16px 1fr 1fr 52px;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.appdetail-check-row:last-child { border-bottom: none; }
+.appdetail-check-row:hover { background: var(--bg3); }
+
+.appdetail-check-name {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.appdetail-check-target {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.appdetail-check-status {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-align: right;
+  flex-shrink: 0;
+}
+
 .service-check-row {
   display: flex;
   align-items: center;
@@ -611,6 +716,35 @@
 .detail-load-more:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* ── Section header row (label + action button) ── */
+.appdetail-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+/* ── TWO-COLUMN LAYOUT ── */
+.appdetail-two-col {
+  display: grid;
+  grid-template-columns: 1fr 340px;
+  gap: 16px;
+  align-items: start;
+}
+
+.appdetail-col-left,
+.appdetail-col-right {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+@media (max-width: 768px) {
+  .appdetail-two-col {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* ── ANIMATIONS ── */

--- a/frontend/src/pages/AppDetail.tsx
+++ b/frontend/src/pages/AppDetail.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { DetailPageLayout } from '../components/DetailPageLayout'
-import { apps as appsApi, dashboard as dashboardApi, appTemplates as templatesApi, checks as checksApi } from '../api/client'
+import { apps as appsApi, dashboard as dashboardApi, appTemplates as templatesApi, checks as checksApi, events as eventsApi, infrastructure as infraApi } from '../api/client'
 import type { App, AppChainResponse, AppMetricSnapshot, AppSummary, AppTemplate, MonitorCheck } from '../api/types'
 import { AppChain } from '../components/AppChain'
 import { AppMetricCard, AppMetricCardSkeleton } from '../components/AppMetricCard'
@@ -20,25 +20,6 @@ import './AppDetail.css'
 
 type TimeFilter = 'day' | 'week' | 'month'
 
-// ── Sparkline ─────────────────────────────────────────────────────────────────
-
-function Sparkline({ data, color = 'var(--accent)' }: { data: number[]; color?: string }) {
-  if (!data || data.length < 2) return null
-  const w = 80, h = 20
-  const max = Math.max(...data, 1)
-  const pts = data.map((v, i) => {
-    const x = ((i / (data.length - 1)) * w).toFixed(1)
-    const y = (h - 2 - (v / max) * (h - 4)).toFixed(1)
-    return `${x},${y}`
-  }).join(' ')
-  const closed = `${pts} ${w},${h} 0,${h}`
-  return (
-    <svg className="detail-sparkline" viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none">
-      <polyline points={pts} fill="none" stroke={color} strokeWidth="1.5" opacity="0.8" />
-      <polyline points={closed} fill={color} stroke="none" opacity="0.08" />
-    </svg>
-  )
-}
 
 // ── App Settings Modal ────────────────────────────────────────────────────────
 
@@ -311,6 +292,18 @@ export function AppSettingsModal({ open, app, onClose, onUpdated, onDeleted }: A
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+function formatIngestTime(dateStr: string): string {
+  const d = new Date(dateStr)
+  if (isNaN(d.getTime())) return ''
+  const diff = Date.now() - d.getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'updated just now'
+  if (mins < 60) return `updated ${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `updated ${hrs}h ago`
+  return `updated ${Math.floor(hrs / 24)}d ago`
+}
+
 function statusColor(s: string | null) {
   if (s === 'up')   return 'var(--green)'
   if (s === 'warn') return 'var(--yellow)'
@@ -325,7 +318,7 @@ export function AppDetail() {
   const navigate = useNavigate()
   const { tick } = useAutoRefresh()
 
-  const timeFilter: TimeFilter = 'week'
+  const [timeFilter, setTimeFilter] = useState<TimeFilter>('week')
 
   const [app, setApp] = useState<App | null>(null)
   const [appSummary, setAppSummary] = useState<AppSummary | null>(null)
@@ -344,6 +337,7 @@ export function AppDetail() {
   const [polling, setPolling] = useState(false)
   const [pollError, setPollError] = useState<string | null>(null)
   const [appChain, setAppChain] = useState<AppChainResponse | null>(null)
+  const [eventCounts, setEventCounts] = useState<Record<string, number>>({})
 
   const appId = id ?? ''
 
@@ -392,6 +386,21 @@ export function AppDetail() {
   }, [appId, tick])
 
   useEffect(() => {
+    if (!appId) return
+    const ms = timeFilter === 'day' ? 86400000 : timeFilter === 'month' ? 30 * 86400000 : 7 * 86400000
+    const since = new Date(Date.now() - ms).toISOString()
+    Promise.all(
+      (['info', 'warn', 'error', 'critical'] as const).map(level =>
+        eventsApi.list({ source_id: appId, source_type: 'app', level, from: since, limit: 1 })
+          .then(res => [level, res.total] as const)
+          .catch(() => [level, 0] as const)
+      )
+    ).then(results => {
+      setEventCounts(Object.fromEntries(results))
+    })
+  }, [appId, timeFilter, tick])
+
+  useEffect(() => {
     if (!id) navigate('/apps')
   }, [id, navigate])
 
@@ -422,12 +431,45 @@ export function AppDetail() {
     setPolling(true)
     setPollError(null)
     try {
-      await appsApi.pollNow(appId)
+      const tasks: Promise<unknown>[] = []
+
+      // 1. API polling — skip gracefully if the profile has no api_polling config
+      tasks.push(
+        appsApi.pollNow(appId).catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : ''
+          if (msg.includes('no api_polling') || msg.includes('no profile')) return
+          throw err
+        })
+      )
+
+      // 2. Scan each infra node in the chain (skip app node itself)
+      const infraTypes = new Set([
+        'portainer', 'docker_engine', 'vm_linux', 'vm_windows', 'vm_other',
+        'proxmox_node', 'synology', 'linux_host', 'windows_host', 'generic_host', 'traefik',
+      ])
+      for (const node of appChain?.chain ?? []) {
+        if (infraTypes.has(node.type)) {
+          tasks.push(infraApi.scan(node.id).catch(() => {}))
+        }
+      }
+
+      // 3. Run all linked monitor checks
+      for (const check of appChecks) {
+        tasks.push(checksApi.run(check.id).catch(() => {}))
+      }
+
+      await Promise.all(tasks)
+
+      // Refresh metrics and checks after
       setMetricsLoading(true)
-      const res = await appsApi.metrics(appId)
-      setAppMetrics(res.data)
+      const [metricsRes, checksRes] = await Promise.all([
+        appsApi.metrics(appId).catch(() => ({ data: [] as typeof appMetrics })),
+        checksApi.list().catch(() => ({ data: [] as MonitorCheck[] })),
+      ])
+      setAppMetrics(metricsRes.data)
+      setAppChecks(checksRes.data.filter(c => c.app_id === appId))
     } catch (err: unknown) {
-      setPollError(err instanceof Error ? err.message : 'Poll failed')
+      setPollError(err instanceof Error ? err.message : 'Discover failed')
     } finally {
       setPolling(false)
       setMetricsLoading(false)
@@ -489,6 +531,8 @@ export function AppDetail() {
         keyDataPoints={keyDataPoints}
         icon={appIcon}
         headerExtra={AppExtraHeader}
+        timeFilter={timeFilter}
+        onTimeFilter={setTimeFilter}
         actions={
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6 }}>
             <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
@@ -525,72 +569,109 @@ export function AppDetail() {
             )}
           </div>
         }
-        sourceType="app"
-        sourceId={appId}
       >
-        {/* ── Live metrics + stats ── */}
-        {(metricsLoading || appMetrics.length > 0 || (appSummary?.stats ?? []).length > 0) && (
-          <div className="amg-section">
-            {!metricsLoading && <div className="amg-label">Live Metrics</div>}
-            <div className="amg-grid">
-              {metricsLoading ? (
-                [0, 1, 2].map(i => <AppMetricCardSkeleton key={i} />)
+        {/* ── Top row: events + metrics (left) | monitor checks (right) ── */}
+        <div className="appdetail-two-col">
+
+          <div className="appdetail-col-left">
+
+            {/* Live metrics */}
+            {(metricsLoading || appMetrics.length > 0 || (appSummary?.stats ?? []).length > 0) && (
+              <div className="amg-section">
+                {!metricsLoading && <div className="amg-label">Live Metrics</div>}
+                <div className="amg-grid">
+                  {metricsLoading ? (
+                    [0, 1, 2].map(i => <AppMetricCardSkeleton key={i} />)
+                  ) : (
+                    <>
+                      {appMetrics.map(m => <AppMetricCard key={m.id} metric={m} />)}
+                      {(appSummary?.stats ?? []).map(stat => (
+                        <div key={`stat-${stat.label}`} className="amc-card">
+                          <div className={`amc-value${stat.color ? ` color-${stat.color}` : ''}`}>{stat.value}</div>
+                          <div className="amc-label">{stat.label}</div>
+                          {appSummary?.last_event_at && (
+                            <div className="amc-timestamp">{formatIngestTime(appSummary.last_event_at)}</div>
+                          )}
+                        </div>
+                      ))}
+                    </>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Event summary */}
+            <div className="amg-section">
+              <div className="amg-label">Events ({timeFilter === 'day' ? 'last 24h' : timeFilter === 'month' ? 'last month' : 'last week'})</div>
+              <div className="appdetail-check-list">
+                {([
+                  { level: 'info',     label: 'Info',     colorVar: 'var(--accent)',
+                    icon: <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><circle cx="10" cy="10" r="8"/><path d="M10 9v5M10 7h.01"/></svg> },
+                  { level: 'warn',     label: 'Warnings', colorVar: 'var(--yellow)',
+                    icon: <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><path d="M10 3L18.5 17H1.5L10 3z"/><path d="M10 9v4M10 15h.01"/></svg> },
+                  { level: 'error',    label: 'Errors',   colorVar: 'var(--red)',
+                    icon: <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><circle cx="10" cy="10" r="8"/><path d="M7 7l6 6M13 7l-6 6"/></svg> },
+                  { level: 'critical', label: 'Critical', colorVar: 'var(--red)',
+                    icon: <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><path d="M10 2c0 4-4 5-4 9a4 4 0 0 0 8 0c0-4-4-5-4-9z"/><path d="M8 17.5a2 2 0 0 0 4 0"/></svg> },
+                ] as const).map(({ level, label, colorVar, icon }) => (
+                  <div
+                    key={level}
+                    className="appdetail-event-row"
+                    onClick={() => navigate(`/events?source_type=app&source_id=${appId}&level=${level}`)}
+                  >
+                    <span className="appdetail-event-icon" style={{ color: colorVar }}>{icon}</span>
+                    <span className="appdetail-event-level" style={{ color: colorVar }}>{label}</span>
+                    <span className="appdetail-event-count" style={{ color: colorVar }}>
+                      {eventCounts[level] ?? '—'}
+                    </span>
+                    <span className="appdetail-event-link">View →</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Monitor checks as cards */}
+            <div className="amg-section">
+              <div className="appdetail-section-header">
+                <span className="amg-label" style={{ marginBottom: 0 }}>Monitor Checks</span>
+                <button className="service-add-check-btn" onClick={openAddCheck}>+ Add check</button>
+              </div>
+              {appChecks.length === 0 ? (
+                <div className="service-checks-empty" style={{ background: 'none', border: 'none', padding: '8px 0', textAlign: 'left' }}>
+                  No monitor checks linked to this app yet.
+                </div>
               ) : (
-                <>
-                  {appMetrics.map(m => <AppMetricCard key={m.id} metric={m} />)}
-                  {(appSummary?.stats ?? []).map(stat => (
-                    <div key={`stat-${stat.label}`} className="amc-card">
-                      <div className={`amc-value${stat.color ? ` color-${stat.color}` : ''}`}>{stat.value}</div>
-                      <div className="amc-label">{stat.label}</div>
+                <div className="appdetail-check-list">
+                  {appChecks.map(c => (
+                    <div key={c.id} className="appdetail-check-row" onClick={() => navigate(`/checks/${c.id}`)}>
+                      <CheckTypeIcon type={c.type} size={14} />
+                      <span className="appdetail-check-name" title={c.name}>{c.name}</span>
+                      <span className="appdetail-check-target" title={c.target}>{c.target}</span>
+                      <span className="appdetail-check-status" style={{ color: statusColor(c.last_status) }}>
+                        {c.last_status?.toUpperCase() ?? '—'}
+                      </span>
                     </div>
                   ))}
-                  {appSummary?.sparkline.some(v => v > 0) && (
-                    <div className="amc-card">
-                      <div className="amc-label">Activity</div>
-                      <Sparkline data={Array.from(appSummary.sparkline)} />
-                    </div>
-                  )}
-                </>
+                </div>
               )}
             </div>
-          </div>
-        )}
 
-        {/* ── Infrastructure chain ── */}
-        {appChain && appChain.chain.length > 0 && (
-          <AppChain
-            chain={appChain.chain}
-            appStatus={appSummary?.status}
-            traefik={appChain.traefik ?? []}
-          />
-        )}
-
-        {/* ── Monitor checks — shown for all apps ── */}
-        <div className="service-checks-section">
-          <div className="service-checks-header">
-            <span className="service-checks-title">Monitor Checks</span>
-            <button className="service-add-check-btn" onClick={openAddCheck}>+ Add check</button>
           </div>
-          {appChecks.length === 0 ? (
-            <div className="service-checks-empty">
-              No monitor checks linked to this app yet.
-            </div>
-          ) : (
-            <div className="service-checks-list">
-              {appChecks.map(c => (
-                <div key={c.id} className="service-check-row" onClick={() => navigate(`/checks/${c.id}`)}>
-                  <CheckTypeIcon type={c.type} size={14} />
-                  <span className="service-check-type">{c.type.toUpperCase()}</span>
-                  <span className="service-check-target">{c.target}</span>
-                  <span className="service-check-name">{c.name !== c.target ? c.name : ''}</span>
-                  <span className="service-check-status" style={{ color: statusColor(c.last_status) }}>
-                    {c.last_status?.toUpperCase() ?? '—'}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
+
+          {/* Right column: infra chain (vertical) only */}
+          <div className="appdetail-col-right">
+            {appChain && appChain.chain.length > 0 && (
+              <AppChain
+                chain={appChain.chain}
+                appStatus={appSummary?.status}
+                traefik={appChain.traefik ?? []}
+                vertical
+              />
+            )}
+          </div>
+
         </div>
+
       </DetailPageLayout>
 
       {app && (

--- a/frontend/src/pages/Apps.css
+++ b/frontend/src/pages/Apps.css
@@ -249,6 +249,250 @@
 .card-dropdown-item.danger { color: var(--red); }
 .card-dropdown-item.danger:hover { background: var(--red-dim); color: var(--red); }
 
+/* ── Summary pill strip ── */
+.apps-stats-strip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.apps-stats-pill {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text2);
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px 10px;
+}
+
+.apps-stats-sep {
+  width: 1px;
+  height: 14px;
+  background: var(--border2);
+  flex-shrink: 0;
+  margin: 0 2px;
+}
+
+/* ── Summary bar (old — kept for reference) ── */
+.apps-summary-bar {
+  display: flex;
+  align-items: stretch;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+/* Each group is its own card */
+.apps-summary-group {
+  flex: 1;
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 20px 10px;
+  gap: 0;
+}
+
+.apps-summary-group-stats {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  flex: 1;
+}
+
+.apps-summary-group-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text2);
+  margin-top: 10px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
+  text-align: center;
+}
+
+.apps-summary-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.apps-summary-value {
+  font-family: var(--mono);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text);
+  letter-spacing: -0.02em;
+}
+
+.apps-summary-label {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text3);
+}
+
+/* dividers no longer needed — kept for safety but hidden */
+.apps-summary-divider { display: none; }
+
+/* ── Bottom two-column sections ── */
+.apps-bottom-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+@media (max-width: 768px) {
+  .apps-bottom-grid { grid-template-columns: 1fr; }
+}
+
+.apps-section {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.apps-section-title {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text3);
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+/* ── Check rows ── */
+.apps-checks-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.apps-check-row {
+  display: grid;
+  grid-template-columns: 8px 1fr 1fr 48px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.apps-check-row:last-child { border-bottom: none; }
+.apps-check-row:hover { background: var(--bg3); }
+
+.apps-check-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text3);
+  flex-shrink: 0;
+}
+.apps-check-dot.up   { background: var(--green); box-shadow: 0 0 4px var(--green); }
+.apps-check-dot.down { background: var(--red); }
+.apps-check-dot.warn { background: var(--yellow); }
+
+.apps-check-name {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.apps-check-target {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.apps-check-status {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 700;
+  text-align: right;
+}
+
+/* ── Activity rows ── */
+.apps-activity-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.apps-activity-row {
+  display: grid;
+  grid-template-columns: 8px auto 1fr auto;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.apps-activity-row:last-child { border-bottom: none; }
+.apps-activity-row:hover { background: var(--bg3); }
+
+.apps-activity-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--text3);
+}
+.apps-activity-dot.sev-info     { background: var(--accent); }
+.apps-activity-dot.sev-warn     { background: var(--yellow); }
+.apps-activity-dot.sev-error    { background: var(--red); }
+.apps-activity-dot.sev-critical { background: var(--red); }
+
+.apps-activity-app {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text2);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.apps-activity-msg {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.apps-activity-time {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--text3);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 @keyframes fadeUp {
   from { opacity: 0; transform: translateY(6px); }
   to   { opacity: 1; transform: translateY(0); }

--- a/frontend/src/pages/Checks.css
+++ b/frontend/src/pages/Checks.css
@@ -1,3 +1,226 @@
+/* ── Summary bar ── */
+.checks-summary-bar {
+  display: flex;
+  align-items: stretch;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.checks-summary-group {
+  flex: 1;
+  min-width: 140px;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 20px 10px;
+}
+
+.checks-summary-group-stats {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  flex: 1;
+}
+
+.checks-summary-group-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text2);
+  margin-top: 10px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
+  text-align: center;
+}
+
+.checks-summary-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.checks-summary-value {
+  font-family: var(--mono);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text);
+  letter-spacing: -0.02em;
+}
+
+.checks-summary-label {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text3);
+}
+
+/* ── Section header inline stats ── */
+.checks-header-stats {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text2);
+  flex: 1;
+  margin-left: 16px;
+}
+
+.checks-header-dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--border2);
+  flex-shrink: 0;
+}
+
+.checks-header-sep {
+  width: 1px;
+  height: 12px;
+  background: var(--border2);
+  flex-shrink: 0;
+  margin: 0 4px;
+}
+
+/* ── Filter / search bar ── */
+.checks-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.checks-search {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 7px 12px;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
+  outline: none;
+  width: 220px;
+  transition: border-color 0.15s;
+}
+.checks-search:focus { border-color: var(--accent); }
+.checks-search::placeholder { color: var(--text3); }
+
+.checks-filter-pills {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.checks-filter-pill {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--bg2);
+  color: var(--text3);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.checks-filter-pill:hover { border-color: var(--accent); color: var(--accent); }
+.checks-filter-pill.active {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.checks-view-toggle {
+  display: flex;
+  margin-left: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.checks-view-btn {
+  padding: 6px 12px;
+  background: none;
+  border: none;
+  color: var(--text3);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.checks-view-btn.active { background: var(--bg4); color: var(--text); }
+.checks-view-btn:hover:not(.active) { background: var(--bg3); color: var(--text2); }
+
+/* ── Compact table view ── */
+.checks-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.checks-table th {
+  text-align: left;
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text3);
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.checks-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text2);
+  vertical-align: middle;
+}
+
+.checks-table tr:last-child td { border-bottom: none; }
+
+.checks-table tr:hover td { background: var(--bg3); }
+
+.checks-table-wrap {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  overflow-x: auto;
+}
+
+.checks-table-name {
+  color: var(--text);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.checks-table-target {
+  color: var(--text3);
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.checks-table-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
 /* ── EMPTY STATE ── */
 .checks-empty {
   padding: 40px;

--- a/frontend/src/pages/ContainerDetail.css
+++ b/frontend/src/pages/ContainerDetail.css
@@ -1,0 +1,351 @@
+/* ── Container Detail Page ── */
+
+/* ── Field list ──────────────────────────────────────────────────────────────── */
+
+.ctr-det-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ctr-det-field {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.ctr-det-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  min-width: 110px;
+  flex-shrink: 0;
+}
+
+.ctr-det-value {
+  font-size: 13px;
+  color: var(--text1);
+  word-break: break-all;
+}
+
+.ctr-det-mono {
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.ctr-det-dim {
+  color: var(--text3);
+  font-size: 12px;
+}
+
+.ctr-det-digest {
+  font-size: 11px;
+  word-break: break-all;
+}
+
+/* ── Section title count badge ───────────────────────────────────────────────── */
+
+.ctr-section-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 600;
+  min-width: 18px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--bg4);
+  color: var(--text3);
+  margin-left: 8px;
+  letter-spacing: 0;
+  vertical-align: middle;
+}
+
+/* ── Key-value grid (ports, networks) ────────────────────────────────────────── */
+
+.ctr-kv-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ctr-kv-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 5px 10px;
+  background: var(--bg3);
+  border-radius: 4px;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.ctr-kv-key {
+  color: var(--text1);
+  flex-shrink: 0;
+}
+
+.ctr-kv-val {
+  color: var(--text3);
+  font-size: 11px;
+}
+
+/* ── Port pills ──────────────────────────────────────────────────────────────── */
+
+.ctr-port-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.ctr-port-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--bg3);
+  color: var(--text1);
+  white-space: nowrap;
+}
+
+.ctr-port-type {
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text3);
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--bg4);
+}
+
+.ctr-port-tcp .ctr-port-type {
+  color: #60a5fa;
+  background: rgba(96, 165, 250, 0.1);
+}
+
+.ctr-port-udp .ctr-port-type {
+  color: #a78bfa;
+  background: rgba(167, 139, 250, 0.1);
+}
+
+/* ── Mounts ──────────────────────────────────────────────────────────────────── */
+
+.ctr-mount-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ctr-mount-row {
+  padding: 8px 10px;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.ctr-mount-dest {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text1);
+}
+
+.ctr-mount-arrow {
+  color: var(--accent);
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.ctr-mount-src {
+  font-size: 11px;
+  padding-left: 20px;
+  word-break: break-all;
+}
+
+.ctr-mount-badges {
+  display: flex;
+  gap: 4px;
+  padding-left: 20px;
+  margin-top: 2px;
+  flex-wrap: wrap;
+}
+
+.ctr-mount-badge {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--bg4);
+  color: var(--text3);
+  border: 1px solid var(--border);
+}
+
+.ctr-mount-ro {
+  color: var(--red, #f87171);
+  border-color: rgba(248, 113, 113, 0.3);
+  background: rgba(248, 113, 113, 0.08);
+}
+
+.ctr-mount-rw {
+  color: var(--green, #4ade80);
+  border-color: rgba(74, 222, 128, 0.3);
+  background: rgba(74, 222, 128, 0.08);
+}
+
+/* ── Environment variables ───────────────────────────────────────────────────── */
+
+.ctr-env-table {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.ctr-env-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 30%) 1fr;
+  align-items: baseline;
+  gap: 0;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.ctr-env-row:last-child {
+  border-bottom: none;
+}
+
+.ctr-env-row:hover {
+  background: var(--bg3);
+}
+
+.ctr-env-key {
+  color: var(--text2);
+  font-size: 11px;
+  word-break: break-all;
+  padding-right: 12px;
+}
+
+.ctr-env-val {
+  color: var(--text1);
+  font-size: 11px;
+  word-break: break-all;
+}
+
+.ctr-env-masked {
+  color: var(--text3);
+  letter-spacing: 0.1em;
+  user-select: none;
+}
+
+/* ── Show more button ────────────────────────────────────────────────────────── */
+
+.ctr-show-more {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 6px 0 2px;
+  transition: color 0.15s;
+  text-align: left;
+}
+
+.ctr-show-more:hover {
+  color: var(--accent);
+}
+
+/* ── Linked app header extra ─────────────────────────────────────────────────── */
+
+.ctr-det-linked-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ctr-det-linked-row,
+.ctr-det-link-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.ctr-det-linked-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  min-width: 70px;
+}
+
+.ctr-det-linked-name {
+  font-size: 13px;
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.ctr-det-select {
+  font-family: var(--mono);
+  font-size: 12px;
+  background: var(--bg2);
+  color: var(--text1);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+}
+
+.ctr-det-link-btn,
+.ctr-det-unlink-btn {
+  font-family: var(--mono);
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  background: var(--bg2);
+  color: var(--text2);
+  transition: background 0.15s, color 0.15s;
+}
+
+.ctr-det-link-btn:hover:not(:disabled),
+.ctr-det-unlink-btn:hover:not(:disabled) {
+  background: var(--bg3);
+  color: var(--text1);
+}
+
+.ctr-det-link-btn:disabled,
+.ctr-det-unlink-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.ctr-det-error {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--red);
+}

--- a/frontend/src/pages/ContainerDetail.tsx
+++ b/frontend/src/pages/ContainerDetail.tsx
@@ -1,0 +1,382 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useAutoRefresh } from '../context/AutoRefreshContext'
+import { DetailPageLayout } from '../components/DetailPageLayout'
+import { discovery, apps as appsApi } from '../api/client'
+import type { ContainerDetail as ContainerDetailType, App } from '../api/types'
+import './InfraComponentDetail.css'
+import './ContainerDetail.css'
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+function sourceLabel(s: string) {
+  if (s === 'docker_engine') return 'Docker'
+  if (s === 'portainer')     return 'Portainer'
+  return s || '—'
+}
+
+// Regex for env var keys that likely contain sensitive values.
+const SENSITIVE_RE = /password|passwd|pwd|secret|token|_key|apikey|api_key|auth(?!or)|credential|private/i
+
+function isSensitive(key: string): boolean {
+  return SENSITIVE_RE.test(key)
+}
+
+interface PortBinding { PrivatePort: number; PublicPort?: number; Type: string; IP?: string }
+interface NetworkEntry  { name: string; ip?: string }
+interface VolumeEntry   { Source?: string; Destination: string; Mode?: string; Type?: string; RW?: boolean }
+interface EnvEntry      { key: string; value: string }
+
+function parsePorts(raw: string | null): PortBinding[] {
+  if (!raw) return []
+  try { return JSON.parse(raw) as PortBinding[] } catch { return [] }
+}
+function parseNetworks(raw: string | null): NetworkEntry[] {
+  if (!raw) return []
+  try { return JSON.parse(raw) as NetworkEntry[] } catch { return [] }
+}
+function parseVolumes(raw: string | null): VolumeEntry[] {
+  if (!raw) return []
+  try { return JSON.parse(raw) as VolumeEntry[] } catch { return [] }
+}
+function parseEnvVars(raw: string | null): EnvEntry[] {
+  if (!raw) return []
+  try {
+    const arr = JSON.parse(raw) as string[]
+    return arr.map(entry => {
+      const idx = entry.indexOf('=')
+      if (idx === -1) return { key: entry, value: '' }
+      return { key: entry.slice(0, idx), value: entry.slice(idx + 1) }
+    })
+  } catch { return [] }
+}
+function parseLabels(raw: string | null): [string, string][] {
+  if (!raw) return []
+  try {
+    const obj = JSON.parse(raw) as Record<string, string>
+    return Object.entries(obj).sort(([a], [b]) => a.localeCompare(b))
+  } catch { return [] }
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function ContainerDetail() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { tick } = useAutoRefresh()
+
+  const [ctr, setCtr] = useState<ContainerDetailType | null>(null)
+  const [allApps, setAllApps] = useState<App[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showAllEnv, setShowAllEnv] = useState(false)
+  const [showAllLabels, setShowAllLabels] = useState(false)
+
+  const [linkAppId, setLinkAppId] = useState('')
+  const [linkBusy, setLinkBusy] = useState(false)
+  const [linkError, setLinkError] = useState('')
+
+  useEffect(() => {
+    if (!id) return
+    discovery.getContainer(id)
+      .then(c => { setCtr(c); setLoading(false) })
+      .catch(() => navigate('/infrastructure'))
+    appsApi.list()
+      .then(res => setAllApps(res.data))
+      .catch(() => {})
+  }, [id, navigate, tick])
+
+  async function handleLink() {
+    if (!id || !linkAppId) return
+    setLinkBusy(true)
+    setLinkError('')
+    try {
+      await discovery.linkContainerApp(id, { mode: 'existing', app_id: linkAppId })
+      const updated = await discovery.getContainer(id)
+      setCtr(updated)
+      setLinkAppId('')
+    } catch {
+      setLinkError('Failed to link app')
+    } finally {
+      setLinkBusy(false)
+    }
+  }
+
+  async function handleUnlink() {
+    if (!id) return
+    setLinkBusy(true)
+    setLinkError('')
+    try {
+      await discovery.unlinkContainerApp(id)
+      const updated = await discovery.getContainer(id)
+      setCtr(updated)
+    } catch {
+      setLinkError('Failed to unlink app')
+    } finally {
+      setLinkBusy(false)
+    }
+  }
+
+  if (loading || !ctr) {
+    return null
+  }
+
+  const ports    = parsePorts(ctr.ports)
+  const networks = parseNetworks(ctr.networks)
+  const volumes  = parseVolumes(ctr.volumes)
+  const envVars  = parseEnvVars(ctr.env_vars)
+  const labels   = parseLabels(ctr.labels)
+
+  const ENV_PREVIEW  = 10
+  const LABEL_PREVIEW = 8
+  const visibleEnv    = showAllEnv    ? envVars : envVars.slice(0, ENV_PREVIEW)
+  const visibleLabels = showAllLabels ? labels  : labels.slice(0, LABEL_PREVIEW)
+
+  const linkedApp = allApps.find(a => a.id === ctr.app_id)
+  const available = allApps.filter(a => a.id !== ctr.app_id)
+
+  const dplStatus = ctr.status === 'running' ? 'online'
+    : (ctr.status === 'stopped' || ctr.status === 'exited') ? 'offline'
+    : 'unknown'
+
+  const keyDataPoints = [
+    { label: 'Source', value: sourceLabel(ctr.source_type) },
+    { label: 'Image',  value: ctr.image.length > 40 ? ctr.image.slice(0, 40) + '…' : ctr.image },
+    ...(ctr.restart_policy ? [{ label: 'Restart', value: ctr.restart_policy }] : []),
+  ]
+
+  const linkedAppExtra = (
+    <div className="ctr-det-linked-section">
+      {linkedApp ? (
+        <div className="ctr-det-linked-row">
+          <span className="ctr-det-linked-label">Linked App</span>
+          <span
+            className="ctr-det-linked-name"
+            onClick={() => navigate(`/apps/${linkedApp.id}`)}
+          >
+            {linkedApp.name}
+          </span>
+          <button
+            className="ctr-det-unlink-btn"
+            onClick={() => void handleUnlink()}
+            disabled={linkBusy}
+          >
+            {linkBusy ? 'Unlinking…' : 'Unlink'}
+          </button>
+        </div>
+      ) : (
+        <div className="ctr-det-link-row">
+          <span className="ctr-det-linked-label">Link App</span>
+          <select
+            className="ctr-det-select"
+            value={linkAppId}
+            onChange={e => setLinkAppId(e.target.value)}
+          >
+            <option value="">— select app —</option>
+            {available.map(a => (
+              <option key={a.id} value={a.id}>{a.name}</option>
+            ))}
+          </select>
+          <button
+            className="ctr-det-link-btn"
+            onClick={() => void handleLink()}
+            disabled={!linkAppId || linkBusy}
+          >
+            {linkBusy ? 'Linking…' : 'Link'}
+          </button>
+        </div>
+      )}
+      {linkError && <div className="ctr-det-error">{linkError}</div>}
+    </div>
+  )
+
+  return (
+    <DetailPageLayout
+      breadcrumb="Infrastructure"
+      breadcrumbPath="/infrastructure"
+      name={ctr.container_name}
+      status={{ status: dplStatus, label: ctr.status }}
+      keyDataPoints={keyDataPoints}
+      headerExtra={linkedAppExtra}
+      sourceId={ctr.id}
+    >
+      {/* ── Image ── */}
+      <div className="icd-section">
+        <div className="icd-section-title">Image</div>
+        <div className="ctr-det-fields">
+          <div className="ctr-det-field">
+            <span className="ctr-det-label">Name</span>
+            <span className="ctr-det-value ctr-det-mono">{ctr.image}</span>
+          </div>
+          <div className="ctr-det-field">
+            <span className="ctr-det-label">Update</span>
+            <span className="ctr-det-value">
+              {ctr.image_last_checked_at === null
+                ? <span className="ctr-det-dim">Not checked yet</span>
+                : ctr.image_update_available
+                  ? <span className="de-update-badge">Update available</span>
+                  : <span className="de-uptodate-badge">Up to date</span>
+              }
+            </span>
+          </div>
+          {ctr.image_last_checked_at && (
+            <div className="ctr-det-field">
+              <span className="ctr-det-label">Checked</span>
+              <span className="ctr-det-value ctr-det-dim">
+                {new Date(ctr.image_last_checked_at).toLocaleString()}
+              </span>
+            </div>
+          )}
+          {ctr.image_digest && (
+            <div className="ctr-det-field">
+              <span className="ctr-det-label">Local digest</span>
+              <span className="ctr-det-value ctr-det-mono ctr-det-digest">{ctr.image_digest}</span>
+            </div>
+          )}
+          {ctr.registry_digest && (
+            <div className="ctr-det-field">
+              <span className="ctr-det-label">Registry digest</span>
+              <span className="ctr-det-value ctr-det-mono ctr-det-digest">{ctr.registry_digest}</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── Runtime ── */}
+      <div className="icd-section">
+        <div className="icd-section-title">Runtime</div>
+        <div className="ctr-det-fields">
+          <div className="ctr-det-field">
+            <span className="ctr-det-label">Container ID</span>
+            <span className="ctr-det-value ctr-det-mono ctr-det-digest">{ctr.container_id || '—'}</span>
+          </div>
+          {ctr.docker_created_at && (
+            <div className="ctr-det-field">
+              <span className="ctr-det-label">Created</span>
+              <span className="ctr-det-value ctr-det-dim">
+                {new Date(ctr.docker_created_at).toLocaleString()}
+              </span>
+            </div>
+          )}
+          <div className="ctr-det-field">
+            <span className="ctr-det-label">Last seen</span>
+            <span className="ctr-det-value ctr-det-dim">
+              {new Date(ctr.last_seen_at).toLocaleString()}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Ports ── */}
+      {ports.length > 0 && (
+        <div className="icd-section">
+          <div className="icd-section-title">Ports</div>
+          <div className="ctr-port-pills">
+            {ports.map((p, i) => (
+              <span key={i} className={`ctr-port-pill ctr-port-${p.Type}`}>
+                {p.PublicPort ? `${p.PublicPort}:${p.PrivatePort}` : String(p.PrivatePort)}
+                <span className="ctr-port-type">{p.Type}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Networks ── */}
+      {networks.length > 0 && (
+        <div className="icd-section">
+          <div className="icd-section-title">Networks</div>
+          <div className="ctr-kv-grid">
+            {networks.map((n, i) => (
+              <div key={i} className="ctr-kv-row">
+                <span className="ctr-kv-key">{n.name}</span>
+                <span className="ctr-kv-val ctr-det-dim">{n.ip || '—'}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Mounts ── */}
+      {volumes.length > 0 && (
+        <div className="icd-section">
+          <div className="icd-section-title">Mounts</div>
+          <div className="ctr-mount-list">
+            {volumes.map((v, i) => (
+              <div key={i} className="ctr-mount-row">
+                <div className="ctr-mount-dest">
+                  <span className="ctr-mount-arrow">→</span>
+                  <span className="ctr-det-mono">{v.Destination}</span>
+                </div>
+                {v.Source && (
+                  <div className="ctr-mount-src ctr-det-mono ctr-det-dim">{v.Source}</div>
+                )}
+                <div className="ctr-mount-badges">
+                  {v.Type && <span className="ctr-mount-badge">{v.Type}</span>}
+                  {v.Mode && v.Mode !== 'z' && <span className="ctr-mount-badge">{v.Mode}</span>}
+                  {v.RW === false && <span className="ctr-mount-badge ctr-mount-ro">ro</span>}
+                  {v.RW === true  && <span className="ctr-mount-badge ctr-mount-rw">rw</span>}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Environment ── */}
+      {envVars.length > 0 && (
+        <div className="icd-section">
+          <div className="icd-section-title">
+            Environment
+            <span className="ctr-section-count">{envVars.length}</span>
+          </div>
+          <div className="ctr-env-table">
+            {visibleEnv.map((ev, i) => {
+              const masked = isSensitive(ev.key)
+              return (
+                <div key={i} className="ctr-env-row">
+                  <span className="ctr-env-key">{ev.key}</span>
+                  <span className={`ctr-env-val${masked ? ' ctr-env-masked' : ''}`}>
+                    {masked ? '••••••••' : (ev.value || <span className="ctr-det-dim">(empty)</span>)}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+          {envVars.length > ENV_PREVIEW && (
+            <button className="ctr-show-more" onClick={() => setShowAllEnv(v => !v)}>
+              {showAllEnv
+                ? `▲ Show fewer`
+                : `▼ Show ${envVars.length - ENV_PREVIEW} more`}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* ── Labels ── */}
+      {labels.length > 0 && (
+        <div className="icd-section">
+          <div className="icd-section-title">
+            Labels
+            <span className="ctr-section-count">{labels.length}</span>
+          </div>
+          <div className="ctr-env-table">
+            {visibleLabels.map(([k, v], i) => (
+              <div key={i} className="ctr-env-row">
+                <span className="ctr-env-key">{k}</span>
+                <span className="ctr-env-val">{v || <span className="ctr-det-dim">(empty)</span>}</span>
+              </div>
+            ))}
+          </div>
+          {labels.length > LABEL_PREVIEW && (
+            <button className="ctr-show-more" onClick={() => setShowAllLabels(v => !v)}>
+              {showAllLabels
+                ? `▲ Show fewer`
+                : `▼ Show ${labels.length - LABEL_PREVIEW} more`}
+            </button>
+          )}
+        </div>
+      )}
+
+    </DetailPageLayout>
+  )
+}

--- a/frontend/src/pages/Events.css
+++ b/frontend/src/pages/Events.css
@@ -147,6 +147,14 @@
 }
 .event-app-link:hover { color: var(--accent); text-decoration: underline; }
 
+/* ── Time range selector ─────────────────────────────────────────────────────── */
+
+.events-range-row {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
 /* ── Chart ──────────────────────────────────────────────────────────────────── */
 
 .events-chart-container {
@@ -193,14 +201,13 @@
 
 .events-chart-body {
   padding: 8px 8px 4px;
-  height: 200px;
   display: flex;
   align-items: center;
 }
 
 .events-chart-svg {
   width: 100%;
-  height: 100%;
+  display: block;
 }
 
 .chart-empty {

--- a/frontend/src/pages/Events.tsx
+++ b/frontend/src/pages/Events.tsx
@@ -3,22 +3,22 @@ import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useAutoRefresh } from '../context/AutoRefreshContext'
 import { Topbar } from '../components/Topbar'
 import { EventRow } from '../components/EventRow'
-import { events as eventsApi } from '../api/client'
-import type { Event, EventFilter, EventSort, Severity, TimeseriesBucket } from '../api/types'
+import { apps as appsApi, checks as checksApi, events as eventsApi, infrastructure as infraApi } from '../api/client'
+import type { App, Event, EventFilter, EventSort, InfrastructureComponent, MonitorCheck, Severity, TimeseriesBucket } from '../api/types'
 import './Events.css'
 
-type TimeFilter = 'day' | 'week' | 'month'
 type ChartRange = 'day' | 'week' | 'month' | '3m'
 type SourceType = '' | 'app' | 'infra' | 'check'
 
 const SEVERITIES: Severity[] = ['debug', 'info', 'warn', 'error', 'critical']
 const PAGE_SIZES = [25, 50, 100, 500]
 
-function sinceFromTimeFilter(tf: TimeFilter): string {
+function sinceFromChartRange(range: ChartRange): string {
   const d = new Date()
-  if (tf === 'day') d.setDate(d.getDate() - 1)
-  else if (tf === 'week') d.setDate(d.getDate() - 7)
-  else d.setMonth(d.getMonth() - 1)
+  if (range === 'day') d.setDate(d.getDate() - 1)
+  else if (range === 'week') d.setDate(d.getDate() - 7)
+  else if (range === 'month') d.setMonth(d.getMonth() - 1)
+  else d.setMonth(d.getMonth() - 3)
   return d.toISOString()
 }
 
@@ -96,11 +96,24 @@ function EventsLineChart({
   buckets: TimeseriesBucket[]
   granularity: 'hour' | 'day'
 }) {
+  const svgRef = useRef<SVGSVGElement>(null)
+  const [W, setW] = useState(800)
+
+  useEffect(() => {
+    const el = svgRef.current
+    if (!el) return
+    const ro = new ResizeObserver(entries => {
+      const w = entries[0]?.contentRect.width
+      if (w && w > 0) setW(Math.floor(w))
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
   if (buckets.length === 0) {
     return <div className="chart-empty">No event data for this range</div>
   }
 
-  const W = 800
   const H = 180
   const padL = 38
   const padR = 16
@@ -138,9 +151,10 @@ function EventsLineChart({
 
   return (
     <svg
-      viewBox={`0 0 ${W} ${H}`}
+      ref={svgRef}
+      width="100%"
+      height={H}
       className="events-chart-svg"
-      preserveAspectRatio="xMidYMid meet"
     >
       {/* horizontal grid lines */}
       {[0, 0.25, 0.5, 0.75, 1].map(t => (
@@ -205,12 +219,18 @@ export function Events() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const { tick } = useAutoRefresh()
-  const [timeFilter, setTimeFilter] = useState<TimeFilter>('week')
+  const [chartRange, setChartRange] = useState<ChartRange>('week')
   const initialLevel = searchParams.get('level') as Severity | null
   const [severity, setSeverity] = useState<Severity | ''>(
     SEVERITIES.includes(initialLevel as Severity) ? (initialLevel as Severity) : ''
   )
-  const [sourceType, setSourceType] = useState<SourceType>('')
+  const initialSourceType = searchParams.get('source_type') as SourceType | null
+  const initialSourceId = searchParams.get('source_id') ?? ''
+  const [sourceType, setSourceType] = useState<SourceType>(
+    initialSourceType && ['app', 'infra', 'check'].includes(initialSourceType) ? initialSourceType : ''
+  )
+  const [sourceId, setSourceId] = useState(initialSourceId)
+  const [sourceOptions, setSourceOptions] = useState<{ id: string; name: string }[]>([])
   const [search, setSearch] = useState('')
   const [searchDraft, setSearchDraft] = useState('')
   const [searchTrigger, setSearchTrigger] = useState(0)
@@ -219,7 +239,6 @@ export function Events() {
   const [sort, setSort] = useState<EventSort>('newest')
   const [pageSize, setPageSize] = useState(50)
   const [page, setPage] = useState(0)
-  const [chartRange, setChartRange] = useState<ChartRange>('week')
 
   const [eventList, setEventList] = useState<Event[]>([])
   const [total, setTotal] = useState(0)
@@ -242,17 +261,18 @@ export function Events() {
         limit: pageSize,
         offset: page * pageSize,
       }
-      // Date range: custom dates take priority over timeFilter tabs
+      // Date range: custom dates take priority over chart range
       if (fromDate) {
         filter.from = new Date(fromDate).toISOString()
       } else {
-        filter.from = sinceFromTimeFilter(timeFilter)
+        filter.from = sinceFromChartRange(chartRange)
       }
       if (toDate) {
         filter.to = new Date(toDate + 'T23:59:59').toISOString()
       }
       if (severity) filter.level = severity
       if (sourceType) filter.source_type = sourceType as 'app' | 'infra' | 'check'
+      if (sourceId) filter.source_id = sourceId
       if (search) filter.search = search
       try {
         const res = await eventsApi.list(filter)
@@ -264,9 +284,9 @@ export function Events() {
         setLoading(false)
       }
     })()
-  }, [timeFilter, severity, sourceType, search, searchTrigger, fromDate, toDate, sort, pageSize, page, tick])
+  }, [chartRange, severity, sourceType, sourceId, search, searchTrigger, fromDate, toDate, sort, pageSize, page, tick])
 
-  // Fetch chart data
+  // Fetch chart data — follows the chart range selector
   useEffect(() => {
     setChartLoading(true)
     const { since, until, granularity } = chartRangeParams(chartRange)
@@ -282,6 +302,29 @@ export function Events() {
       .finally(() => setChartLoading(false))
   }, [chartRange, severity])
 
+  // Fetch source options when source type changes
+  useEffect(() => {
+    setSourceOptions([])
+    if (!sourceType) return
+    const fetch = async () => {
+      try {
+        if (sourceType === 'app') {
+          const res = await appsApi.list()
+          setSourceOptions((res.data as App[]).map(a => ({ id: a.id, name: a.name })))
+        } else if (sourceType === 'infra') {
+          const res = await infraApi.list()
+          setSourceOptions((res.data as InfrastructureComponent[]).map(c => ({ id: c.id, name: c.name })))
+        } else if (sourceType === 'check') {
+          const res = await checksApi.list()
+          setSourceOptions((res.data as MonitorCheck[]).map(c => ({ id: c.id, name: c.name })))
+        }
+      } catch {
+        setSourceOptions([])
+      }
+    }
+    void fetch()
+  }, [sourceType])
+
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
 
   function changePage(next: number) {
@@ -291,28 +334,26 @@ export function Events() {
 
   return (
     <>
-      <Topbar
-        title="Events"
-        timeFilter={timeFilter}
-        onTimeFilter={t => { setTimeFilter(t as TimeFilter); setPage(0) }}
-      />
+      <Topbar title="Events" />
       <div className="content">
+
+        {/* ── Time range selector ── */}
+        <div className="events-range-row">
+          {(['day', 'week', 'month', '3m'] as ChartRange[]).map(r => (
+            <button
+              key={r}
+              className={`chart-range-tab${chartRange === r ? ' active' : ''}`}
+              onClick={() => { setChartRange(r); setPage(0) }}
+            >
+              {r === 'day' ? 'Day' : r === 'week' ? 'Week' : r === 'month' ? 'Month' : '3 Months'}
+            </button>
+          ))}
+        </div>
 
         {/* ── Chart ── */}
         <div className="events-chart-container">
           <div className="events-chart-header">
             <span className="section-title">Event Volume</span>
-            <div className="chart-range-tabs">
-              {(['day', 'week', 'month', '3m'] as ChartRange[]).map(r => (
-                <button
-                  key={r}
-                  className={`chart-range-tab${chartRange === r ? ' active' : ''}`}
-                  onClick={() => setChartRange(r)}
-                >
-                  {r === 'day' ? '24h' : r === 'week' ? '7d' : r === 'month' ? '30d' : '3M'}
-                </button>
-              ))}
-            </div>
           </div>
           <div className="events-chart-body">
             {chartLoading ? (
@@ -364,12 +405,23 @@ export function Events() {
           <select
             className="events-select"
             value={sourceType}
-            onChange={e => { setSourceType(e.target.value as SourceType); setPage(0) }}
+            onChange={e => { setSourceType(e.target.value as SourceType); setSourceId(''); setPage(0) }}
           >
-            <option value="">All sources</option>
+            <option value="">All types</option>
             <option value="app">Apps</option>
             <option value="infra">Infrastructure</option>
             <option value="check">Checks</option>
+          </select>
+          <select
+            className="events-select"
+            value={sourceId}
+            onChange={e => { setSourceId(e.target.value); setPage(0) }}
+            disabled={!sourceType || sourceOptions.length === 0}
+          >
+            <option value="">{sourceType ? 'All names' : 'Select type first'}</option>
+            {sourceOptions.map(o => (
+              <option key={o.id} value={o.id}>{o.name}</option>
+            ))}
           </select>
           <div className="events-date-range">
             <input

--- a/frontend/src/pages/InfraComponentDetail.tsx
+++ b/frontend/src/pages/InfraComponentDetail.tsx
@@ -294,6 +294,7 @@ function TraefikShell({ component, ep }: { component: InfrastructureComponent; e
         </>
       }
       sourceId={component.id}
+      sourceType="infra"
     >
       <InfraEditModal
         open={ep.editOpen}
@@ -356,6 +357,7 @@ function SynologyShell({ component, ep }: { component: InfrastructureComponent; 
         </>
       }
       sourceId={component.id}
+      sourceType="infra"
     >
       <InfraEditModal
         open={ep.editOpen}
@@ -517,6 +519,7 @@ export function InfraComponentDetail() {
           </>
         }
         sourceId={component.id}
+      sourceType="infra"
       >
         <InfraEditModal
           open={editOpen}
@@ -558,6 +561,7 @@ export function InfraComponentDetail() {
           </>
         }
         sourceId={component.id}
+      sourceType="infra"
       >
         <InfraEditModal
           open={editOpen}
@@ -635,6 +639,7 @@ export function InfraComponentDetail() {
         </>
       }
       sourceId={component.id}
+      sourceType="infra"
     >
       <InfraEditModal
         open={editOpen}

--- a/frontend/src/pages/Relationships.css
+++ b/frontend/src/pages/Relationships.css
@@ -207,8 +207,9 @@
 /* ── Action cell / gear button ───────────────────────────────────────────────── */
 
 .rel-action-cell {
-  width: 48px;
+  width: 72px;
   text-align: right;
+  white-space: nowrap;
 }
 
 .rel-gear-btn {
@@ -228,6 +229,28 @@
   color: var(--text);
   border-color: var(--border2);
   background: var(--bg3);
+}
+
+.rel-nav-btn {
+  display: inline-flex;
+  align-items: center;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 2px 9px;
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+  margin-left: 10px;
+  white-space: nowrap;
+}
+
+.rel-nav-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: rgba(99, 102, 241, 0.08);
 }
 
 /* ── Status dot ──────────────────────────────────────────────────────────────── */

--- a/frontend/src/styles/Modal.css
+++ b/frontend/src/styles/Modal.css
@@ -142,6 +142,37 @@
 .modal-input-sm   { width: 120px; }
 .modal-input-mono { font-family: var(--mono); font-size: 11px; flex: 1; }
 
+.modal-check-pills {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.modal-check-pill {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 5px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border2);
+  background: var(--bg3);
+  color: var(--text2);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.modal-check-pill:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.modal-check-pill.active {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .modal-field-row {
   display: flex;
   gap: 8px;

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -1,8 +1,13 @@
-import { precacheAndRoute } from 'workbox-precaching'
+import { precacheAndRoute, createHandlerBoundToURL } from 'workbox-precaching'
+import { NavigationRoute, registerRoute } from 'workbox-routing'
 
 declare let self: ServiceWorkerGlobalScope
 
 precacheAndRoute(self.__WB_MANIFEST)
+
+// SPA navigation fallback — any navigation request (clicking a link, typing a URL)
+// that isn't a precached asset gets served index.html so React Router handles it.
+registerRoute(new NavigationRoute(createHandlerBoundToURL('index.html')))
 
 self.addEventListener('push', (event) => {
   const data = event.data?.json() as Record<string, string> ?? {}

--- a/internal/api/docker_discovery.go
+++ b/internal/api/docker_discovery.go
@@ -33,6 +33,7 @@ func (h *DockerDiscoveryHandler) Routes(r chi.Router) {
 	r.Get("/discovery/all", h.ListAll)
 	r.Get("/containers", h.ListAllContainers)
 	r.Get("/routes", h.ListAllRoutes)
+	r.Get("/discovered-containers/{id}", h.GetContainer)
 	r.Delete("/discovered-containers/{id}", h.DeleteContainer)
 	r.Post("/discovered-containers/{id}/link-app", h.LinkContainerApp)
 	r.Delete("/discovered-containers/{id}/link-app", h.UnlinkContainerApp)
@@ -40,7 +41,7 @@ func (h *DockerDiscoveryHandler) Routes(r chi.Router) {
 	r.Delete("/discovered-routes/{id}/link-app", h.UnlinkRouteApp)
 }
 
-// discoveredContainerResponse is the per-container shape returned by the API.
+// discoveredContainerResponse is the per-container shape returned by the list API.
 type discoveredContainerResponse struct {
 	ID                   string     `json:"id"`
 	InfraComponentID     string     `json:"infra_component_id"`
@@ -57,13 +58,32 @@ type discoveredContainerResponse struct {
 	// Image update fields (DD-9): populated by the ImageUpdatePoller.
 	ImageUpdateAvailable bool       `json:"image_update_available"`
 	ImageLastCheckedAt   *time.Time `json:"image_last_checked_at,omitempty"`
-	// Enrichment fields (AP-04 / migration 037).
-	Ports           *string    `json:"ports,omitempty"`
-	Labels          *string    `json:"labels,omitempty"`
-	Volumes         *string    `json:"volumes,omitempty"`
-	Networks        *string    `json:"networks,omitempty"`
-	RestartPolicy   *string    `json:"restart_policy,omitempty"`
-	DockerCreatedAt *time.Time `json:"docker_created_at,omitempty"`
+}
+
+// containerDetailResponse is the full shape returned by GET /discovered-containers/{id}.
+type containerDetailResponse struct {
+	ID                   string     `json:"id"`
+	InfraComponentID     string     `json:"infra_component_id"`
+	SourceType           string     `json:"source_type"`
+	ContainerID          string     `json:"container_id"`
+	ContainerName        string     `json:"container_name"`
+	Image                string     `json:"image"`
+	Status               string     `json:"status"`
+	AppID                *string    `json:"app_id"`
+	LastSeenAt           time.Time  `json:"last_seen_at"`
+	DockerCreatedAt      *time.Time `json:"docker_created_at,omitempty"`
+	// Image update fields.
+	ImageDigest          *string    `json:"image_digest,omitempty"`
+	RegistryDigest       *string    `json:"registry_digest,omitempty"`
+	ImageUpdateAvailable bool       `json:"image_update_available"`
+	ImageLastCheckedAt   *time.Time `json:"image_last_checked_at,omitempty"`
+	// Runtime fields.
+	Ports         *string `json:"ports,omitempty"`
+	Networks      *string `json:"networks,omitempty"`
+	Volumes       *string `json:"volumes,omitempty"`
+	RestartPolicy *string `json:"restart_policy,omitempty"`
+	Labels        *string `json:"labels,omitempty"`
+	EnvVars       *string `json:"env_vars,omitempty"`
 }
 
 type listDiscoveredContainersResponse struct {
@@ -126,12 +146,6 @@ func (h *DockerDiscoveryHandler) ListContainers(w http.ResponseWriter, r *http.R
 			LastSeenAt:           c.LastSeenAt,
 			ImageUpdateAvailable: c.ImageUpdateAvailable != 0,
 			ImageLastCheckedAt:   c.ImageLastCheckedAt,
-			Ports:                c.Ports,
-			Labels:               c.Labels,
-			Volumes:              c.Volumes,
-			Networks:             c.Networks,
-			RestartPolicy:        c.RestartPolicy,
-			DockerCreatedAt:      c.DockerCreatedAt,
 		}
 
 		// Walk lookup priority until we find a source ID that has metrics.
@@ -445,6 +459,43 @@ func (h *DockerDiscoveryHandler) LinkContainerApp(w http.ResponseWriter, r *http
 	default:
 		writeError(w, http.StatusUnprocessableEntity, "mode must be 'existing' or 'create'")
 	}
+}
+
+// GetContainer returns the full detail record for a single discovered container.
+// GET /api/v1/discovered-containers/{id}
+func (h *DockerDiscoveryHandler) GetContainer(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	c, err := h.store.DiscoveredContainers.GetDiscoveredContainer(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "discovered container not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, containerDetailResponse{
+		ID:                   c.ID,
+		InfraComponentID:     c.InfraComponentID,
+		SourceType:           c.SourceType,
+		ContainerID:          c.ContainerID,
+		ContainerName:        c.ContainerName,
+		Image:                c.Image,
+		Status:               c.Status,
+		AppID:                c.AppID,
+		LastSeenAt:           c.LastSeenAt,
+		DockerCreatedAt:      c.DockerCreatedAt,
+		ImageDigest:          c.ImageDigest,
+		RegistryDigest:       c.RegistryDigest,
+		ImageUpdateAvailable: c.ImageUpdateAvailable != 0,
+		ImageLastCheckedAt:   c.ImageLastCheckedAt,
+		Ports:                c.Ports,
+		Networks:             c.Networks,
+		Volumes:              c.Volumes,
+		RestartPolicy:        c.RestartPolicy,
+		Labels:               c.Labels,
+		EnvVars:              c.EnvVars,
+	})
 }
 
 // DeleteContainer hard-deletes a discovered container record.

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -115,9 +115,22 @@ func parseFilter(r *http.Request) (repo.ListFilter, error) {
 		Offset:     0,
 	}
 
-	// Accept source_type directly.
+	// Map logical source_type filter values to the actual stored source_type strings.
 	if st := q.Get("source_type"); st != "" {
-		f.SourceType = st
+		switch st {
+		case "infra":
+			f.SourceTypes = []string{
+				"physical_host", "proxmox_node",
+				"vm_linux", "vm_windows", "vm_other",
+				"linux_host", "windows_host", "generic_host",
+				"synology", "docker_engine", "traefik",
+				"portainer", "container",
+			}
+		case "check":
+			f.SourceType = "monitor_check"
+		default:
+			f.SourceType = st
+		}
 	}
 
 	if s := q.Get("search"); s != "" {

--- a/internal/api/proxmox_detail.go
+++ b/internal/api/proxmox_detail.go
@@ -28,6 +28,8 @@ func (h *ProxmoxDetailHandler) Routes(r chi.Router) {
 	r.Get("/infrastructure/proxmox/{id}/guests",  h.GetGuests)
 	r.Get("/infrastructure/proxmox/{id}/status",  h.GetNodeStatus)
 	r.Get("/infrastructure/proxmox/{id}/tasks",   h.GetTaskFailures)
+	r.Get("/infrastructure/proxmox/{id}/backups", h.GetBackupJobs)
+	r.Get("/infrastructure/proxmox/{id}/backup-files", h.GetBackupFiles)
 }
 
 // getPoller loads the component, validates it is a proxmox_node with credentials,
@@ -122,6 +124,56 @@ func (h *ProxmoxDetailHandler) GetNodeStatus(w http.ResponseWriter, r *http.Requ
 		statuses = []infra.ProxmoxNodeStatusDetail{}
 	}
 	writeJSON(w, http.StatusOK, map[string]interface{}{"data": statuses, "total": len(statuses)})
+}
+
+// GetBackupJobs returns recent vzdump backup tasks (all statuses) from the Proxmox API.
+// GET /api/v1/infrastructure/proxmox/{id}/backups
+func (h *ProxmoxDetailHandler) GetBackupJobs(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	poller, err := h.getPoller(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "component not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	jobs, err := poller.FetchBackupJobs(r.Context())
+	if err != nil {
+		writeError(w, http.StatusBadGateway, fmt.Sprintf("proxmox api: %s", err.Error()))
+		return
+	}
+	if jobs == nil {
+		jobs = []infra.ProxmoxBackupJob{}
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"data": jobs, "total": len(jobs)})
+}
+
+// GetBackupFiles returns per-VM backup files from storage.
+// GET /api/v1/infrastructure/proxmox/{id}/backup-files
+func (h *ProxmoxDetailHandler) GetBackupFiles(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	poller, err := h.getPoller(r.Context(), id)
+	if errors.Is(err, repo.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "component not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	files, err := poller.FetchBackupFiles(r.Context())
+	if err != nil {
+		writeError(w, http.StatusBadGateway, fmt.Sprintf("proxmox api: %s", err.Error()))
+		return
+	}
+	if files == nil {
+		files = []infra.ProxmoxBackupFile{}
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"data": files, "total": len(files)})
 }
 
 // GetTaskFailures returns recent failed tasks from the Proxmox API.

--- a/internal/infra/docker_enrichment_test.go
+++ b/internal/infra/docker_enrichment_test.go
@@ -111,6 +111,9 @@ func (m *enrichMockContainerRepo) UpdateContainerImageCheck(_ context.Context, _
 func (m *enrichMockContainerRepo) UpdateContainerRestartPolicy(_ context.Context, _ string, _ string) error {
 	return nil
 }
+func (m *enrichMockContainerRepo) UpdateContainerEnvVars(_ context.Context, _ string, _ string) error {
+	return nil
+}
 
 type enrichMockRouteRepo struct {
 	routes map[string]*models.DiscoveredRoute

--- a/internal/infra/docker_enrichment_test.go
+++ b/internal/infra/docker_enrichment_test.go
@@ -102,6 +102,9 @@ func (m *enrichMockContainerRepo) FindByName(_ context.Context, _ string, _ stri
 func (m *enrichMockContainerRepo) DeleteDiscoveredContainer(_ context.Context, _ string) error {
 	return nil
 }
+func (m *enrichMockContainerRepo) UpdateContainerLocalDigest(_ context.Context, _ string, _ string) error {
+	return nil
+}
 func (m *enrichMockContainerRepo) UpdateContainerImageCheck(_ context.Context, _, _, _ string, _ bool) error {
 	return nil
 }

--- a/internal/infra/portainer.go
+++ b/internal/infra/portainer.go
@@ -115,6 +115,8 @@ type PortainerContainerInspect struct {
 	Config struct {
 		// Image is the image name:tag used to create the container.
 		Image string `json:"Image"`
+		// Env is the list of environment variables as "KEY=VALUE" strings.
+		Env []string `json:"Env"`
 	} `json:"Config"`
 }
 

--- a/internal/infra/portainer_enrichment.go
+++ b/internal/infra/portainer_enrichment.go
@@ -15,8 +15,9 @@ import (
 
 // PortainerEnrichmentWorker polls all enabled Portainer infrastructure components
 // every 15 minutes. For each Portainer endpoint, it lists containers, upserts them
-// into discovered_containers (keyed by the Portainer component ID), checks image
-// update availability, and emits an event on false→true transitions.
+// into discovered_containers (keyed by the Portainer component ID), stores the
+// locally running image manifest digest, and emits an event when the registry
+// poller later marks image_update_available as true.
 //
 // Gate: if no infrastructure components with type="portainer" are configured,
 // each Run call returns early. Docker Engine components are NOT required.
@@ -182,6 +183,7 @@ func (w *PortainerEnrichmentWorker) enrichComponent(
 				CreatedAt:        now,
 				Ports:            encJSON(pc.Ports),
 				Networks:         encJSON(networks),
+				Labels:           encJSON(pc.Labels),
 			}
 			if err := w.store.DiscoveredContainers.UpsertDiscoveredContainer(ctx, rec); err != nil {
 				log.Printf("portainer enrichment: upsert container %q: %v", name, err)
@@ -195,23 +197,22 @@ func (w *PortainerEnrichmentWorker) enrichComponent(
 
 			seenContainerIDs = append(seenContainerIDs, pc.ID)
 
-			// Re-fetch the full row so determineImageUpdate has the current
-			// registry_digest (set by DD-9) — the upsert only returns the id.
+			// Inspect the container to capture env vars and the local image digest.
+			// Both are written in a single inspect call to avoid extra round-trips.
+			if localDigest := w.extractInspectData(ctx, client, ep.ID, pc, rec.ID); localDigest != "" {
+				if err := w.store.DiscoveredContainers.UpdateContainerLocalDigest(ctx, rec.ID, localDigest); err != nil {
+					log.Printf("portainer enrichment: update local digest %q: %v", name, err)
+				}
+			}
+
+			// Re-fetch the full row so we can read image_update_available as set by
+			// the registry poller (the upsert only returns the id).
 			if full, fetchErr := w.store.DiscoveredContainers.GetDiscoveredContainer(ctx, rec.ID); fetchErr == nil {
 				rec = full
 			}
 
-			// Check image update availability via Portainer's Docker gateway.
-			updateAvailable := w.determineImageUpdate(ctx, client, ep.ID, pc, rec)
-
-			if err := w.store.DiscoveredContainers.UpdateContainerImageCheck(
-				ctx, rec.ID, pc.ID, "", updateAvailable,
-			); err != nil {
-				log.Printf("portainer enrichment: update image check %q: %v", name, err)
-				continue
-			}
-
-			// Emit event on false→true transition only.
+			// Emit event if registry poller already flagged an update (false→true).
+			updateAvailable := rec.ImageUpdateAvailable != 0
 			if updateAvailable {
 				prev, _ := w.lastUpdateAvailable.Load(rec.ID)
 				prevBool, _ := prev.(bool)
@@ -233,60 +234,43 @@ func (w *PortainerEnrichmentWorker) enrichComponent(
 	return upserted, len(endpoints), nil
 }
 
-// determineImageUpdate inspects the running container's image via the Portainer
-// Docker gateway and returns true when a newer image is available.
-//
-// Detection method:
-//  1. Call GET /api/endpoints/{id}/docker/containers/{id}/json to get the
-//     running image's config hash (Image field, always sha256:...).
-//  2. Call GET /api/endpoints/{id}/docker/images/{imageId}/json to retrieve
-//     the locally stored RepoDigests (manifest digests in "img@sha256:..." form).
-//  3. Extract the manifest digest matching the container's image name:tag.
-//  4. Compare against the registry_digest stored by DD-9's image poller.
-//     If they differ and both are non-empty → update available.
-//
-// If the Portainer inspect fails or RepoDigests is empty, falls back to the
-// existing image_update_available value from NORA's DB (no change).
-func (w *PortainerEnrichmentWorker) determineImageUpdate(
+// extractInspectData calls InspectContainer once to capture env vars and the
+// local image manifest digest. Env vars are persisted immediately; the digest
+// is returned so the caller can write it via UpdateContainerLocalDigest.
+// Returns "" if the inspect fails or no manifest digest is available.
+func (w *PortainerEnrichmentWorker) extractInspectData(
 	ctx context.Context,
 	client *PortainerClient,
 	endpointID int,
 	pc PortainerContainer,
-	nora *models.DiscoveredContainer,
-) bool {
-	// Inspect the container to get the running image ID.
+	containerID string, // NORA UUID — used for the env vars DB write
+) string {
 	inspect, err := client.InspectContainer(ctx, endpointID, pc.ID)
 	if err != nil {
 		log.Printf("portainer enrichment: inspect container %s: %v (debug)", pc.FirstName(), err)
-		return nora.ImageUpdateAvailable != 0
+		return ""
 	}
 
-	// Inspect the image to get manifest digests stored locally.
+	// Persist environment variables.
+	if len(inspect.Config.Env) > 0 {
+		if b, jsonErr := json.Marshal(inspect.Config.Env); jsonErr == nil {
+			s := string(b)
+			if err := w.store.DiscoveredContainers.UpdateContainerEnvVars(ctx, containerID, s); err != nil {
+				log.Printf("portainer enrichment: update env vars %q: %v", pc.FirstName(), err)
+			}
+		}
+	}
+
 	imgDetail, err := client.InspectImage(ctx, endpointID, inspect.Image)
 	if err != nil {
 		log.Printf("portainer enrichment: inspect image %s: %v (debug)", inspect.Image, err)
-		return nora.ImageUpdateAvailable != 0
+		return ""
 	}
-
-	// Extract the manifest digest for this image's name:tag.
 	imageName := inspect.Config.Image
 	if imageName == "" {
 		imageName = pc.Image
 	}
-	runningManifest := ExtractManifestDigest(imgDetail.RepoDigests, imageName)
-
-	// If we couldn't get a manifest digest locally, fall back to stored value.
-	if runningManifest == "" {
-		return nora.ImageUpdateAvailable != 0
-	}
-
-	// If DD-9 hasn't checked the registry yet, we can't determine update status.
-	if nora.RegistryDigest == nil || *nora.RegistryDigest == "" {
-		return nora.ImageUpdateAvailable != 0
-	}
-
-	// Update available when locally running manifest ≠ latest registry manifest.
-	return runningManifest != *nora.RegistryDigest
+	return ExtractManifestDigest(imgDetail.RepoDigests, imageName)
 }
 
 // emitImageUpdateEvent fires an "image update available" event through the

--- a/internal/infra/portainer_enrichment_test.go
+++ b/internal/infra/portainer_enrichment_test.go
@@ -16,6 +16,18 @@ import (
 	"github.com/digitalcheffe/nora/migrations"
 )
 
+// mockRegistryDigester is a simple registry stub for tests.
+type mockRegistryDigester struct {
+	digests map[string]string // image → digest
+}
+
+func (m *mockRegistryDigester) GetLatestDigest(_ context.Context, image string) (string, error) {
+	if d, ok := m.digests[image]; ok {
+		return d, nil
+	}
+	return "", fmt.Errorf("no mock digest for %q", image)
+}
+
 // ── test helpers ──────────────────────────────────────────────────────────────
 
 func newPortainerTestStore(t *testing.T) *repo.Store {
@@ -315,26 +327,22 @@ func TestPortainerWinsOverDD9ForImageUpdateAvailable(t *testing.T) {
 		t.Fatalf("find pre-seeded container: %v", err)
 	}
 
-	// Manually store DD-9 registry_digest (different from running manifest → update available).
-	registryDigest := "sha256:newermanifest"
-	if err := store.DiscoveredContainers.UpdateContainerImageCheck(
-		context.Background(), seeded.ID, "ctr1", registryDigest, false,
-	); err != nil {
-		t.Fatalf("seed DD-9 data: %v", err)
-	}
-
 	worker := NewPortainerEnrichmentWorker(store)
 	if err := worker.Run(context.Background()); err != nil {
 		t.Fatalf("Run(): %v", err)
 	}
 
-	// Reload and verify Portainer detected the update (running manifest ≠ registry digest).
+	// Reload and verify Portainer stored the local manifest digest (registry poller does the comparison).
 	updated, err := store.DiscoveredContainers.GetDiscoveredContainer(context.Background(), seeded.ID)
 	if err != nil {
 		t.Fatalf("get container: %v", err)
 	}
-	if updated.ImageUpdateAvailable != 1 {
-		t.Errorf("expected image_update_available=1, got %d", updated.ImageUpdateAvailable)
+	if updated.ImageDigest == nil || *updated.ImageDigest != "sha256:localmanifest" {
+		got := "<nil>"
+		if updated.ImageDigest != nil {
+			got = *updated.ImageDigest
+		}
+		t.Errorf("expected image_digest=sha256:localmanifest, got %q", got)
 	}
 }
 
@@ -381,9 +389,9 @@ func TestPortainerEventEmittedOnFalseToTrueTransition(t *testing.T) {
 		t.Fatalf("find pre-seeded container: %v", err)
 	}
 
-	// Seed: DD-9 says there's a newer image.
+	// Seed: registry poller already found a newer image (image_update_available=true).
 	if err := store.DiscoveredContainers.UpdateContainerImageCheck(
-		context.Background(), dc.ID, "sha256:oldmanifest", "sha256:newermanifest", false,
+		context.Background(), dc.ID, "sha256:oldmanifest", "sha256:newermanifest", true,
 	); err != nil {
 		t.Fatalf("seed: %v", err)
 	}

--- a/internal/infra/portainer_enrichment_test.go
+++ b/internal/infra/portainer_enrichment_test.go
@@ -254,7 +254,10 @@ func TestPortainerContainerNameNormalization(t *testing.T) {
 	}
 	fakeServer.inspects["abc123"] = &PortainerContainerInspect{
 		Image:  "sha256:aaabbb",
-		Config: struct{ Image string `json:"Image"` }{Image: "linuxserver/sonarr:latest"},
+		Config: struct {
+			Image string   `json:"Image"`
+			Env   []string `json:"Env"`
+		}{Image: "linuxserver/sonarr:latest"},
 	}
 	fakeServer.images["sha256:aaabbb"] = &PortainerImageInspect{
 		RepoDigests: []string{},
@@ -298,7 +301,10 @@ func TestPortainerWinsOverDD9ForImageUpdateAvailable(t *testing.T) {
 	}
 	fakeServer.inspects["ctr1"] = &PortainerContainerInspect{
 		Image:  "sha256:running",
-		Config: struct{ Image string `json:"Image"` }{Image: "myrepo/myapp:latest"},
+		Config: struct {
+			Image string   `json:"Image"`
+			Env   []string `json:"Env"`
+		}{Image: "myrepo/myapp:latest"},
 	}
 	// RepoDigests contains the manifest digest of the locally running image.
 	fakeServer.images["sha256:running"] = &PortainerImageInspect{
@@ -362,7 +368,10 @@ func TestPortainerEventEmittedOnFalseToTrueTransition(t *testing.T) {
 	}
 	fakeServer.inspects["ctr2"] = &PortainerContainerInspect{
 		Image:  "sha256:old",
-		Config: struct{ Image string `json:"Image"` }{Image: "myrepo/webapp:1.0"},
+		Config: struct {
+			Image string   `json:"Image"`
+			Env   []string `json:"Env"`
+		}{Image: "myrepo/webapp:1.0"},
 	}
 	fakeServer.images["sha256:old"] = &PortainerImageInspect{
 		RepoDigests: []string{"myrepo/webapp@sha256:oldmanifest"},
@@ -440,7 +449,10 @@ func TestPortainerNoEventWhenValueUnchanged(t *testing.T) {
 	}
 	fakeServer.inspects["ctr3"] = &PortainerContainerInspect{
 		Image:  "sha256:old2",
-		Config: struct{ Image string `json:"Image"` }{Image: "myrepo/svc:1.0"},
+		Config: struct {
+			Image string   `json:"Image"`
+			Env   []string `json:"Env"`
+		}{Image: "myrepo/svc:1.0"},
 	}
 	fakeServer.images["sha256:old2"] = &PortainerImageInspect{
 		RepoDigests: []string{"myrepo/svc@sha256:oldmanifest2"},

--- a/internal/infra/proxmox_detail.go
+++ b/internal/infra/proxmox_detail.go
@@ -9,6 +9,16 @@ import (
 	"sync"
 )
 
+// upidObjectID extracts the object/VM ID from a Proxmox UPID string.
+// UPID format: UPID:<node>:<pid>:<pstart>:<starttime>:<type>:<id>:<user>:
+func upidObjectID(upid string) string {
+	parts := strings.Split(upid, ":")
+	if len(parts) >= 7 {
+		return parts[6]
+	}
+	return ""
+}
+
 // ── Raw Proxmox API shapes ────────────────────────────────────────────────────
 
 type proxmoxStorageRaw struct {
@@ -58,6 +68,16 @@ type proxmoxTaskRaw struct {
 	EndTime    int64  `json:"endtime"`
 	User       string `json:"user"`
 	Node       string `json:"node"`
+}
+
+type proxmoxStorageContentRaw struct {
+	VolID   string `json:"volid"`
+	Content string `json:"content"`
+	VMID    int    `json:"vmid"`
+	CTime   int64  `json:"ctime"`
+	Size    int64  `json:"size"`
+	Format  string `json:"format"`
+	Notes   string `json:"notes"`
 }
 
 // ── Result types returned to the API handler ─────────────────────────────────
@@ -111,6 +131,27 @@ type ProxmoxTaskFailure struct {
 	EndTime    int64  `json:"end_time,omitempty"`
 	User       string `json:"user"`
 	Node       string `json:"node"`
+}
+
+// ProxmoxBackupJob is one vzdump backup task entry (success or failure).
+type ProxmoxBackupJob struct {
+	UPID       string `json:"upid"`
+	ObjectID   string `json:"object_id,omitempty"`
+	ExitStatus string `json:"exit_status"`
+	StartTime  int64  `json:"start_time"`
+	EndTime    int64  `json:"end_time,omitempty"`
+	Node       string `json:"node"`
+}
+
+// ProxmoxBackupFile is one backup file entry from storage content.
+type ProxmoxBackupFile struct {
+	VolID  string `json:"volid"`
+	VMID   int    `json:"vmid"`
+	CTime  int64  `json:"ctime"`
+	Size   int64  `json:"size"`
+	Format string `json:"format"`
+	Node   string `json:"node"`
+	Store  string `json:"store"`
 }
 
 // ── Methods on ProxmoxPoller ──────────────────────────────────────────────────
@@ -302,6 +343,50 @@ func (p *ProxmoxPoller) FetchNodeStatus(ctx context.Context) ([]ProxmoxNodeStatu
 	return statuses, nil
 }
 
+// FetchBackupJobs returns recent vzdump backup tasks (all statuses) across all nodes.
+func (p *ProxmoxPoller) FetchBackupJobs(ctx context.Context) ([]ProxmoxBackupJob, error) {
+	var nodes []proxmoxNode
+	if err := p.get(ctx, "/api2/json/nodes", &nodes); err != nil {
+		return nil, fmt.Errorf("list nodes: %w", err)
+	}
+
+	var jobs []ProxmoxBackupJob
+	for _, node := range nodes {
+		var tasks []proxmoxTaskRaw
+		path := fmt.Sprintf("/api2/json/nodes/%s/tasks?typefilter=vzdump&limit=50", node.Node)
+		if err := p.get(ctx, path, &tasks); err != nil {
+			log.Printf("proxmox detail: backup tasks node %s: %v", node.Node, err)
+			continue
+		}
+		for _, t := range tasks {
+			// Only include completed tasks (EndTime > 0)
+			if t.EndTime == 0 {
+				continue
+			}
+			// Proxmox puts the exit status in Status for completed tasks ("OK",
+			// "error: ...", etc.); ExitStatus is only populated on some PVE versions.
+			exitStatus := t.ExitStatus
+			if exitStatus == "" {
+				exitStatus = t.Status
+			}
+			// Object ID: prefer the id field, fall back to parsing the UPID.
+			objectID := t.ID
+			if objectID == "" {
+				objectID = upidObjectID(t.UPID)
+			}
+			jobs = append(jobs, ProxmoxBackupJob{
+				UPID:       t.UPID,
+				ObjectID:   objectID,
+				ExitStatus: exitStatus,
+				StartTime:  t.StartTime,
+				EndTime:    t.EndTime,
+				Node:       t.Node,
+			})
+		}
+	}
+	return jobs, nil
+}
+
 // FetchTaskFailures returns failed tasks from the last 7 days across all nodes.
 func (p *ProxmoxPoller) FetchTaskFailures(ctx context.Context) ([]ProxmoxTaskFailure, error) {
 	var nodes []proxmoxNode
@@ -337,4 +422,48 @@ func (p *ProxmoxPoller) FetchTaskFailures(ctx context.Context) ([]ProxmoxTaskFai
 		}
 	}
 	return failures, nil
+}
+
+// FetchBackupFiles returns backup files found in storage across all nodes.
+// It queries each backup-capable storage's content endpoint to get per-VM file entries.
+func (p *ProxmoxPoller) FetchBackupFiles(ctx context.Context) ([]ProxmoxBackupFile, error) {
+	var nodes []proxmoxNode
+	if err := p.get(ctx, "/api2/json/nodes", &nodes); err != nil {
+		return nil, fmt.Errorf("list nodes: %w", err)
+	}
+
+	var files []ProxmoxBackupFile
+	for _, node := range nodes {
+		var storages []proxmoxStorageRaw
+		if err := p.get(ctx, fmt.Sprintf("/api2/json/nodes/%s/storage", node.Node), &storages); err != nil {
+			log.Printf("proxmox backup files: list storage node %s: %v", node.Node, err)
+			continue
+		}
+		for _, s := range storages {
+			if s.Active != 1 {
+				continue
+			}
+			var content []proxmoxStorageContentRaw
+			path := fmt.Sprintf("/api2/json/nodes/%s/storage/%s/content?content=backup", node.Node, s.Storage)
+			if err := p.get(ctx, path, &content); err != nil {
+				log.Printf("proxmox backup files: content %s/%s: %v", node.Node, s.Storage, err)
+				continue
+			}
+			for _, c := range content {
+				if c.VMID == 0 {
+					continue
+				}
+				files = append(files, ProxmoxBackupFile{
+					VolID:  c.VolID,
+					VMID:   c.VMID,
+					CTime:  c.CTime,
+					Size:   c.Size,
+					Format: c.Format,
+					Node:   node.Node,
+					Store:  s.Storage,
+				})
+			}
+		}
+	}
+	return files, nil
 }

--- a/internal/jobs/discover.go
+++ b/internal/jobs/discover.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/digitalcheffe/nora/internal/infra"
 	"github.com/digitalcheffe/nora/internal/models"
 	"github.com/digitalcheffe/nora/internal/repo"
 	"github.com/digitalcheffe/nora/internal/scanner"
@@ -21,6 +22,19 @@ import (
 func DiscoverOneComponent(ctx context.Context, store *repo.Store, c *models.InfrastructureComponent) (*scanner.DiscoveryResult, error) {
 	if !c.Enabled {
 		return nil, fmt.Errorf("component is disabled")
+	}
+
+	// Portainer: route through PortainerEnrichmentWorker rather than
+	// PortainerDiscoveryScanner.  The enrichment worker correctly sets
+	// source_type="portainer", calls MarkStoppedIfNotRunning, performs digest
+	// extraction, and emits image-update events — the discovery scanner does
+	// none of those things.
+	if c.Type == "portainer" {
+		worker := infra.NewPortainerEnrichmentWorker(store)
+		if err := worker.Run(ctx); err != nil {
+			return nil, err
+		}
+		return &scanner.DiscoveryResult{EntityID: c.ID, EntityType: c.Type}, nil
 	}
 
 	sc := discoveryScanner(store, c)

--- a/internal/models/discovery.go
+++ b/internal/models/discovery.go
@@ -32,6 +32,8 @@ type DiscoveredContainer struct {
 	Networks        *string    `db:"networks"          json:"networks,omitempty"`          // JSON array of network names
 	RestartPolicy   *string    `db:"restart_policy"    json:"restart_policy,omitempty"`   // e.g. "always", "no"
 	DockerCreatedAt *time.Time `db:"docker_created_at" json:"docker_created_at,omitempty"` // when Docker created the container
+	// Fields added in migration 051 (AP-05).
+	EnvVars *string `db:"env_vars" json:"env_vars,omitempty"` // JSON array of "KEY=VALUE" strings from container inspect
 }
 
 // DiscoveredRoute is an HTTP router entry found via a Traefik infrastructure component.

--- a/internal/repo/discovery.go
+++ b/internal/repo/discovery.go
@@ -31,12 +31,20 @@ type DiscoveredContainerRepo interface {
 	MarkStoppedIfNotRunning(ctx context.Context, infraComponentID string, runningIDs []string) error
 	// DeleteDiscoveredContainer hard-deletes a discovered container record by UUID.
 	DeleteDiscoveredContainer(ctx context.Context, id string) error
+	// UpdateContainerLocalDigest stores the locally running image manifest digest.
+	// Called by Portainer/Docker Engine enrichment after inspecting the container.
+	// Does not touch registry_digest or image_update_available.
+	UpdateContainerLocalDigest(ctx context.Context, id string, imageDigest string) error
 	// UpdateContainerImageCheck writes the latest image and registry digests and
 	// sets image_update_available.  Called by the ImageUpdatePoller after each poll.
 	UpdateContainerImageCheck(ctx context.Context, id string, imageDigest string, registryDigest string, updateAvailable bool) error
 	// UpdateContainerRestartPolicy persists the container restart policy.
 	// Called by the ImageUpdatePoller which already performs a ContainerInspect.
 	UpdateContainerRestartPolicy(ctx context.Context, id string, policy string) error
+	// UpdateContainerEnvVars persists the JSON-encoded environment variable list.
+	// Called by the Portainer enrichment worker after InspectContainer.
+	// Does not touch any other fields.
+	UpdateContainerEnvVars(ctx context.Context, id string, envVars string) error
 }
 
 // DiscoveredRouteRepo manages the discovered_routes table.
@@ -68,7 +76,7 @@ type DiscoveredRouteRepo interface {
 const containerSelectCols = `id, infra_component_id, source_type, container_id, container_name, image, status,
 	app_id, profile_suggestion, suggestion_confidence, last_seen_at, created_at,
 	image_digest, registry_digest, COALESCE(image_update_available,0) AS image_update_available, image_last_checked_at,
-	ports, labels, volumes, networks, restart_policy, docker_created_at`
+	ports, labels, volumes, networks, restart_policy, docker_created_at, env_vars`
 
 type sqliteDiscoveredContainerRepo struct{ db *sqlx.DB }
 
@@ -275,6 +283,19 @@ func (r *sqliteDiscoveredContainerRepo) FindByName(ctx context.Context, infraCom
 	return &c, nil
 }
 
+func (r *sqliteDiscoveredContainerRepo) UpdateContainerLocalDigest(ctx context.Context, id string, imageDigest string) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE discovered_containers SET image_digest = ? WHERE id = ?`, imageDigest, id)
+	if err != nil {
+		return fmt.Errorf("update local digest on container %s: %w", id, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("discovered container %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
 func (r *sqliteDiscoveredContainerRepo) UpdateContainerImageCheck(ctx context.Context, id string, imageDigest string, registryDigest string, updateAvailable bool) error {
 	updateAvailableInt := 0
 	if updateAvailable {
@@ -301,6 +322,15 @@ func (r *sqliteDiscoveredContainerRepo) UpdateContainerRestartPolicy(ctx context
 		`UPDATE discovered_containers SET restart_policy = ? WHERE id = ?`, policy, id)
 	if err != nil {
 		return fmt.Errorf("update restart policy on container %s: %w", id, err)
+	}
+	return nil
+}
+
+func (r *sqliteDiscoveredContainerRepo) UpdateContainerEnvVars(ctx context.Context, id string, envVars string) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE discovered_containers SET env_vars = ? WHERE id = ?`, envVars, id)
+	if err != nil {
+		return fmt.Errorf("update env vars on container %s: %w", id, err)
 	}
 	return nil
 }

--- a/internal/repo/events.go
+++ b/internal/repo/events.go
@@ -19,6 +19,9 @@ type ListFilter struct {
 	// SourceType filters by the source_type column: "app", "physical_host",
 	// "virtual_host", "docker_engine", "monitor_check", "system".
 	SourceType string
+	// SourceTypes filters by multiple source_type values (IN clause). Takes
+	// precedence over SourceType when non-empty.
+	SourceTypes []string
 	// SourceName filters events whose source_name contains this substring (case-insensitive).
 	SourceName string
 	// Search filters events whose title contains the given substring (case-insensitive).
@@ -134,7 +137,14 @@ func buildWhere(f ListFilter) (clause string, args []interface{}) {
 		args = append(args, f.SourceID)
 	}
 
-	if f.SourceType != "" {
+	if len(f.SourceTypes) > 0 {
+		placeholders := strings.Repeat("?,", len(f.SourceTypes))
+		placeholders = placeholders[:len(placeholders)-1]
+		parts = append(parts, "e.source_type IN ("+placeholders+")")
+		for _, st := range f.SourceTypes {
+			args = append(args, st)
+		}
+	} else if f.SourceType != "" {
 		parts = append(parts, "e.source_type = ?")
 		args = append(args, f.SourceType)
 	}

--- a/internal/scanner/daily/image_update.go
+++ b/internal/scanner/daily/image_update.go
@@ -1,4 +1,4 @@
-package snapshot
+package daily
 
 import (
 	"context"
@@ -22,17 +22,19 @@ type imageUpdateAPI interface {
 }
 
 // latestDigester is the registry lookup surface used by ImageUpdatePoller.
-// *docker.RegistryClient satisfies this interface; tests inject a mock.
+// *infra.RegistryClient satisfies this interface; tests inject a mock.
 type latestDigester interface {
 	GetLatestDigest(ctx context.Context, image string) (string, error)
 }
 
-// ImageUpdatePoller polls container registries to detect whether a newer
-// image is available for each running discovered container.  It is purely
-// informational — it never pulls or updates images.
+// ImageUpdatePoller checks container registries once per day to detect whether
+// a newer image is available for each running discovered container. It is
+// purely informational — it never pulls or updates images.
 //
-// Startup gate: if no infrastructure_components with type="docker_engine" exist,
-// each Run call returns early without contacting any registry.
+// Both Docker Engine and Portainer containers are supported:
+//   - Docker Engine containers: local manifest digest fetched via Docker socket.
+//   - Portainer containers: local manifest digest stored by the Portainer
+//     enrichment worker; used directly without a socket call.
 type ImageUpdatePoller struct {
 	store    *repo.Store
 	registry latestDigester
@@ -40,7 +42,7 @@ type ImageUpdatePoller struct {
 }
 
 // NewImageUpdatePoller returns an ImageUpdatePoller connected to the local
-// Docker daemon.  It returns an error only if the Docker client cannot be
+// Docker daemon. It returns an error only if the Docker client cannot be
 // constructed (socket absent, etc.).
 func NewImageUpdatePoller(store *repo.Store) (*ImageUpdatePoller, error) {
 	cli, err := dockerclient.NewClientWithOpts(
@@ -64,26 +66,8 @@ func newImageUpdatePollerWithClient(store *repo.Store, client imageUpdateAPI, re
 }
 
 // Run performs one full image update check cycle across all running discovered
-// containers.  It returns early if no Docker Engine infrastructure components
-// are configured.
+// containers.
 func (p *ImageUpdatePoller) Run(ctx context.Context) error {
-	// Gate check — skip silently if no Docker Engine components are configured.
-	components, err := p.store.InfraComponents.List(ctx)
-	if err != nil {
-		return fmt.Errorf("list infra components: %w", err)
-	}
-	hasDockerEngine := false
-	for _, c := range components {
-		if c.Type == "docker_engine" {
-			hasDockerEngine = true
-			break
-		}
-	}
-	if !hasDockerEngine {
-		log.Printf("image update poller: no Docker Engine components configured, skipping")
-		return nil
-	}
-
 	containers, err := p.store.DiscoveredContainers.ListAllDiscoveredContainers(ctx)
 	if err != nil {
 		return fmt.Errorf("list discovered containers: %w", err)
@@ -98,38 +82,42 @@ func (p *ImageUpdatePoller) Run(ctx context.Context) error {
 			continue
 		}
 
-		// Step 1: Get image info from Docker socket.
+		// Step 1: Get image digest — try Docker socket first, fall back to stored digest.
+		imageDigest := ""
+		imageName := c.Image // from DB (set during discovery)
+
 		inspect, err := p.client.ContainerInspect(ctx, c.ContainerID)
 		if err != nil {
-			log.Printf("image update poller: inspect container %s (%s): %v", c.ContainerName, c.ContainerID, err)
-			continue
-		}
-
-		// image_digest: prefer the OCI manifest descriptor digest (available on
-		// Docker Engine 25+), fall back to the image config hash (image ID).
-		imageDigest := inspect.Image // sha256 config hash — always present
-		if inspect.ImageManifestDescriptor != nil {
-			imageDigest = inspect.ImageManifestDescriptor.Digest.String()
+			// Docker socket unavailable for this container (e.g. Portainer-sourced).
+			// Use the manifest digest stored by the enrichment worker if available.
+			if c.ImageDigest != nil && *c.ImageDigest != "" {
+				imageDigest = *c.ImageDigest
+			} else {
+				// No local digest available — skip until enrichment populates it.
+				continue
+			}
 		} else {
-			// Try ImageInspect to find the manifest digest from RepoDigests.
-			if imgInfo, err := p.client.ImageInspect(ctx, inspect.Image); err == nil { //nolint:staticcheck
-				imageName := c.Image
-				if inspect.Config != nil && inspect.Config.Image != "" {
-					imageName = inspect.Config.Image
+			// Prefer the OCI manifest descriptor digest (Docker Engine 25+),
+			// fall back to the image config hash (image ID).
+			imageDigest = inspect.Image
+			if inspect.ImageManifestDescriptor != nil {
+				imageDigest = inspect.ImageManifestDescriptor.Digest.String()
+			} else {
+				if imgInfo, err := p.client.ImageInspect(ctx, inspect.Image); err == nil { //nolint:staticcheck
+					if inspect.Config != nil && inspect.Config.Image != "" {
+						imageName = inspect.Config.Image
+					}
+					if d := extractRepoDigest(imgInfo.RepoDigests, imageName); d != "" {
+						imageDigest = d
+					}
 				}
-				if d := extractRepoDigest(imgInfo.RepoDigests, imageName); d != "" {
-					imageDigest = d
-				}
+			}
+			if inspect.Config != nil && inspect.Config.Image != "" {
+				imageName = inspect.Config.Image
 			}
 		}
 
-		// Step 2: Determine image name/tag to look up in the registry.
-		imageName := c.Image // from DB (set during discovery)
-		if inspect.Config != nil && inspect.Config.Image != "" {
-			imageName = inspect.Config.Image
-		}
-
-		// Step 3: Fetch the latest manifest digest from the registry.
+		// Step 2: Fetch the latest manifest digest from the registry.
 		registryDigest, err := p.registry.GetLatestDigest(ctx, imageName)
 		if err != nil {
 			log.Printf("image update poller: get digest for %s (%s): %v", c.ContainerName, imageName, err)
@@ -137,10 +125,8 @@ func (p *ImageUpdatePoller) Run(ctx context.Context) error {
 			continue
 		}
 
-		// Step 4: Compare and persist.
+		// Step 3: Compare and persist.
 		// Only set update_available=1 when both digests are non-empty and differ.
-		// This avoids false positives when we could only get a config hash locally
-		// (config hash ≠ manifest hash by definition).
 		updateAvailable := imageDigest != "" && registryDigest != "" && imageDigest != registryDigest
 
 		if err := p.store.DiscoveredContainers.UpdateContainerImageCheck(
@@ -150,8 +136,9 @@ func (p *ImageUpdatePoller) Run(ctx context.Context) error {
 			continue
 		}
 
-		// Persist restart policy — available from the inspect we already have.
-		if inspect.HostConfig != nil && inspect.HostConfig.RestartPolicy.Name != "" {
+		// Persist restart policy — only available when we have a socket inspect.
+		if inspect.ContainerJSONBase != nil && inspect.HostConfig != nil &&
+			inspect.HostConfig.RestartPolicy.Name != "" {
 			if err := p.store.DiscoveredContainers.UpdateContainerRestartPolicy(
 				ctx, c.ID, string(inspect.HostConfig.RestartPolicy.Name),
 			); err != nil {
@@ -172,7 +159,6 @@ func (p *ImageUpdatePoller) Run(ctx context.Context) error {
 // extractRepoDigest returns the manifest digest (sha256:...) from a
 // RepoDigests slice for the given image name.
 func extractRepoDigest(repoDigests []string, imageName string) string {
-	// Strip tag from imageName to get the repo reference.
 	repoRef := imageName
 	if i := strings.LastIndex(repoRef, ":"); i >= 0 {
 		if !strings.Contains(repoRef[i+1:], "/") {
@@ -196,7 +182,6 @@ func extractRepoDigest(repoDigests []string, imageName string) string {
 		}
 	}
 
-	// Fallback: return the first entry's digest regardless of image match.
 	if len(repoDigests) > 0 {
 		if at := strings.LastIndex(repoDigests[0], "@"); at >= 0 {
 			return repoDigests[0][at+1:]
@@ -204,4 +189,3 @@ func extractRepoDigest(repoDigests []string, imageName string) string {
 	}
 	return ""
 }
-

--- a/internal/scanner/daily/image_update_test.go
+++ b/internal/scanner/daily/image_update_test.go
@@ -1,4 +1,4 @@
-package snapshot
+package daily
 
 import (
 	"context"
@@ -62,34 +62,6 @@ func (m *mockLatestDigester) GetLatestDigest(_ context.Context, image string) (s
 
 // ── mock repos ─────────────────────────────────────────────────────────────────
 
-type mockImageInfraComponentRepo struct {
-	components []models.InfrastructureComponent
-}
-
-func (r *mockImageInfraComponentRepo) List(_ context.Context) ([]models.InfrastructureComponent, error) {
-	return r.components, nil
-}
-func (r *mockImageInfraComponentRepo) ListByParent(_ context.Context, _ string) ([]models.InfrastructureComponent, error) {
-	return nil, nil
-}
-func (r *mockImageInfraComponentRepo) Get(_ context.Context, _ string) (*models.InfrastructureComponent, error) {
-	return nil, repo.ErrNotFound
-}
-func (r *mockImageInfraComponentRepo) Create(_ context.Context, _ *models.InfrastructureComponent) error {
-	return nil
-}
-func (r *mockImageInfraComponentRepo) Update(_ context.Context, _ *models.InfrastructureComponent) error {
-	return nil
-}
-func (r *mockImageInfraComponentRepo) Delete(_ context.Context, _ string) error { return nil }
-func (r *mockImageInfraComponentRepo) UpdateStatus(_ context.Context, _, _, _ string) error {
-	return nil
-}
-func (r *mockImageInfraComponentRepo) UpdateMeta(_ context.Context, _, _ string) error {
-	return nil
-}
-func (r *mockImageInfraComponentRepo) UpdateIP(_ context.Context, _, _ string) error { return nil }
-
 type imageCheckCall struct {
 	id              string
 	imageDigest     string
@@ -132,6 +104,9 @@ func (r *mockDiscoveredContainerRepo) MarkStoppedIfNotRunning(_ context.Context,
 func (r *mockDiscoveredContainerRepo) DeleteDiscoveredContainer(_ context.Context, _ string) error {
 	return nil
 }
+func (r *mockDiscoveredContainerRepo) UpdateContainerLocalDigest(_ context.Context, _ string, _ string) error {
+	return nil
+}
 func (r *mockDiscoveredContainerRepo) UpdateContainerImageCheck(_ context.Context, id, imageDigest, registryDigest string, updateAvailable bool) error {
 	r.imageChecks = append(r.imageChecks, imageCheckCall{
 		id:              id,
@@ -147,19 +122,15 @@ func (r *mockDiscoveredContainerRepo) UpdateContainerRestartPolicy(_ context.Con
 
 // ── helpers ────────────────────────────────────────────────────────────────────
 
-func makePollerStore(infraComponents []models.InfrastructureComponent, containers []*models.DiscoveredContainer) (*repo.Store, *mockDiscoveredContainerRepo) {
+func makePollerStore(containers []*models.DiscoveredContainer) (*repo.Store, *mockDiscoveredContainerRepo) {
 	dc := &mockDiscoveredContainerRepo{containers: containers}
 	store := repo.NewStore(
 		nil, nil, nil, nil, nil, nil,
-		&mockImageInfraComponentRepo{components: infraComponents},
+		nil,
 		nil, nil, nil,
 		dc, nil, nil, nil, nil, nil, nil, nil,
 	)
 	return store, dc
-}
-
-func dockerEngineComponent() models.InfrastructureComponent {
-	return models.InfrastructureComponent{ID: "engine-1", Type: "docker_engine"}
 }
 
 func makeInspect(containerID, imageID, imageName string, repoDigests []string) (map[string]container.InspectResponse, map[string]dockerimage.InspectResponse) {
@@ -175,23 +146,7 @@ func makeInspect(containerID, imageID, imageName string, repoDigests []string) (
 	return inspects, imgInspects
 }
 
-// ── gate check: no Docker Engine components ────────────────────────────────────
-
-func TestImageUpdatePoller_GateCheck_NoEngines(t *testing.T) {
-	store, dc := makePollerStore(nil, []*models.DiscoveredContainer{
-		{ID: "c1", ContainerID: "abc", ContainerName: "sonarr", Image: "linuxserver/sonarr:latest", Status: "running"},
-	})
-
-	reg := &mockLatestDigester{digests: map[string]string{"linuxserver/sonarr:latest": "sha256:new"}}
-	p := newImageUpdatePollerWithClient(store, &mockImageUpdateClient{}, reg)
-
-	if err := p.Run(context.Background()); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(dc.imageChecks) != 0 {
-		t.Errorf("expected 0 image checks when no Docker Engine configured, got %d", len(dc.imageChecks))
-	}
-}
+func strPtr(s string) *string { return &s }
 
 // ── digest mismatch → update_available=true ────────────────────────────────────
 
@@ -203,12 +158,9 @@ func TestImageUpdatePoller_DigestMismatch(t *testing.T) {
 		imageName        = "linuxserver/sonarr:latest"
 	)
 
-	store, dc := makePollerStore(
-		[]models.InfrastructureComponent{dockerEngineComponent()},
-		[]*models.DiscoveredContainer{
-			{ID: "c1", ContainerID: containerID, ContainerName: "sonarr", Image: imageName, Status: "running"},
-		},
-	)
+	store, dc := makePollerStore([]*models.DiscoveredContainer{
+		{ID: "c1", ContainerID: containerID, ContainerName: "sonarr", Image: imageName, Status: "running"},
+	})
 
 	inspects, imgInspects := makeInspect(containerID, "sha256:cfg1", imageName,
 		[]string{"linuxserver/sonarr@" + localManifest})
@@ -241,12 +193,9 @@ func TestImageUpdatePoller_DigestMatch(t *testing.T) {
 		imageName   = "ghcr.io/meeb/tubesync:latest"
 	)
 
-	store, dc := makePollerStore(
-		[]models.InfrastructureComponent{dockerEngineComponent()},
-		[]*models.DiscoveredContainer{
-			{ID: "c2", ContainerID: containerID, ContainerName: "tubesync", Image: imageName, Status: "running"},
-		},
-	)
+	store, dc := makePollerStore([]*models.DiscoveredContainer{
+		{ID: "c2", ContainerID: containerID, ContainerName: "tubesync", Image: imageName, Status: "running"},
+	})
 
 	inspects, imgInspects := makeInspect(containerID, "sha256:cfg2", imageName,
 		[]string{"ghcr.io/meeb/tubesync@" + sameDigest})
@@ -266,17 +215,51 @@ func TestImageUpdatePoller_DigestMatch(t *testing.T) {
 	}
 }
 
+// ── Portainer container uses stored digest ─────────────────────────────────────
+
+func TestImageUpdatePoller_PortainerStoredDigest(t *testing.T) {
+	const (
+		storedManifest   = "sha256:portainerlocal"
+		registryManifest = "sha256:registrynewer"
+		imageName        = "linuxserver/plex:latest"
+	)
+
+	store, dc := makePollerStore([]*models.DiscoveredContainer{
+		{
+			ID: "c-portainer", ContainerID: "ptctr1", ContainerName: "plex",
+			Image: imageName, Status: "running",
+			ImageDigest: strPtr(storedManifest), // populated by Portainer enrichment
+		},
+	})
+
+	// Socket client returns error for all containers (simulates non-local containers).
+	client := &mockImageUpdateClient{inspectErr: errors.New("no such container")}
+	reg := &mockLatestDigester{digests: map[string]string{imageName: registryManifest}}
+	p := newImageUpdatePollerWithClient(store, client, reg)
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if len(dc.imageChecks) != 1 {
+		t.Fatalf("expected 1 image check via stored digest, got %d", len(dc.imageChecks))
+	}
+	check := dc.imageChecks[0]
+	if !check.updateAvailable {
+		t.Error("expected update_available=true when stored digest differs from registry")
+	}
+	if check.imageDigest != storedManifest {
+		t.Errorf("image_digest: got %q, want %q", check.imageDigest, storedManifest)
+	}
+}
+
 // ── registry error → UpdateContainerImageCheck not called ─────────────────────
 
 func TestImageUpdatePoller_RegistryError_NoUpdateSet(t *testing.T) {
 	const containerID = "ctr-err"
 
-	store, dc := makePollerStore(
-		[]models.InfrastructureComponent{dockerEngineComponent()},
-		[]*models.DiscoveredContainer{
-			{ID: "c3", ContainerID: containerID, ContainerName: "myapp", Image: "myapp:latest", Status: "running"},
-		},
-	)
+	store, dc := makePollerStore([]*models.DiscoveredContainer{
+		{ID: "c3", ContainerID: containerID, ContainerName: "myapp", Image: "myapp:latest", Status: "running"},
+	})
 
 	inspects, imgInspects := makeInspect(containerID, "sha256:cfg3", "myapp:latest",
 		[]string{"myapp@sha256:local"})
@@ -296,13 +279,10 @@ func TestImageUpdatePoller_RegistryError_NoUpdateSet(t *testing.T) {
 // ── stopped/exited containers skipped ────────────────────────────────────────
 
 func TestImageUpdatePoller_NonRunningContainersSkipped(t *testing.T) {
-	store, dc := makePollerStore(
-		[]models.InfrastructureComponent{dockerEngineComponent()},
-		[]*models.DiscoveredContainer{
-			{ID: "c4", ContainerID: "s1", ContainerName: "stopped-app", Image: "myapp:latest", Status: "stopped"},
-			{ID: "c5", ContainerID: "s2", ContainerName: "exited-app", Image: "myapp:latest", Status: "exited"},
-		},
-	)
+	store, dc := makePollerStore([]*models.DiscoveredContainer{
+		{ID: "c4", ContainerID: "s1", ContainerName: "stopped-app", Image: "myapp:latest", Status: "stopped"},
+		{ID: "c5", ContainerID: "s2", ContainerName: "exited-app", Image: "myapp:latest", Status: "exited"},
+	})
 
 	reg := &mockLatestDigester{digests: map[string]string{"myapp:latest": "sha256:digest"}}
 	p := newImageUpdatePollerWithClient(store, &mockImageUpdateClient{}, reg)

--- a/internal/scanner/daily/image_update_test.go
+++ b/internal/scanner/daily/image_update_test.go
@@ -119,6 +119,9 @@ func (r *mockDiscoveredContainerRepo) UpdateContainerImageCheck(_ context.Contex
 func (r *mockDiscoveredContainerRepo) UpdateContainerRestartPolicy(_ context.Context, _ string, _ string) error {
 	return nil
 }
+func (r *mockDiscoveredContainerRepo) UpdateContainerEnvVars(_ context.Context, _ string, _ string) error {
+	return nil
+}
 
 // ── helpers ────────────────────────────────────────────────────────────────────
 

--- a/internal/scanner/discovery/docker.go
+++ b/internal/scanner/discovery/docker.go
@@ -60,41 +60,89 @@ func (s *DockerDiscoveryScanner) Discover(ctx context.Context, entityID string, 
 		knownByID[dc.ContainerID] = dc
 	}
 
+	encJSON := func(v any) *string {
+		b, err := json.Marshal(v)
+		if err != nil || string(b) == "null" {
+			return nil
+		}
+		s := string(b)
+		return &s
+	}
+
 	now := time.Now().UTC()
 	found := 0
 	runningIDs := make([]string, 0, len(containers))
 
 	for _, ct := range containers {
 		name := containerName(ct.Names)
+		if name == "" {
+			continue
+		}
 		status := "stopped"
 		if ct.State == "running" {
 			status = "running"
 			runningIDs = append(runningIDs, ct.ID)
 		}
 
+		// Build network list matching the shared JSON schema.
+		type netEntry struct {
+			Name string `json:"name"`
+			IP   string `json:"ip,omitempty"`
+		}
+		var nets []netEntry
+		if ct.NetworkSettings != nil {
+			for netName, ep := range ct.NetworkSettings.Networks {
+				entry := netEntry{Name: netName}
+				if ep != nil && ep.IPAddress != "" {
+					entry.IP = ep.IPAddress
+				}
+				nets = append(nets, entry)
+			}
+		}
+
 		dc := &models.DiscoveredContainer{
 			InfraComponentID: entityID,
+			SourceType:       "docker_engine",
 			ContainerID:      ct.ID,
 			ContainerName:    name,
 			Image:            ct.Image,
 			Status:           status,
 			LastSeenAt:       now,
 			CreatedAt:        now,
+			Labels:           encJSON(ct.Labels),
+			Ports:            encJSON(ct.Ports),
+			Networks:         encJSON(nets),
+			Volumes:          encJSON(ct.Mounts),
 		}
 
+		isNew := false
 		if _, alreadyKnown := knownByID[ct.ID]; !alreadyKnown {
-			if upsertErr := s.store.DiscoveredContainers.UpsertDiscoveredContainer(ctx, dc); upsertErr != nil {
-				log.Printf("docker discovery: upsert %s: %v", name, upsertErr)
-				continue
-			}
+			isNew = true
+		}
+
+		if upsertErr := s.store.DiscoveredContainers.UpsertDiscoveredContainer(ctx, dc); upsertErr != nil {
+			log.Printf("docker discovery: upsert %s: %v", name, upsertErr)
+			continue
+		}
+
+		if isNew {
 			writeDiscoveryEvent(ctx, s.store, entityID, c.Name, "docker_engine", "info",
 				fmt.Sprintf("[discovery] New container discovered: %s", name))
 			found++
-		} else {
-			// Known — update last_seen_at and status.
-			if updateErr := s.store.DiscoveredContainers.UpdateDiscoveredContainerStatus(ctx, knownByID[ct.ID].ID, status, now); updateErr != nil {
-				log.Printf("docker discovery: update status %s: %v", name, updateErr)
+		}
+
+		// Capture env vars via inspect (one extra call per container, non-fatal).
+		if inspect, inspErr := cli.ContainerInspect(ctx, ct.ID); inspErr == nil {
+			if len(inspect.Config.Env) > 0 {
+				if b, jsonErr := json.Marshal(inspect.Config.Env); jsonErr == nil {
+					ev := string(b)
+					if updErr := s.store.DiscoveredContainers.UpdateContainerEnvVars(ctx, dc.ID, ev); updErr != nil {
+						log.Printf("docker discovery: update env vars %s: %v", name, updErr)
+					}
+				}
 			}
+		} else {
+			log.Printf("docker discovery: inspect %s: %v (non-fatal)", name, inspErr)
 		}
 	}
 

--- a/internal/scanner/discovery/portainer.go
+++ b/internal/scanner/discovery/portainer.go
@@ -53,6 +53,7 @@ func (s *PortainerDiscoveryScanner) Discover(ctx context.Context, entityID strin
 	totalContainers := 0
 	upserted := 0
 	now := time.Now().UTC()
+	var seenContainerIDs []string
 
 	for _, ep := range endpoints {
 		containers, err := client.ListContainers(ctx, ep.ID)
@@ -70,6 +71,7 @@ func (s *PortainerDiscoveryScanner) Discover(ctx context.Context, entityID strin
 			}
 			rec := &models.DiscoveredContainer{
 				InfraComponentID: entityID,
+				SourceType:       "portainer",
 				ContainerID:      pc.ID,
 				ContainerName:    name,
 				Image:            pc.Image,
@@ -81,8 +83,14 @@ func (s *PortainerDiscoveryScanner) Discover(ctx context.Context, entityID strin
 				log.Printf("portainer discovery: upsert container %q: %v", name, err)
 				continue
 			}
+			seenContainerIDs = append(seenContainerIDs, pc.ID)
 			upserted++
 		}
+	}
+
+	// Mark containers that no longer appear in any endpoint as stopped.
+	if err := s.store.DiscoveredContainers.MarkStoppedIfNotRunning(ctx, entityID, seenContainerIDs); err != nil {
+		log.Printf("portainer discovery: mark stopped %s: %v", entityID, err)
 	}
 
 	_ = s.store.InfraComponents.UpdateStatus(ctx, entityID, "online", time.Now().UTC().Format(time.RFC3339Nano))

--- a/internal/scanner/intervals.go
+++ b/internal/scanner/intervals.go
@@ -8,6 +8,7 @@ const (
 	DiscoveryInterval = 1 * time.Hour
 	MetricsInterval   = 60 * time.Second
 	SnapshotInterval  = 30 * time.Minute
+	DailyInterval     = 24 * time.Hour
 
 	// Per-scan timeouts — individual entity scans are cancelled after these
 	// durations so a single stuck target cannot block the scheduler.

--- a/internal/scanner/scheduler.go
+++ b/internal/scanner/scheduler.go
@@ -51,6 +51,20 @@ type GlobalMetricsJob interface {
 	Run(ctx context.Context)
 }
 
+// GlobalDailyJob is a job that runs once per day — on startup and then every
+// 24 hours. Use for expensive external calls with rate limits (e.g. container
+// registry digest lookups).
+type GlobalDailyJob interface {
+	Run(ctx context.Context)
+}
+
+// GlobalDailyFunc is an adapter so a plain func(context.Context) satisfies
+// GlobalDailyJob without defining a named type.
+type GlobalDailyFunc func(ctx context.Context)
+
+// Run implements GlobalDailyJob.
+func (f GlobalDailyFunc) Run(ctx context.Context) { f(ctx) }
+
 // ScanScheduler runs the three scan buckets — Discovery, Metrics, and
 // Snapshots — on their canonical intervals. Each tick fans out to all enabled
 // infrastructure components concurrently with a per-entity timeout.
@@ -73,10 +87,11 @@ type ScanScheduler struct {
 	metricsByMethod          map[string]MetricsScanner   // keyed by collection_method
 	snapshots         map[string]SnapshotScanner // keyed by entity type
 	snapshotsByMethod map[string]SnapshotScanner // keyed by collection_method
-	globalDiscovery   []GlobalDiscoveryJob
-	globalSnapshots   []GlobalSnapshotJob
-	globalMetrics     []GlobalMetricsJob
-	mu                sync.RWMutex
+	globalDiscovery []GlobalDiscoveryJob
+	globalSnapshots []GlobalSnapshotJob
+	globalMetrics   []GlobalMetricsJob
+	globalDaily     []GlobalDailyJob
+	mu              sync.RWMutex
 }
 
 // NewScanScheduler returns a ScanScheduler wired to store with empty scanner
@@ -170,19 +185,41 @@ func (s *ScanScheduler) RegisterGlobalMetrics(job GlobalMetricsJob) {
 	s.globalMetrics = append(s.globalMetrics, job)
 }
 
-// Start launches the three ticker loops and blocks until ctx is cancelled.
+// RegisterGlobalDaily registers a GlobalDailyJob that runs once on startup
+// and then every 24 hours. Use for rate-limited external calls such as
+// container registry digest lookups.
+func (s *ScanScheduler) RegisterGlobalDaily(job GlobalDailyJob) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.globalDaily = append(s.globalDaily, job)
+}
+
+// Start launches the four ticker loops and blocks until ctx is cancelled.
 // Each ticker fires independently; slow discovery scans will not delay metrics
-// collection.
+// collection. Daily jobs run once immediately on start, then every 24 hours.
 func (s *ScanScheduler) Start(ctx context.Context) {
-	log.Printf("scan scheduler: starting (discovery=%s, metrics=%s, snapshots=%s)",
-		DiscoveryInterval, MetricsInterval, SnapshotInterval)
+	log.Printf("scan scheduler: starting (discovery=%s, metrics=%s, snapshots=%s, daily=%s)",
+		DiscoveryInterval, MetricsInterval, SnapshotInterval, DailyInterval)
 
 	discoveryTicker := time.NewTicker(DiscoveryInterval)
 	metricsTicker := time.NewTicker(MetricsInterval)
 	snapshotTicker := time.NewTicker(SnapshotInterval)
+	dailyTicker := time.NewTicker(DailyInterval)
 	defer discoveryTicker.Stop()
 	defer metricsTicker.Stop()
 	defer snapshotTicker.Stop()
+	defer dailyTicker.Stop()
+
+	// Delay the first daily pass so enrichment workers (Portainer, Docker Engine)
+	// have time to complete their initial cycle and populate image_digest before
+	// the registry poller reads it.
+	go func() {
+		select {
+		case <-time.After(3 * time.Minute):
+			s.runDailyPass(ctx)
+		case <-ctx.Done():
+		}
+	}()
 
 	for {
 		select {
@@ -195,6 +232,8 @@ func (s *ScanScheduler) Start(ctx context.Context) {
 			go s.runMetricsPass(ctx)
 		case <-snapshotTicker.C:
 			go s.runSnapshotPass(ctx)
+		case <-dailyTicker.C:
+			go s.runDailyPass(ctx)
 		}
 	}
 }
@@ -366,6 +405,17 @@ func (s *ScanScheduler) runSnapshotPass(ctx context.Context) {
 	s.mu.RLock()
 	globals := make([]GlobalSnapshotJob, len(s.globalSnapshots))
 	copy(globals, s.globalSnapshots)
+	s.mu.RUnlock()
+	for _, job := range globals {
+		job.Run(ctx)
+	}
+}
+
+// runDailyPass runs all registered GlobalDailyJobs sequentially.
+func (s *ScanScheduler) runDailyPass(ctx context.Context) {
+	s.mu.RLock()
+	globals := make([]GlobalDailyJob, len(s.globalDaily))
+	copy(globals, s.globalDaily)
 	s.mu.RUnlock()
 	for _, job := range globals {
 		job.Run(ctx)

--- a/internal/scanner/snapshot/proxmox.go
+++ b/internal/scanner/snapshot/proxmox.go
@@ -112,6 +112,62 @@ func (s *ProxmoxSnapshotScanner) TakeSnapshot(ctx context.Context, entityID stri
 		}
 	}
 
+	// ── Backup files: detect new completions and stale VMs ───────────────────────
+	backupFiles, err := poller.FetchBackupFiles(ctx)
+	if err != nil {
+		log.Printf("proxmox snapshot: %s: fetch backup files: %v (non-fatal)", c.Name, err)
+	} else {
+		// Build per-VMID latest ctime map.
+		latestByVMID := make(map[int]int64)
+		for _, f := range backupFiles {
+			if f.VMID == 0 {
+				continue
+			}
+			if f.CTime > latestByVMID[f.VMID] {
+				latestByVMID[f.VMID] = f.CTime
+			}
+		}
+
+		staleThreshold := int64(48 * 60 * 60) // 48 hours
+		nowUnix := now.Unix()
+
+		for vmid, ctime := range latestByVMID {
+			ctimeStr := fmt.Sprintf("%d", ctime)
+			vmKey := fmt.Sprintf("%d", vmid)
+
+			// Track latest backup ctime — fires on new backup.
+			_, ch := captureSnapshot(ctx, s.store, "physical_host", entityID,
+				"backup_ctime_vm_"+vmKey, ctimeStr, now)
+			if ch {
+				changed = true
+				writeSnapshotEvent(ctx, s.store, entityID, c.Name, "physical_host", "info",
+					fmt.Sprintf("[backup] VM %d backed up successfully on %s",
+						vmid, c.Name))
+			}
+
+			// Track stale status — warn when no backup in 48 h.
+			isStale := "0"
+			if nowUnix-ctime > staleThreshold {
+				isStale = "1"
+			}
+			prevStale, staleChanged := captureSnapshot(ctx, s.store, "physical_host", entityID,
+				"backup_stale_vm_"+vmKey, isStale, now)
+			if staleChanged {
+				changed = true
+				if isStale == "1" && prevStale == "0" {
+					writeSnapshotEvent(ctx, s.store, entityID, c.Name, "physical_host", "warn",
+						fmt.Sprintf("[backup] VM %d has no recent backup on %s (>48h)",
+							vmid, c.Name))
+				} else if isStale == "0" && prevStale == "1" {
+					// Stale condition resolved (new backup appeared).
+					writeSnapshotEvent(ctx, s.store, entityID, c.Name, "physical_host", "info",
+						fmt.Sprintf("[backup] VM %d backup recovered on %s",
+							vmid, c.Name))
+				}
+			}
+		}
+	}
+
 	writeDebugEvent(ctx, s.store, entityID, c.Name, "physical_host")
 	log.Printf("proxmox snapshot: %s: done (changed=%v)", c.Name, changed)
 

--- a/migrations/051_container_env_vars.sql
+++ b/migrations/051_container_env_vars.sql
@@ -1,0 +1,4 @@
+-- AP-05: store environment variables captured during container inspect.
+-- env_vars is a JSON array of "KEY=VALUE" strings, populated by the Portainer
+-- enrichment worker via InspectContainer during each poll cycle.
+ALTER TABLE discovered_containers ADD COLUMN env_vars TEXT;


### PR DESCRIPTION
## Summary
- Restores all uncommitted local changes that were never pushed before PR #272 merged
- Fixes Apps page pill strip styling (classes were missing from deployed CSS)
- Fixes Checks page table/filter formatting (entire stylesheet was missing)
- Adds ContainerDetail (docker drill-down) page and route
- Wires NotFound page into the `*` catch-all route
- Restores Events page responsive chart and 3-month range option
- Backend: daily image scanner, container env vars migration, portainer/proxmox updates

## Test plan
- [ ] Apps page — stat pills at top render correctly with borders and background
- [ ] Checks page — table rows, filter pills, and status badges render correctly
- [ ] Navigate to a container from the Infrastructure or Topology page — ContainerDetail loads
- [ ] Navigate to a nonexistent route — 404 page displays instead of redirecting to `/`
- [ ] Events page — chart resizes with window, 3-month range option works
- [ ] Verify migration 051 applies cleanly on a fresh deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)