### PR TITLE
fix: GetResources nil pointer panic when rollup query fails

### DIFF
--- a/internal/api/infra_components.go
+++ b/internal/api/infra_components.go
@@ -575,7 +575,7 @@ func (h *InfraComponentHandler) GetResources(w http.ResponseWriter, r *http.Requ
 		rollups, rollupErr = h.rollups.LatestForSource(r.Context(), id, sourceType, period)
 	}
 	if rollupErr != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeError(w, http.StatusInternalServerError, rollupErr.Error())
 		return
 	}
 


### PR DESCRIPTION
## Summary
One-line fix for a nil-pointer panic in \`infra_components.go:578\`. Pre-existing bug that surfaced on UAT when the database was under enough load for the rollup query to return a real error (seen in the log as \`context deadline exceeded\`).

## Root cause
\`\`\`go
if rollupErr != nil {
    writeError(w, http.StatusInternalServerError, err.Error())  // BUG
    return
}
\`\`\`
The check reads \`rollupErr\` but the error message reads \`err.Error()\` — \`err\` was the return from \`components.Get()\` above, which is \`nil\` at this point. When \`rollupErr\` is actually non-nil, calling \`err.Error()\` deref'd nil and panicked.

Pre-existing; not caused by #279. Found while investigating a UAT panic trace.

## Test plan
- [ ] \`go test ./internal/api\` green (verified locally)
- [ ] When a rollup query fails, the 500 response body contains the real error message instead of crashing the handler

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)