### PR TITLE
feat: bulk cleanup jobs for stale digest_registry + stopped containers

### DIFF
--- a/cmd/nora/main.go
+++ b/cmd/nora/main.go
@@ -406,6 +406,24 @@ func main() {
 		RunFn:       func(ctx context.Context) error { return jobs.RunDigestRegistryReconcile(ctx, reconciler) },
 	})
 
+	// CLEANUP — bulk-delete destructive jobs. The Jobs UI intercepts Run clicks
+	// on entries with Destructive=true and shows the preview returned by
+	// PreviewFn before firing RunFn.
+	jobRegistry.Register(&jobs.JobEntry{
+		ID: "cleanup_inactive_registry", Name: "Clean Stale Registry Entries", Category: "cleanup",
+		Description: "Hard-deletes every digest_registry row marked inactive. Inactive rows are produced when a profile YAML is edited or removed — they accumulate over time until cleaned up.",
+		Destructive: true,
+		RunFn:       func(ctx context.Context) error { return jobs.RunCleanupInactiveRegistry(ctx, store) },
+		PreviewFn:   func(ctx context.Context) (jobs.CleanupPreview, error) { return jobs.PreviewInactiveRegistry(ctx, store) },
+	})
+	jobRegistry.Register(&jobs.JobEntry{
+		ID: "cleanup_stopped_containers", Name: "Clean Stopped Containers", Category: "cleanup",
+		Description: "Hard-deletes every discovered_containers row whose status is not running. Stopped rows stay in the DB after a container is removed from its engine; this clears the ghosts.",
+		Destructive: true,
+		RunFn:       func(ctx context.Context) error { return jobs.RunCleanupStoppedContainers(ctx, store) },
+		PreviewFn:   func(ctx context.Context) (jobs.CleanupPreview, error) { return jobs.PreviewStoppedContainers(ctx, store) },
+	})
+
 	// Router
 	r := chi.NewRouter()
 	if cfg.IsDebug() {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -28,6 +28,7 @@ import type {
   InfrastructureComponent,
   InfrastructureComponentInput,
   InstanceMetrics,
+  CleanupPreview,
   Job,
   JobRunResult,
   PortainerEndpoint,
@@ -602,6 +603,9 @@ export const jobsApi = {
 
   run: (id: string) =>
     request<JobRunResult>('POST', `/jobs/${id}/run`),
+
+  preview: (id: string) =>
+    request<CleanupPreview>('GET', `/jobs/${id}/preview`),
 }
 
 // ── Portainer (DD-8) ──────────────────────────────────────────────────────────

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -791,6 +791,7 @@ export interface Job {
   name: string
   description: string
   category: string
+  destructive?: boolean
   last_run_at: string | null
   last_run_status: string | null
 }
@@ -799,6 +800,17 @@ export interface JobRunResult {
   status: 'ok' | 'error'
   error?: string
   duration_ms: number
+}
+
+export interface CleanupPreviewItem {
+  id: string
+  label: string
+  sub: string
+}
+
+export interface CleanupPreview {
+  count: number
+  items: CleanupPreviewItem[]
 }
 
 // ── Portainer (DD-8) ─────────────────────────────────────────────────────────

--- a/frontend/src/pages/ContainerDetail.css
+++ b/frontend/src/pages/ContainerDetail.css
@@ -349,3 +349,55 @@
   font-size: 11px;
   color: var(--red);
 }
+
+/* ── Delete button in the DetailPageLayout actions slot ── */
+.ctr-det-delete-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.ctr-det-delete-btn {
+  padding: 6px 14px;
+  background: transparent;
+  color: var(--text2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.ctr-det-delete-btn:hover {
+  color: var(--red);
+  border-color: var(--red);
+}
+.ctr-det-delete-confirm {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.ctr-det-delete-warn {
+  font-size: 12px;
+  color: var(--yellow);
+}
+.ctr-det-delete-cancel {
+  padding: 5px 12px;
+  background: var(--bg3);
+  color: var(--text2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.ctr-det-delete-confirm-btn {
+  padding: 5px 12px;
+  background: var(--red);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.ctr-det-delete-confirm-btn:disabled,
+.ctr-det-delete-cancel:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/pages/ContainerDetail.tsx
+++ b/frontend/src/pages/ContainerDetail.tsx
@@ -75,6 +75,10 @@ export function ContainerDetail() {
   const [linkBusy, setLinkBusy] = useState(false)
   const [linkError, setLinkError] = useState('')
 
+  const [deleteConfirm, setDeleteConfirm] = useState(false)
+  const [deleteBusy, setDeleteBusy] = useState(false)
+  const [deleteError, setDeleteError] = useState('')
+
   useEffect(() => {
     if (!id) return
     discovery.getContainer(id)
@@ -113,6 +117,23 @@ export function ContainerDetail() {
       setLinkError('Failed to unlink app')
     } finally {
       setLinkBusy(false)
+    }
+  }
+
+  // handleDelete hard-removes the discovered_containers row. This doesn't touch
+  // the actual container on the Docker engine — it just forgets about it.
+  // Useful for pruning ghosts left behind after a container was removed from
+  // its source (e.g. docker-compose down leftovers, old image rollovers).
+  async function handleDelete() {
+    if (!id) return
+    setDeleteBusy(true)
+    setDeleteError('')
+    try {
+      await discovery.deleteContainer(id)
+      navigate('/infrastructure?view=containers')
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete container')
+      setDeleteBusy(false)
     }
   }
 
@@ -189,6 +210,39 @@ export function ContainerDetail() {
     </div>
   )
 
+  const deleteAction = (
+    <div className="ctr-det-delete-wrap">
+      {!deleteConfirm ? (
+        <button
+          className="ctr-det-delete-btn"
+          onClick={() => { setDeleteConfirm(true); setDeleteError('') }}
+          title="Remove this container record from NORA"
+        >
+          Delete
+        </button>
+      ) : (
+        <div className="ctr-det-delete-confirm">
+          <span className="ctr-det-delete-warn">Delete this record?</span>
+          <button
+            className="ctr-det-delete-cancel"
+            onClick={() => setDeleteConfirm(false)}
+            disabled={deleteBusy}
+          >
+            Cancel
+          </button>
+          <button
+            className="ctr-det-delete-confirm-btn"
+            onClick={() => void handleDelete()}
+            disabled={deleteBusy}
+          >
+            {deleteBusy ? 'Deleting…' : 'Confirm'}
+          </button>
+        </div>
+      )}
+      {deleteError && <span className="ctr-det-error">{deleteError}</span>}
+    </div>
+  )
+
   return (
     <DetailPageLayout
       breadcrumb="Infrastructure"
@@ -197,6 +251,7 @@ export function ContainerDetail() {
       status={{ status: dplStatus, label: ctr.status }}
       keyDataPoints={keyDataPoints}
       headerExtra={linkedAppExtra}
+      actions={deleteAction}
       sourceId={ctr.id}
     >
       {/* ── Image ── */}

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -1346,3 +1346,41 @@
   border-radius: 6px;
 }
 
+
+/* ── Cleanup preview list (destructive job confirmation) ── */
+.cleanup-preview-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 12px;
+  max-height: 420px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px;
+  background: var(--bg1);
+}
+.cleanup-preview-row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  border-radius: 4px;
+  background: var(--bg2);
+}
+.cleanup-preview-label {
+  font-size: 12px;
+  color: var(--text1);
+  font-family: var(--mono);
+}
+.cleanup-preview-sub {
+  font-size: 11px;
+  color: var(--text3);
+}
+.cleanup-preview-more {
+  font-size: 11px;
+  color: var(--text3);
+  font-style: italic;
+  background: none;
+  padding: 6px 10px;
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '../context/AuthContext'
 import { usePushSubscription } from '../hooks/usePushSubscription'
 import type {
   AppTemplate,
+  CleanupPreview,
   CreateRuleInput,
   CustomProfile,
   DigestFrequency,
@@ -1848,13 +1849,28 @@ const CATEGORY_LABELS: Record<string, string> = {
   scan: 'Scan Engine',
   data: 'Data',
   profiles: 'Profiles',
+  cleanup: 'Cleanup',
 }
-const CATEGORY_ORDER = ['monitor', 'scan', 'data', 'profiles']
+const CATEGORY_ORDER = ['monitor', 'scan', 'data', 'profiles', 'cleanup']
+
+// ConfirmJob is the state carried by the destructive-job preview SlidePanel.
+// When open === true the panel renders the preview returned from
+// jobsApi.preview() and waits for the user to confirm before firing jobsApi.run().
+type ConfirmJob = {
+  open: boolean
+  job: Job | null
+  loading: boolean
+  preview: CleanupPreview | null
+  error: string | null
+}
 
 function JobsTab() {
   const [jobList, setJobList] = useState<Job[]>([])
   const [loading, setLoading] = useState(true)
   const [runState, setRunState] = useState<Record<string, RunState>>({})
+  const [confirm, setConfirm] = useState<ConfirmJob>({
+    open: false, job: null, loading: false, preview: null, error: null,
+  })
 
   useEffect(() => {
     jobsApi.list()
@@ -1863,7 +1879,9 @@ function JobsTab() {
       .finally(() => setLoading(false))
   }, [])
 
-  const handleRun = async (id: string) => {
+  // fireRun runs a job and updates the per-job status card. Pulled out of
+  // handleRun so the destructive confirm flow can share it.
+  const fireRun = async (id: string) => {
     setRunState(prev => ({ ...prev, [id]: { status: 'running' } }))
     try {
       const result: JobRunResult = await jobsApi.run(id)
@@ -1877,6 +1895,34 @@ function JobsTab() {
     setTimeout(() => {
       setRunState(prev => ({ ...prev, [id]: { status: 'idle' } }))
     }, 3000)
+  }
+
+  const handleRun = async (job: Job) => {
+    // Destructive jobs require an "Are you sure?" confirmation showing exactly
+    // which rows will disappear. Non-destructive jobs fire immediately.
+    if (!job.destructive) {
+      await fireRun(job.id)
+      return
+    }
+    setConfirm({ open: true, job, loading: true, preview: null, error: null })
+    try {
+      const preview = await jobsApi.preview(job.id)
+      setConfirm(prev => ({ ...prev, loading: false, preview }))
+    } catch (e) {
+      setConfirm(prev => ({ ...prev, loading: false, error: String(e) }))
+    }
+  }
+
+  const closeConfirm = () =>
+    setConfirm({ open: false, job: null, loading: false, preview: null, error: null })
+
+  const confirmAndRun = async () => {
+    const job = confirm.job
+    if (!job) return
+    closeConfirm()
+    await fireRun(job.id)
+    // Refresh job list so last_run_at / last_run_status reflect the cleanup.
+    jobsApi.list().then(r => setJobList(r.data)).catch(() => {})
   }
 
   const grouped = Object.fromEntries(
@@ -1933,8 +1979,8 @@ function JobsTab() {
                       </div>
                       <div className="job-card-action">
                         <button
-                          className="settings-btn secondary"
-                          onClick={() => handleRun(job.id)}
+                          className={`settings-btn ${job.destructive ? 'danger' : 'secondary'}`}
+                          onClick={() => handleRun(job)}
                           disabled={isRunning}
                         >
                           {isRunning ? (
@@ -1952,6 +1998,53 @@ function JobsTab() {
             ))
         )}
       </section>
+
+      <SlidePanel
+        open={confirm.open}
+        onClose={closeConfirm}
+        title="Are you sure?"
+        subtitle={confirm.job?.name}
+        footer={
+          confirm.loading || confirm.error ? null : (
+            <button
+              className="settings-btn danger"
+              onClick={() => void confirmAndRun()}
+              disabled={!confirm.preview || confirm.preview.count === 0}
+            >
+              {confirm.preview && confirm.preview.count > 0
+                ? `Delete ${confirm.preview.count} item${confirm.preview.count === 1 ? '' : 's'}`
+                : 'Nothing to delete'}
+            </button>
+          )
+        }
+      >
+        {confirm.loading && <div className="settings-placeholder">Loading preview…</div>}
+        {confirm.error && <div className="modal-error">{confirm.error}</div>}
+        {confirm.preview && confirm.preview.count === 0 && (
+          <div className="settings-placeholder">No matching rows — nothing to clean up.</div>
+        )}
+        {confirm.preview && confirm.preview.count > 0 && (
+          <>
+            <p className="jobs-description">
+              This will permanently delete {confirm.preview.count} row
+              {confirm.preview.count === 1 ? '' : 's'}. This action cannot be undone.
+            </p>
+            <div className="cleanup-preview-list">
+              {confirm.preview.items.map(item => (
+                <div key={item.id} className="cleanup-preview-row">
+                  <span className="cleanup-preview-label">{item.label}</span>
+                  <span className="cleanup-preview-sub">{item.sub}</span>
+                </div>
+              ))}
+              {confirm.preview.count > confirm.preview.items.length && (
+                <div className="cleanup-preview-row cleanup-preview-more">
+                  …and {confirm.preview.count - confirm.preview.items.length} more
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </SlidePanel>
     </div>
   )
 }

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -21,6 +21,7 @@ func NewJobsHandler(registry *jobs.Registry) *JobsHandler {
 // Routes registers the jobs endpoints on r.
 func (h *JobsHandler) Routes(r chi.Router) {
 	r.Get("/jobs", h.List)
+	r.Get("/jobs/{id}/preview", h.Preview)
 	r.Post("/jobs/{id}/run", h.Run)
 }
 
@@ -29,6 +30,7 @@ type jobResponse struct {
 	Name          string  `json:"name"`
 	Description   string  `json:"description"`
 	Category      string  `json:"category"`
+	Destructive   bool    `json:"destructive,omitempty"`
 	LastRunAt     *string `json:"last_run_at"`
 	LastRunStatus *string `json:"last_run_status"`
 }
@@ -43,6 +45,7 @@ func (h *JobsHandler) List(w http.ResponseWriter, r *http.Request) {
 			Name:          e.Name,
 			Description:   e.Description,
 			Category:      e.Category,
+			Destructive:   e.Destructive,
 			LastRunStatus: e.LastRunStatus(),
 		}
 		if t := e.LastRunAt(); t != nil {
@@ -52,6 +55,27 @@ func (h *JobsHandler) List(w http.ResponseWriter, r *http.Request) {
 		out = append(out, j)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"data": out})
+}
+
+// Preview returns the list of rows a destructive job would delete.
+// GET /api/v1/jobs/{id}/preview
+func (h *JobsHandler) Preview(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	entry := h.registry.Get(id)
+	if entry == nil {
+		writeError(w, http.StatusNotFound, "job not found: "+id)
+		return
+	}
+	if !entry.Destructive || entry.PreviewFn == nil {
+		writeError(w, http.StatusBadRequest, "job is not a destructive cleanup job")
+		return
+	}
+	preview, err := entry.PreviewFn(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, preview)
 }
 
 // Run triggers a job immediately: POST /api/v1/jobs/{id}/run

--- a/internal/infra/docker_enrichment_test.go
+++ b/internal/infra/docker_enrichment_test.go
@@ -102,6 +102,12 @@ func (m *enrichMockContainerRepo) FindByName(_ context.Context, _ string, _ stri
 func (m *enrichMockContainerRepo) DeleteDiscoveredContainer(_ context.Context, _ string) error {
 	return nil
 }
+func (m *enrichMockContainerRepo) ListStoppedContainers(_ context.Context) ([]*models.DiscoveredContainer, error) {
+	return nil, nil
+}
+func (m *enrichMockContainerRepo) DeleteAllStoppedContainers(_ context.Context) (int64, error) {
+	return 0, nil
+}
 func (m *enrichMockContainerRepo) UpdateContainerLocalDigest(_ context.Context, _ string, _ string) error {
 	return nil
 }

--- a/internal/jobs/cleanup.go
+++ b/internal/jobs/cleanup.go
@@ -1,0 +1,100 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/digitalcheffe/nora/internal/repo"
+)
+
+// cleanupItemCap is the maximum number of rows surfaced in a preview response.
+// The preview modal only needs enough detail for the user to recognize what
+// will be deleted — if a user has more than a hundred stale rows, truncating
+// protects both the API payload and the rendered DOM. Count is still the real
+// total so the confirm label stays honest.
+const cleanupItemCap = 200
+
+// PreviewInactiveRegistry returns a CleanupPreview listing every
+// digest_registry row with active=0. Used by the "Clean Stale Registry
+// Entries" job's PreviewFn.
+func PreviewInactiveRegistry(ctx context.Context, store *repo.Store) (CleanupPreview, error) {
+	entries, err := store.DigestRegistry.ListInactive(ctx)
+	if err != nil {
+		return CleanupPreview{}, fmt.Errorf("list inactive registry: %w", err)
+	}
+	out := CleanupPreview{Count: len(entries)}
+	limit := len(entries)
+	if limit > cleanupItemCap {
+		limit = cleanupItemCap
+	}
+	for _, e := range entries[:limit] {
+		label := e.Label
+		if label == "" {
+			label = e.Name
+		}
+		out.Items = append(out.Items, CleanupPreviewItem{
+			ID:    e.ID,
+			Label: label,
+			Sub:   fmt.Sprintf("%s · %s", e.ProfileID, e.EntryType),
+		})
+	}
+	return out, nil
+}
+
+// RunCleanupInactiveRegistry hard-deletes every digest_registry row with
+// active=0 and returns the number of rows removed. Designed to be bound to
+// a JobEntry.RunFn via a closure in main.go.
+func RunCleanupInactiveRegistry(ctx context.Context, store *repo.Store) error {
+	n, err := store.DigestRegistry.DeleteAllInactive(ctx)
+	if err != nil {
+		return fmt.Errorf("cleanup inactive registry: %w", err)
+	}
+	return logCleanupResult(ctx, "digest registry", n)
+}
+
+// PreviewStoppedContainers returns a CleanupPreview listing every
+// discovered_containers row whose status is not "running". Used by the
+// "Clean Stopped Containers" job's PreviewFn.
+func PreviewStoppedContainers(ctx context.Context, store *repo.Store) (CleanupPreview, error) {
+	rows, err := store.DiscoveredContainers.ListStoppedContainers(ctx)
+	if err != nil {
+		return CleanupPreview{}, fmt.Errorf("list stopped containers: %w", err)
+	}
+	out := CleanupPreview{Count: len(rows)}
+	limit := len(rows)
+	if limit > cleanupItemCap {
+		limit = cleanupItemCap
+	}
+	for _, c := range rows[:limit] {
+		sub := c.Image
+		if !c.LastSeenAt.IsZero() {
+			sub = fmt.Sprintf("%s · last seen %s", c.Image, c.LastSeenAt.UTC().Format(time.RFC3339))
+		}
+		out.Items = append(out.Items, CleanupPreviewItem{
+			ID:    c.ID,
+			Label: c.ContainerName,
+			Sub:   sub,
+		})
+	}
+	return out, nil
+}
+
+// RunCleanupStoppedContainers hard-deletes every discovered_containers row
+// whose status is not "running".
+func RunCleanupStoppedContainers(ctx context.Context, store *repo.Store) error {
+	n, err := store.DiscoveredContainers.DeleteAllStoppedContainers(ctx)
+	if err != nil {
+		return fmt.Errorf("cleanup stopped containers: %w", err)
+	}
+	return logCleanupResult(ctx, "stopped containers", n)
+}
+
+// logCleanupResult is a tiny helper so the two cleanup runners have a
+// consistent log line shape. Errors are never returned here — the delete
+// already succeeded.
+func logCleanupResult(_ context.Context, label string, n int64) error {
+	log.Printf("cleanup %s: %d rows removed", label, n)
+	return nil
+}

--- a/internal/jobs/registry.go
+++ b/internal/jobs/registry.go
@@ -7,13 +7,37 @@ import (
 	"time"
 )
 
+// CleanupPreviewItem is a single row shown in the confirmation modal for a
+// destructive job. Label is the primary name (e.g. container name or registry
+// label); Sub is a subtitle line with context (e.g. image + last-seen time, or
+// profile_id + entry_type).
+type CleanupPreviewItem struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+	Sub   string `json:"sub"`
+}
+
+// CleanupPreview is the payload returned by GET /jobs/{id}/preview for
+// destructive jobs. Count is the total number of rows that would be deleted
+// (items may be capped for payload size; count is the true total).
+type CleanupPreview struct {
+	Count int                  `json:"count"`
+	Items []CleanupPreviewItem `json:"items"`
+}
+
 // JobEntry is a single registered background job.
+//
+// Destructive jobs MUST provide a PreviewFn so the UI can show a confirmation
+// modal before triggering the run. The jobs handler refuses to return a
+// preview for a non-destructive job.
 type JobEntry struct {
 	ID          string
 	Name        string
 	Description string
 	Category    string
+	Destructive bool
 	RunFn       func(ctx context.Context) error
+	PreviewFn   func(ctx context.Context) (CleanupPreview, error)
 
 	mu            sync.Mutex
 	lastRunAt     *time.Time

--- a/internal/profile/reconciler_test.go
+++ b/internal/profile/reconciler_test.go
@@ -37,6 +37,12 @@ func (s *stubRepo) ListByProfile(_ context.Context, _ string) ([]models.DigestRe
 
 func (s *stubRepo) Delete(_ context.Context, _ string) error { return nil }
 
+func (s *stubRepo) ListInactive(_ context.Context) ([]models.DigestRegistryEntry, error) {
+	return nil, nil
+}
+
+func (s *stubRepo) DeleteAllInactive(_ context.Context) (int64, error) { return 0, nil }
+
 func (s *stubRepo) SetActiveByID(_ context.Context, _ string, _ bool) error { return nil }
 
 var _ repo.DigestRegistryRepo = (*stubRepo)(nil)

--- a/internal/repo/digest_registry.go
+++ b/internal/repo/digest_registry.go
@@ -14,7 +14,9 @@ type DigestRegistryRepo interface {
 	SetActive(ctx context.Context, profileID string, name string, active bool) error
 	List(ctx context.Context) ([]models.DigestRegistryEntry, error)
 	ListByProfile(ctx context.Context, profileID string) ([]models.DigestRegistryEntry, error)
+	ListInactive(ctx context.Context) ([]models.DigestRegistryEntry, error)
 	Delete(ctx context.Context, id string) error
+	DeleteAllInactive(ctx context.Context) (int64, error)
 	SetActiveByID(ctx context.Context, id string, active bool) error
 }
 
@@ -90,6 +92,33 @@ func (r *sqliteDigestRegistryRepo) ListByProfile(ctx context.Context, profileID 
 		return nil, fmt.Errorf("list digest registry entries by profile: %w", err)
 	}
 	return entries, nil
+}
+
+// ListInactive returns every entry with active = 0. Used by the cleanup job's
+// preview endpoint so the UI can show the user what will be deleted before
+// the job runs.
+func (r *sqliteDigestRegistryRepo) ListInactive(ctx context.Context) ([]models.DigestRegistryEntry, error) {
+	var entries []models.DigestRegistryEntry
+	err := r.db.SelectContext(ctx, &entries, `
+		SELECT id, profile_id, source, entry_type, name, label, config, profile_source, active, created_at, updated_at
+		FROM digest_registry
+		WHERE active = 0
+		ORDER BY profile_id, entry_type, name`)
+	if err != nil {
+		return nil, fmt.Errorf("list inactive digest registry entries: %w", err)
+	}
+	return entries, nil
+}
+
+// DeleteAllInactive hard-deletes every row where active = 0. Returns the
+// number of rows removed.
+func (r *sqliteDigestRegistryRepo) DeleteAllInactive(ctx context.Context) (int64, error) {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM digest_registry WHERE active = 0`)
+	if err != nil {
+		return 0, fmt.Errorf("delete all inactive digest registry entries: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
 }
 
 // Delete removes an inactive entry. Returns ErrConflict if the entry is still active.

--- a/internal/repo/discovery.go
+++ b/internal/repo/discovery.go
@@ -31,6 +31,13 @@ type DiscoveredContainerRepo interface {
 	MarkStoppedIfNotRunning(ctx context.Context, infraComponentID string, runningIDs []string) error
 	// DeleteDiscoveredContainer hard-deletes a discovered container record by UUID.
 	DeleteDiscoveredContainer(ctx context.Context, id string) error
+	// ListStoppedContainers returns every row whose status is not "running".
+	// Used by the cleanup-jobs preview so the UI can show which ghosts will
+	// be pruned before the job fires.
+	ListStoppedContainers(ctx context.Context) ([]*models.DiscoveredContainer, error)
+	// DeleteAllStoppedContainers hard-deletes every row whose status is not
+	// "running". Returns the number of rows removed.
+	DeleteAllStoppedContainers(ctx context.Context) (int64, error)
 	// UpdateContainerLocalDigest stores the locally running image manifest digest.
 	// Called by Portainer/Docker Engine enrichment after inspecting the container.
 	// Does not touch registry_digest or image_update_available.
@@ -346,6 +353,33 @@ func (r *sqliteDiscoveredContainerRepo) DeleteDiscoveredContainer(ctx context.Co
 		return fmt.Errorf("discovered container %s: %w", id, ErrNotFound)
 	}
 	return nil
+}
+
+func (r *sqliteDiscoveredContainerRepo) ListStoppedContainers(ctx context.Context) ([]*models.DiscoveredContainer, error) {
+	var rows []*models.DiscoveredContainer
+	err := r.db.SelectContext(ctx, &rows, `
+		SELECT id, infra_component_id, source_type, container_id, container_name,
+		       image, status, app_id, profile_suggestion, suggestion_confidence,
+		       last_seen_at, created_at, labels, ports, networks, volumes,
+		       env_vars, image_digest, registry_digest, image_last_checked_at,
+		       image_update_available, restart_policy
+		FROM discovered_containers
+		WHERE status != 'running'
+		ORDER BY last_seen_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("list stopped discovered containers: %w", err)
+	}
+	return rows, nil
+}
+
+func (r *sqliteDiscoveredContainerRepo) DeleteAllStoppedContainers(ctx context.Context) (int64, error) {
+	res, err := r.db.ExecContext(ctx,
+		`DELETE FROM discovered_containers WHERE status != 'running'`)
+	if err != nil {
+		return 0, fmt.Errorf("delete all stopped discovered containers: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
 }
 
 // ── DiscoveredRouteRepo implementation ───────────────────────────────────────

--- a/internal/scanner/daily/image_update_test.go
+++ b/internal/scanner/daily/image_update_test.go
@@ -104,6 +104,12 @@ func (r *mockDiscoveredContainerRepo) MarkStoppedIfNotRunning(_ context.Context,
 func (r *mockDiscoveredContainerRepo) DeleteDiscoveredContainer(_ context.Context, _ string) error {
 	return nil
 }
+func (r *mockDiscoveredContainerRepo) ListStoppedContainers(_ context.Context) ([]*models.DiscoveredContainer, error) {
+	return nil, nil
+}
+func (r *mockDiscoveredContainerRepo) DeleteAllStoppedContainers(_ context.Context) (int64, error) {
+	return 0, nil
+}
 func (r *mockDiscoveredContainerRepo) UpdateContainerLocalDigest(_ context.Context, _ string, _ string) error {
 	return nil
 }


### PR DESCRIPTION
## Summary
Two new destructive jobs on **Settings → Jobs** under a new **Cleanup** category, plus a per-container Delete button for individual cleanup. Both bulk jobs show a preview SlidePanel ("Are you sure?") listing the exact rows they'll delete before firing.

- **Clean Stale Registry Entries** → deletes every \`digest_registry\` row where \`active = 0\`
- **Clean Stopped Containers** → deletes every \`discovered_containers\` row where \`status != 'running'\`
- **ContainerDetail → Delete button** → per-row cleanup via existing \`DELETE /discovered-containers/{id}\`

## Framework additions
\`JobEntry\` gains \`Destructive bool\` + \`PreviewFn func(ctx) (CleanupPreview, error)\`. Non-destructive jobs unchanged. The framework is reusable for any future destructive job.

New endpoint: \`GET /api/v1/jobs/{id}/preview\` — returns preview for destructive jobs, \`400\`s for non-destructive.

Repo additions:
- \`DigestRegistryRepo.ListInactive\` + \`DeleteAllInactive\`
- \`DiscoveredContainerRepo.ListStoppedContainers\` + \`DeleteAllStoppedContainers\`

## Non-goals
- No time-based retention window. \`active = 0\` / \`status != running\` is the rule, full stop. The preview modal is the control surface.
- No scheduled automatic cleanup. User-initiated only.
- Digest registry per-row delete already exists on the Digest Registry tab (shipped in #278); untouched.

## Test plan
- [ ] \`go test ./...\` green (verified locally across api/jobs/repo/profile/infra/scanner packages)
- [ ] \`tsc --noEmit\` + \`npm run build\` green (verified locally)
- [ ] Verified both jobs appear in Settings → Jobs under a new **Cleanup** header with red **Run Now** buttons
- [ ] Verified \`GET /api/v1/jobs/cleanup_inactive_registry/preview\` and \`/cleanup_stopped_containers/preview\` both return populated payloads (seeded 3 fake inactive registry rows + 3 fake stopped containers locally to exercise the flow)
- [ ] Verified \`GET /api/v1/jobs/monthly_digest/preview\` returns \`400\` — non-destructive jobs refuse preview
- [ ] Click Run Now on a cleanup job → preview SlidePanel opens, lists the rows, confirm button reads "Delete N items" / "Nothing to delete"
- [ ] Cancel closes the panel, no delete fired
- [ ] Confirm fires the job and refreshes the job list
- [ ] Container detail page: Delete → inline confirm → Confirm → redirects to \`/infrastructure?view=containers\`

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)