### PR TITLE
docs: add ARCHITECTURE.md, update README, remove topology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ bin/
 # Claude Code and local docs — keep local, do not publish
 CLAUDE.md
 AGENTS.md
-ARCHITECTURE.md
 .claude/
 wiki/
 docs/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -251,7 +251,7 @@ NORA ships as a single Docker image built in three stages:
 
 The final image is ~50 MB. There is no Node, no Go toolchain, and no source code in the runtime image.
 
-The binary listens on `NORA_PORT` (default `8081`) and serves everything: static assets, API, and the ingest endpoint.
+The binary listens on `NORA_PORT` (default `8081`) and serves everything: static assets, API, and the ingest endpoint. In local development the Vite dev server runs on `8081` and proxies `/api` requests to the Go backend on `3000` — port `3000` is never exposed in the container.
 
 Data lives in a single directory (`/data` by default):
 - `nora.db` — SQLite database

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,261 @@
+# NORA Architecture
+
+This document describes how NORA is structured — the layers, how data moves through them, and the decisions behind the design.
+
+---
+
+## Overview
+
+NORA is a single Go binary that serves the frontend, runs all background jobs, and exposes a REST API. There is no separate worker process, no message queue, and no external dependencies beyond the Docker socket (optional) and an SMTP server (optional). The database is SQLite.
+
+```
+┌──────────────────────────────────────────────────────┐
+│                    Browser / PWA                     │
+└────────────────────────┬─────────────────────────────┘
+                         │ HTTP / REST
+┌────────────────────────▼─────────────────────────────┐
+│                   Go HTTP Server                     │
+│  ┌──────────────┐  ┌─────────────┐  ┌─────────────┐ │
+│  │  Static SPA  │  │   REST API  │  │  Ingest API │ │
+│  │  (embedded)  │  │  /api/v1/*  │  │  /api/v1/   │ │
+│  └──────────────┘  └──────┬──────┘  │  ingest/:t  │ │
+│                           │         └──────┬────────┘ │
+│  ┌────────────────────────▼──────────────▼────────┐  │
+│  │                   Service Layer                │  │
+│  │  Auth · Ingest · Notify · Digest · Enrichment  │  │
+│  └────────────────────────┬───────────────────────┘  │
+│                           │                          │
+│  ┌────────────────────────▼───────────────────────┐  │
+│  │                  Repo Layer                    │  │
+│  │  Apps · Events · Checks · Infra · Discovery    │  │
+│  └────────────────────────┬───────────────────────┘  │
+│                           │ sqlx / SQLite            │
+│  ┌────────────────────────▼───────────────────────┐  │
+│  │                   SQLite DB                    │  │
+│  └────────────────────────────────────────────────┘  │
+│                                                      │
+│  ┌──────────────────────────────────────────────────┐ │
+│  │               Background Scheduler               │ │
+│  │  Monitor · Discovery · Snapshot · Enrichment     │ │
+│  │  Digest · Daily image scan                       │ │
+│  └──────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────┘
+```
+
+---
+
+## Repository Layout
+
+```
+cmd/
+  nora/              — main entry point; wires everything together
+  nora-cli/          — optional CLI for admin tasks
+
+internal/
+  api/               — HTTP handlers (one file per domain area)
+  apptemplate/       — app profile loader and field mapper
+  auth/              — JWT, session management, TOTP
+  config/            — environment variable parsing
+  crypto/            — VAPID key generation, hashing helpers
+  frontend/          — embeds the compiled React bundle
+  icons/             — serves app profile icons
+  infra/             — integration clients and enrichment workers
+    portainer.go     — Portainer API client
+    portainer_enrichment.go
+    proxmox_detail.go
+    docker_enrichment.go
+  ingest/            — webhook payload parsing and normalization
+  jobs/              — high-level job orchestration (discover, digest, enrich)
+  models/            — shared struct definitions (no DB logic)
+  monitor/           — ping / URL / SSL / DNS check runners
+  profile/           — user profile and password policy
+  push/              — Web Push / VAPID notification dispatch
+  repo/              — all database access (one interface per entity type)
+  rules/             — alert rule evaluation
+  scanner/
+    discovery/       — Docker and Portainer container discovery
+    snapshot/        — resource metric collection (CPU/mem/disk)
+    daily/           — once-per-day jobs (image update check)
+    intervals.go     — per-integration poll intervals
+    scheduler.go     — schedules and owns all scanner goroutines
+
+frontend/
+  src/
+    api/             — typed fetch wrappers for every API endpoint
+    components/      — shared UI components (Topbar, Layout, SlidePanel…)
+    context/         — React contexts (auth, auto-refresh, env status)
+    pages/           — one file per route
+    styles/          — shared CSS (modal primitives, variables)
+    utils/           — formatting helpers
+
+migrations/          — numbered SQL migration files (applied at startup)
+```
+
+---
+
+## Data Flow
+
+### Webhook Ingest
+
+```
+App → POST /api/v1/ingest/{token}
+        │
+        ▼
+  Token lookup → App resolved
+        │
+        ▼
+  Profile applied (field mapping, severity, title extraction)
+        │
+        ▼
+  Event written to events table
+        │
+        ▼
+  Alert rules evaluated → Web Push fired if matched
+```
+
+### Infrastructure Discovery
+
+The scheduler runs discovery on a per-integration cadence (typically 60–300 s):
+
+```
+Scheduler tick
+  │
+  ├── Docker discovery
+  │     → List containers → Upsert discovered_containers
+  │     → Collect CPU/mem/disk → Write resource_readings
+  │
+  ├── Portainer discovery
+  │     → Enumerate endpoints → List containers per endpoint
+  │     → Inspect each container (image, env vars, restart policy)
+  │     → Upsert discovered_containers, resource_readings
+  │
+  ├── Proxmox snapshot
+  │     → Node metrics, VM/LXC list, storage
+  │     → Write resource_readings
+  │
+  └── Traefik snapshot
+        → Routes, services, SSL certs
+        → Write to traefik_routes, traefik_services, traefik_certs
+```
+
+### Daily Image Update Scan
+
+Runs once per day on startup + cron:
+
+```
+List all discovered containers with a known image digest
+  │
+  ▼
+For each container: pull registry digest for the image tag
+  │
+  ▼
+Compare local digest vs registry digest
+  │
+  ▼
+UpdateContainerImageCheck → update_available flag + registry_digest stored
+```
+
+### Monitor Checks
+
+Each enabled check runs on its own ticker:
+
+```
+Scheduler → check runner (ping / url / ssl / dns)
+  │
+  ▼
+Result written to monitor_results
+  │
+  ▼
+last_status + last_checked_at updated on monitor_checks row
+  │
+  ▼
+If status changed → event emitted → alert rules evaluated
+```
+
+---
+
+## Database
+
+NORA uses SQLite via `mattn/go-sqlite3`. The schema is applied at startup from numbered SQL files in `migrations/`. Migrations are applied in order and skipped if already applied (tracked in a `schema_migrations` table).
+
+WAL mode is enabled. There is one write connection and one read connection pool to avoid lock contention.
+
+Key tables:
+
+| Table | Purpose |
+|---|---|
+| `apps` | Registered apps with webhook tokens and profile assignments |
+| `events` | All ingested and system-generated events |
+| `monitor_checks` | Check configuration (type, target, interval) |
+| `monitor_results` | Per-run check results and latency |
+| `infra_components` | Infrastructure integrations (Docker, Proxmox, Portainer, etc.) |
+| `discovered_containers` | Containers found by discovery, with current state |
+| `resource_readings` | Time-series CPU/mem/disk samples |
+| `resource_rollups` | Monthly aggregated rollups (kept indefinitely) |
+| `traefik_routes` | Routes discovered from Traefik API |
+| `traefik_services` | Backend services behind routes |
+| `traefik_certs` | SSL certificates from Traefik |
+| `component_links` | Manual and discovered relationships between components |
+| `alert_rules` | User-defined notification conditions |
+| `push_subscriptions` | Web Push subscriber endpoints |
+| `users` | User accounts, hashed passwords, TOTP secrets |
+
+---
+
+## API
+
+All endpoints are under `/api/v1/`. The API is REST-ish JSON. Authentication uses a JWT in the `Authorization: Bearer` header. Tokens are issued at login and have a configurable TTL.
+
+The ingest endpoint (`/api/v1/ingest/{token}`) is unauthenticated — the token is the credential.
+
+Handlers live in `internal/api/` with one file per domain (e.g. `apps.go`, `events.go`, `checks.go`, `docker_discovery.go`).
+
+---
+
+## Frontend
+
+The frontend is a React SPA built with Vite and embedded into the Go binary at compile time via `embed.FS`. All routes are handled client-side; the server returns `index.html` for any non-API path.
+
+State management is local React state — no Redux or Zustand. The auto-refresh context drives periodic re-fetches. All API calls go through typed wrappers in `frontend/src/api/client.ts`.
+
+The frontend is a PWA: it has a service worker, a web app manifest, and can be installed to the home screen on desktop and mobile.
+
+---
+
+## Authentication
+
+- JWT-based. Tokens are signed with `NORA_SECRET`.
+- TOTP (RFC 6238) via `pquerna/otp`. Secrets are stored encrypted. TOTP can be globally enforced or per-user exempt.
+- Sessions are stateless — no session table. Logout invalidates on the client.
+- Password policy (length, complexity) is enforced server-side and configurable in Settings.
+
+---
+
+## Notifications
+
+### Web Push
+NORA generates VAPID keys on first run (or accepts them via env vars). When an alert rule matches, the rule evaluator queries `push_subscriptions` and dispatches a push message to each subscriber via the Web Push protocol. No third-party push service is involved.
+
+### Digest Email
+A scheduled job (cron, configurable) assembles a summary of events, check results, and infrastructure status over the configured period and sends it via SMTP. SMTP credentials are stored in the database, configured in Settings.
+
+---
+
+## Deployment
+
+NORA ships as a single Docker image built in three stages:
+
+1. **Frontend build** (`node:22-alpine`) — `npm ci && vite build`
+2. **Go build** (`golang:1.24-alpine`) — `CGO_ENABLED=1 go build`
+3. **Final image** (`alpine:3.19`) — copies binary + embedded frontend only
+
+The final image is ~50 MB. There is no Node, no Go toolchain, and no source code in the runtime image.
+
+The binary listens on `NORA_PORT` (default `8081`) and serves everything: static assets, API, and the ingest endpoint.
+
+Data lives in a single directory (`/data` by default):
+- `nora.db` — SQLite database
+- `templates/` — app profile YAML files
+- `icons/` — custom icon overrides
+
+Mount `/data` as a volume to persist data across container restarts.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,7 @@ NORA is a self-hosted monitoring, event capture, and notification platform built
 
 ## A Note on How This Is Built
 
-NORA is heavily developed with **[Claude Code](https://claude.ai/code)** by Anthropic. That comes with an honest disclaimer and an honest commitment.
-
-The sentiment around AI-generated code is fair — the ecosystem is full of projects that got spun up overnight and abandoned just as fast. This isn't that. Every significant piece of work goes through a tracked GitHub issue, every change is documented in PR notes, and nothing ships without being understood. The goal is a solid, maintainable project — not a demo.
-
-If you're evaluating NORA, read the issue history. Read the PRs. The process is the proof.
+NORA is built with **[Claude Code](https://claude.ai/code)**. Every feature goes through a tracked GitHub issue, every change is documented in PR notes, and nothing ships without being understood. Read the issue history and PRs — the process is the proof.
 
 NORA is built on the shoulders of great open-source work — [see the full list of projects credited below](#built-on).
 
@@ -94,11 +90,6 @@ More Screen Shots [Screenshots](https://github.com/Digitalcheffe/N.O.R.A/tree/ma
 - Combine conditions with AND / OR logic
 - Fire Web Push or email notifications when a rule matches
 - Enable, disable, or delete rules from the Settings → Notify Rules tab
-
-### Topology
-- Visual network map of your infrastructure, containers, apps, and routes
-- Clickable nodes drill into component detail
-- Automatically populated from Docker, Traefik, and infrastructure discovery
 
 ### App Library
 
@@ -194,7 +185,6 @@ NORA would not exist without these open-source projects:
 | [gosnmp/gosnmp](https://github.com/gosnmp/gosnmp) | SNMP polling |
 | [robfig/cron](https://github.com/robfig/cron) | Scheduled task execution |
 | [rs/zerolog](https://github.com/rs/zerolog) | Structured logging |
-| [D3.js](https://d3js.org/) | Topology graph visualisation |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ More Screen Shots [Screenshots](https://github.com/Digitalcheffe/N.O.R.A/tree/ma
 | **Portainer** | Endpoints, container inventory, CPU/memory per container, image status |
 | **Traefik** | Routes, services, SSL certificates |
 | **Synology** | System status, storage, uptime |
-| **OPNsense** | CPU, memory, network throughput |
 | **SNMP** | Generic metrics and health from any SNMP-capable device |
 
 ### Notifications

--- a/README.md
+++ b/README.md
@@ -175,17 +175,7 @@ All email configuration is managed in the app under Settings → Notifications �
 
 3-stage Docker build: frontend → Go binary → `alpine:3.19` final image. No node_modules, no Go toolchain, no source in the final image.
 
----
-
-## What's Next
-
-### In Progress
-- **Remote Docker nodes** — multi-host container monitoring via socket proxy; Portainer integration is live, native remote socket support coming
-
-### Considering
-- **Visual profile builder** — point-and-click field mapping from live API responses, no JSONPath required
-- **PostgreSQL support** — for larger installations that outgrow SQLite
-- **SSO / OAuth login** — federated authentication for team deployments
+For a detailed breakdown of the repository layout, data flow, database schema, API design, and deployment internals, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,6 @@ import { AppDetail } from './pages/AppDetail'
 import { Infrastructure } from './pages/Infrastructure'
 import { InfraComponentDetail } from './pages/InfraComponentDetail'
 import { ContainerDetail } from './pages/ContainerDetail'
-import { TopologyPage } from './pages/Topology'
 import { Relationships } from './pages/Relationships'
 import { Settings } from './pages/Settings'
 import { AppTemplateEditor } from './pages/AppTemplateEditor'
@@ -50,8 +49,8 @@ export default function App() {
               <Route path="infrastructure" element={<Infrastructure />} />
               <Route path="infrastructure/:id" element={<InfraComponentDetail />} />
               <Route path="containers/:id" element={<ContainerDetail />} />
-              <Route path="topology" element={<TopologyPage />} />
-              <Route path="network-map" element={<Navigate to="/topology" replace />} />
+              <Route path="topology" element={<Navigate to="/infrastructure" replace />} />
+              <Route path="network-map" element={<Navigate to="/infrastructure" replace />} />
               <Route path="relationships" element={<Relationships />} />
               <Route path="settings" element={<Settings />} />
               <Route path="profile" element={<Profile />} />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -60,22 +60,6 @@ const NAV_ITEMS = [
     ),
   },
   {
-    to: '/topology',
-    title: 'Topology',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
-        <rect x="2" y="9" width="4" height="4" rx="1" />
-        <rect x="10" y="2" width="4" height="4" rx="1" />
-        <rect x="10" y="16" width="4" height="4" rx="1" />
-        <rect x="18" y="9" width="4" height="4" rx="1" />
-        <line x1="6" y1="11" x2="10" y2="4" />
-        <line x1="6" y1="11" x2="10" y2="18" />
-        <line x1="14" y1="4" x2="18" y2="11" />
-        <line x1="14" y1="18" x2="18" y2="11" />
-      </svg>
-    ),
-  },
-  {
     to: '/relationships',
     title: 'Relationships',
     icon: (


### PR DESCRIPTION
## Summary
- Add `ARCHITECTURE.md` with full system documentation: repo layout, data flow diagrams, database schema, API design, auth, notifications, and deployment details
- Remove `ARCHITECTURE.md` from `.gitignore` so it publishes
- Update README: remove roadmap, add all current features (ContainerDetail, Events improvements, route chain view, etc.), tighten "How This Is Built" note, remove OPNsense from integrations
- Remove Topology nav item from sidebar; redirect `/topology` and `/network-map` to `/infrastructure`
- Remove D3.js from README Built On table
- Clarify dev vs production port setup (port 3000 is dev-only, never exposed in Docker)

## Test plan
- [ ] Topology nav item is gone from the sidebar
- [ ] Navigating to `/topology` or `/network-map` redirects to `/infrastructure`
- [ ] README renders correctly on GitHub with no roadmap section
- [ ] ARCHITECTURE.md is visible on GitHub (not gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)