### PR TITLE
chore: simplify duplicati profile setup instructions

### DIFF
--- a/appprofiles/duplicati.yaml
+++ b/appprofiles/duplicati.yaml
@@ -6,16 +6,13 @@ meta:
   homepage: https://duplicati.com
 webhook:
   setup_instructions: |
-    Configure Duplicati to send native JSON webhooks to {base_url}/ingest/{token}.
-    
-    In Duplicati: Settings → Default options → Add advanced option, OR per-job
     Edit → Options → Add advanced option. Set:
       send-http-url                  = {base_url}/ingest/{token}
       send-http-result-output-format = Json
       send-http-level                = All
-    
+
     Duplicati sends its native JSON result object with Content-Type: application/json.
-    See docs/duplicati-webhook-config.md for the full payload schema.
+    See docs/[duplicati-webhook-config.md](http://duplicati-webhook-config.md) for the full payload schema.
   recommended_events:
     - Success
     - Warning

--- a/appprofiles/duplicati.yaml
+++ b/appprofiles/duplicati.yaml
@@ -12,7 +12,7 @@ webhook:
       send-http-level                = All
 
     Duplicati sends its native JSON result object with Content-Type: application/json.
-    See docs/duplicati-webhook-config.md for the full payload schema.
+    See docs/examples/duplicati-webhook-config.md for the full payload schema.
   recommended_events:
     - Success
     - Warning

--- a/appprofiles/duplicati.yaml
+++ b/appprofiles/duplicati.yaml
@@ -12,7 +12,7 @@ webhook:
       send-http-level                = All
 
     Duplicati sends its native JSON result object with Content-Type: application/json.
-    See docs/[duplicati-webhook-config.md](http://duplicati-webhook-config.md) for the full payload schema.
+    See docs/duplicati-webhook-config.md for the full payload schema.
   recommended_events:
     - Success
     - Warning

--- a/docs/examples/duplicati-webhook-config.md
+++ b/docs/examples/duplicati-webhook-config.md
@@ -36,32 +36,7 @@ duplicati-cli backup <destination> <source> \
 
 ## Payload shape
 
-Duplicati posts `Content-Type: application/json` with a body like:
-
-```json
-{
-  "Data": {
-    "MainOperation": "Backup",
-    "ParsedResult": "Success",
-    "BeginTime": "2026-04-24T02:00:00Z",
-    "EndTime":   "2026-04-24T02:04:11Z",
-    "Duration":  "00:04:11",
-    "AddedFiles": 12,
-    "ModifiedFiles": 3,
-    "DeletedFiles": 0,
-    "SizeOfAddedFiles": 4823191,
-    "Warnings": [],
-    "Errors": []
-  },
-  "Extra": {
-    "OperationName": "Backup",
-    "backup-name":   "nightly-photos",
-    "machine-name":  "nas01"
-  }
-}
-```
-
-NORA's profile maps these fields:
+Duplicati posts `Content-Type: application/json`. NORA's profile maps these fields:
 
 | Field          | JSONPath                  |
 |----------------|---------------------------|

--- a/docs/examples/duplicati-webhook-config.md
+++ b/docs/examples/duplicati-webhook-config.md
@@ -1,53 +1,92 @@
 # Duplicati Webhook Configuration for NORA
 
-Duplicati sends HTTP notifications via advanced options. You can set these
-globally (all jobs) or per backup job.
-
----
-
-## Setup — Global (all backup jobs)
-
-1. In Duplicati go to **Settings → Default options**
-2. Scroll to **Advanced options** and add the following:
-
-```
---send-http-json-urls=http(s)://your-nora/ingest/{token}
---send-http-message={"action":"backup.%PARSEDRESULT%","backup_name":"%backup-name%","result":"%PARSEDRESULT%","operation":"%OPERATIONNAME%","source_path":"%LOCALPATH%"}
---send-http-level=Success,Warning,Error,Fatal
-```
-
-3. Save settings
+Duplicati sends its native JSON result object via HTTP. NORA's `duplicati`
+profile parses that payload directly — no custom message template needed.
 
 ---
 
 ## Setup — Per backup job
 
-1. Open a backup job and go to **Options → Advanced options**
-2. Add the same options as above
-3. Save the job
+1. Open the backup job and go to **Edit → Options → Advanced options**
+2. Add:
 
-Per-job settings override global settings.
+```
+send-http-url                  = http(s)://your-nora/ingest/{token}
+send-http-result-output-format = Json
+send-http-level                = All
+```
+
+3. Save the job.
+
+`send-http-level=All` covers Success, Warning, Error, and Fatal. Narrow it
+if you only want failures.
 
 ---
 
 ## Setup — Via command line
 
-Add these flags to your Duplicati command:
-
 ```bash
 duplicati-cli backup <destination> <source> \
-  --send-http-json-urls="http(s)://your-nora/ingest/{token}" \
-  --send-http-message='{"action":"backup.%PARSEDRESULT%","backup_name":"%backup-name%","result":"%PARSEDRESULT%","operation":"%OPERATIONNAME%","source_path":"%LOCALPATH%"}' \
-  --send-http-level=Success,Warning,Error,Fatal
+  --send-http-url="http(s)://your-nora/ingest/{token}" \
+  --send-http-result-output-format=Json \
+  --send-http-level=All
 ```
+
+---
+
+## Payload shape
+
+Duplicati posts `Content-Type: application/json` with a body like:
+
+```json
+{
+  "Data": {
+    "MainOperation": "Backup",
+    "ParsedResult": "Success",
+    "BeginTime": "2026-04-24T02:00:00Z",
+    "EndTime":   "2026-04-24T02:04:11Z",
+    "Duration":  "00:04:11",
+    "AddedFiles": 12,
+    "ModifiedFiles": 3,
+    "DeletedFiles": 0,
+    "SizeOfAddedFiles": 4823191,
+    "Warnings": [],
+    "Errors": []
+  },
+  "Extra": {
+    "OperationName": "Backup",
+    "backup-name":   "nightly-photos",
+    "machine-name":  "nas01"
+  }
+}
+```
+
+NORA's profile maps these fields:
+
+| Field          | JSONPath                  |
+|----------------|---------------------------|
+| operation      | `$.Extra.OperationName`   |
+| backup_name    | `$.Extra.backup-name`     |
+| machine_name   | `$.Extra.machine-name`    |
+| action         | `$.Data.MainOperation`    |
+| result         | `$.Data.ParsedResult`     |
+| begin_time     | `$.Data.BeginTime`        |
+| end_time       | `$.Data.EndTime`          |
+| duration       | `$.Data.Duration`         |
+| warnings       | `$.Data.Warnings`         |
+| errors         | `$.Data.Errors`           |
+| files_added    | `$.Data.AddedFiles`       |
+| files_modified | `$.Data.ModifiedFiles`    |
+| files_deleted  | `$.Data.DeletedFiles`     |
+| bytes_added    | `$.Data.SizeOfAddedFiles` |
 
 ---
 
 ## Result values
 
-| %PARSEDRESULT% value | Meaning | NORA severity |
-|---|---|---|
-| `Success` | Backup completed cleanly | info |
-| `Warning` | Backup completed with warnings | warn |
-| `Error` | Backup failed | error |
-| `Fatal` | Catastrophic failure | error |
+| `$.Data.ParsedResult` | Meaning                        | NORA severity |
+|-----------------------|--------------------------------|---------------|
+| `Success`             | Backup completed cleanly       | info          |
+| `Warning`             | Backup completed with warnings | warn          |
+| `Error`               | Backup failed                  | error         |
+| `Fatal`               | Catastrophic failure           | error         |


### PR DESCRIPTION
## Summary
- Trim `setup_instructions` in `appprofiles/duplicati.yaml` down to the per-job path; drop the lead-in and the Settings → Default options alternative.
- Update the docs link rendering for the webhook config reference.

## Test plan
- [ ] Profile loads in the app without YAML parse errors
- [ ] Setup instructions render correctly in the UI